### PR TITLE
ChatFilter can now filter "Is Away" !

### DIFF
--- a/GWToolbox/GWToolbox/OtherModules/ChatFilter.cpp
+++ b/GWToolbox/GWToolbox/OtherModules/ChatFilter.cpp
@@ -249,6 +249,8 @@ bool ChatFilter::ShouldIgnore(const wchar_t *message) {
 	switch (message[0]) {
 		// ==== Messages not ignored ====
 	case 0x108: return false; // player message
+	case 0x76D: return false; // whisper received.
+	case 0x76E: return false; // whisper sended.
 	case 0x777: return false; // I'm level x and x% of the way earning my next skill point	(author is not part of the message)
 	case 0x778: return false; // I'm following x			(author is not part of the message)
 	case 0x77B: return false; // I'm talking to x			(author is not part of the message)
@@ -296,8 +298,13 @@ bool ChatFilter::ShouldIgnore(const wchar_t *message) {
 	case 0x807: return false; // player joined the game
 	case 0x816: return skill_points; // you gain a skill point
 	case 0x817: return skill_points; // player x gained a skill point
+	case 0x846: return false; // 'Screenshot saved as <path>'.
 	case 0x87B: return noonehearsyou; // 'no one hears you.' (outpost)
 	case 0x87C: return noonehearsyou; // 'no one hears you... ' (explorable)
+	case 0x87D: return false; // 'Player <name> might not reply...' (Away)
+	case 0x87F: return false; // 'Failed to send whisper to player <name>...' (Do not disturb)
+	case 0x880: return false; // 'Player name <name> is invalid.'. (Anyone actually saw it ig ?)
+	case 0x881: return false; // 'Player <name> is not online.' (Offline)
 
 	case 0x8101:
 		switch (message[1]) {

--- a/GWToolbox/GWToolbox/OtherModules/ChatFilter.cpp
+++ b/GWToolbox/GWToolbox/OtherModules/ChatFilter.cpp
@@ -70,7 +70,7 @@ void ChatFilter::Initialize() {
 			|| ninerings
 			|| noonehearsyou
 			|| lunars)
-			&& ShouldIgnore(pak)) {
+			&& ShouldIgnore(pak->message)) {
 
 #ifdef PRINT_CHAT_PACKETS
 			printf("  ` killed \n");
@@ -245,8 +245,8 @@ bool ChatFilter::FullMatch(const wchar_t* s, const std::initializer_list<wchar_t
 	return true;
 }
 
-bool ChatFilter::ShouldIgnore(GW::Packet::StoC::P081* pak) {
-	switch (pak->message[0]) {
+bool ChatFilter::ShouldIgnore(const wchar_t *message) {
+	switch (message[0]) {
 		// ==== Messages not ignored ====
 	case 0x108: return false; // player message
 	case 0x777: return false; // I'm level x and x% of the way earning my next skill point	(author is not part of the message)
@@ -265,7 +265,7 @@ bool ChatFilter::ShouldIgnore(GW::Packet::StoC::P081* pak) {
 	case 0x7BE: return false; // emote yawn
 	case 0x7BF: return false; // emote yes
 	case 0x7CC:
-		if (FullMatch(&pak->message[1], { 0x962D, 0xFEB5, 0x1D08, 0x10A, 0xAC2, 0x101, 0x164, 0x1 })) return lunars; // you receive 100 gold
+		if (FullMatch(&message[1], { 0x962D, 0xFEB5, 0x1D08, 0x10A, 0xAC2, 0x101, 0x164, 0x1 })) return lunars; // you receive 100 gold
 		break;
 	case 0x7E0: return self_common_drops; // party shares gold
 	case 0x7ED: return false; // opening the chest reveals x, which your party reserves for y
@@ -300,7 +300,7 @@ bool ChatFilter::ShouldIgnore(GW::Packet::StoC::P081* pak) {
 	case 0x87C: return noonehearsyou; // 'no one hears you... ' (explorable)
 
 	case 0x8101:
-		switch (pak->message[1]) {
+		switch (message[1]) {
 		case 0x1868: // teilah takes 10 festival tickets
 		case 0x1867: // stay where you are, nine rings is about to begin
 		case 0x1869: // big winner! 55 tickets
@@ -310,15 +310,15 @@ bool ChatFilter::ShouldIgnore(GW::Packet::StoC::P081* pak) {
 		case 0x186D: // did not win 9rings
 			return ninerings;
 		}
-		if (FullMatch(&pak->message[1], { 0x6649, 0xA2F9, 0xBBFA, 0x3C27 })) return lunars; // you will celebrate a festive new year (rocket or popper)
-		if (FullMatch(&pak->message[1], { 0x664B, 0xDBAB, 0x9F4C, 0x6742 })) return lunars; // something special is in your future! (lucky aura)
-		if (FullMatch(&pak->message[1], { 0x6648, 0xB765, 0xBC0D, 0x1F73 })) return lunars; // you will have a prosperous new year! (gain 100 gold)
-		if (FullMatch(&pak->message[1], { 0x664C, 0xD634, 0x91F8, 0x76EF })) return lunars; // your new year will be a blessed one (lunar blessing)
-		if (FullMatch(&pak->message[1], { 0x664A, 0xEFB8, 0xDE25, 0x363 })) return lunars; // You will find bad luck in this new year... or bad luck will find you
+		if (FullMatch(&message[1], { 0x6649, 0xA2F9, 0xBBFA, 0x3C27 })) return lunars; // you will celebrate a festive new year (rocket or popper)
+		if (FullMatch(&message[1], { 0x664B, 0xDBAB, 0x9F4C, 0x6742 })) return lunars; // something special is in your future! (lucky aura)
+		if (FullMatch(&message[1], { 0x6648, 0xB765, 0xBC0D, 0x1F73 })) return lunars; // you will have a prosperous new year! (gain 100 gold)
+		if (FullMatch(&message[1], { 0x664C, 0xD634, 0x91F8, 0x76EF })) return lunars; // your new year will be a blessed one (lunar blessing)
+		if (FullMatch(&message[1], { 0x664A, 0xEFB8, 0xDE25, 0x363 })) return lunars; // You will find bad luck in this new year... or bad luck will find you
 		break;
 
 	case 0x8102:
-		switch (pak->message[1]) {
+		switch (message[1]) {
 		// 0xEFE is a player message (wtf anet?)
 		case 0x4650: return pvp_messages; // skill has been updated for pvp
 		case 0x4651: return pvp_messages; // a hero skill has been updated for pvp

--- a/GWToolbox/GWToolbox/OtherModules/ChatFilter.cpp
+++ b/GWToolbox/GWToolbox/OtherModules/ChatFilter.cpp
@@ -69,7 +69,8 @@ void ChatFilter::Initialize() {
 			|| favor
 			|| ninerings
 			|| noonehearsyou
-			|| lunars)
+			|| lunars
+			|| away)
 			&& ShouldIgnore(pak->message)) {
 
 #ifdef PRINT_CHAT_PACKETS
@@ -144,6 +145,7 @@ void ChatFilter::LoadSettings(CSimpleIni* ini) {
 	noonehearsyou = ini->GetBoolValue(Name(), "noonehearsyou", true);
 	lunars = ini->GetBoolValue(Name(), "lunars", true);
 	messagebycontent = ini->GetBoolValue(Name(), "messagebycontent", false);
+	away = ini->GetBoolValue(Name(), "away", false);
 
 	std::ifstream bycontent_file;
 	bycontent_file.open(GuiUtils::getPath("FilterByContent.txt"));
@@ -177,6 +179,7 @@ void ChatFilter::SaveSettings(CSimpleIni* ini) {
 	ini->SetBoolValue(Name(), "lunars", lunars);
 	ini->SetBoolValue(Name(), "messagebycontent", messagebycontent);
 	//ini->SetBoolValue(Name(), "messagebyauthor", messagebyauthor);
+	ini->SetBoolValue(Name(), "away", away);
 
 	if (bycontent_filedirty) {
 		std::ofstream bycontent_file;
@@ -301,7 +304,7 @@ bool ChatFilter::ShouldIgnore(const wchar_t *message) {
 	case 0x846: return false; // 'Screenshot saved as <path>'.
 	case 0x87B: return noonehearsyou; // 'no one hears you.' (outpost)
 	case 0x87C: return noonehearsyou; // 'no one hears you... ' (explorable)
-	case 0x87D: return false; // 'Player <name> might not reply...' (Away)
+	case 0x87D: return away; // 'Player <name> might not reply...' (Away)
 	case 0x87F: return false; // 'Failed to send whisper to player <name>...' (Do not disturb)
 	case 0x880: return false; // 'Player name <name> is invalid.'. (Anyone actually saw it ig ?)
 	case 0x881: return false; // 'Player <name> is not online.' (Offline)
@@ -389,6 +392,7 @@ void ChatFilter::DrawSettingInternal() {
 	ImGui::Checkbox("9 Rings messages", &ninerings);
 	ImGui::Checkbox("'No one hears you...'", &noonehearsyou);
 	ImGui::Checkbox("Lunar fortunes messages", &lunars);
+	ImGui::Checkbox("'Player is away' messages", &away);
 
 	ImGui::Separator();
 	ImGui::Checkbox("Hide any messages containing:", &messagebycontent);

--- a/GWToolbox/GWToolbox/OtherModules/ChatFilter.cpp
+++ b/GWToolbox/GWToolbox/OtherModules/ChatFilter.cpp
@@ -6,6 +6,7 @@
 #include <GWCA\Managers\AgentMgr.h>
 #include <GWCA\Managers\StoCMgr.h>
 #include <GWCA\Managers\MapMgr.h>
+#include <GWCA\Managers\ChatMgr.h>
 
 #include <imgui.h>
 #include "GuiUtils.h"
@@ -69,8 +70,7 @@ void ChatFilter::Initialize() {
 			|| favor
 			|| ninerings
 			|| noonehearsyou
-			|| lunars
-			|| away)
+			|| lunars)
 			&& ShouldIgnore(pak->message)) {
 
 #ifdef PRINT_CHAT_PACKETS
@@ -128,6 +128,14 @@ void ChatFilter::Initialize() {
 			return true;
 		}
 		return false;
+	});
+
+	GW::Chat::SetLocalMessageCallback(
+		[this](int channel, wchar_t *message) -> bool {
+		if (away && ShouldIgnore(message)) {
+			return false;
+		}
+		return true;
 	});
 }
 

--- a/GWToolbox/GWToolbox/OtherModules/ChatFilter.h
+++ b/GWToolbox/GWToolbox/OtherModules/ChatFilter.h
@@ -25,15 +25,15 @@ public:
 	void DrawSettingInternal() override;
 
 private:
-	const wchar_t* Get1stSegment(GW::Packet::StoC::P081* pak) const;
-	const wchar_t* Get2ndSegment(GW::Packet::StoC::P081* pak) const;
+	const wchar_t* Get1stSegment(const wchar_t *message) const;
+	const wchar_t* Get2ndSegment(const wchar_t *message) const;
 	bool FullMatch(const wchar_t* p, const std::initializer_list<wchar_t>& msg) const;
 
-	DWORD GetNumericSegment(GW::Packet::StoC::P081* pak) const;
+	DWORD GetNumericSegment(const wchar_t *message) const;
 	bool ShouldIgnoreByAgentThatDropped(const wchar_t* agent_segment) const;
 	bool IsRare(const wchar_t* item_segment) const;
-	bool ShouldIgnore(GW::Packet::StoC::P081* pak);
-	bool ShouldIgnoreByContent(GW::Packet::StoC::P081* pak);
+	bool ShouldIgnore(const wchar_t *message);
+	bool ShouldIgnoreByContent(const wchar_t *message);
 
 	bool kill_next_msgdelivery;
 	bool kill_next_p081 = false;

--- a/GWToolbox/GWToolbox/OtherModules/ChatFilter.h
+++ b/GWToolbox/GWToolbox/OtherModules/ChatFilter.h
@@ -49,6 +49,7 @@ private:
 	bool ninerings;
 	bool noonehearsyou;
 	bool lunars;
+	bool away;
 
 	bool messagebycontent;
 #define FILTER_BUF_SIZE 1024*16


### PR DESCRIPTION
Really easy to extend on many other messages that aren't sent from the server.
    - Heroes behaviors change.
    - Screen capture message.
    - Do not disturb & offline.

Also, can generally parse incoming/outgoing message from the private messages channel, so extended ignore list can definitly be done with that.