### PR TITLE
Fix Borderless Mode Fullscreen Check

### DIFF
--- a/GWToolbox/GWToolbox/Modules/GameSettings.h
+++ b/GWToolbox/GWToolbox/Modules/GameSettings.h
@@ -51,5 +51,7 @@ public:
 
 private:
 	std::vector<GW::MemoryPatcher*> patches;
+	bool RectEquals(RECT a, RECT b);
+	bool RectMultiscreen(RECT desktop, RECT gw);
 	
 };


### PR DESCRIPTION
Fixed Fullscreen Check for Borderless mode, see bug #123  --> always works now, resolution based check

TODO: for some reason GameSettings::ApplyBorderless() gets called twice on tb startup with parameter false while in window mode, so the error message in the window case is commented out so tb users wont be confusded - nevertheless we should investigate that strange behaviour and possibly fix it...