### PR TITLE
Prevent DLL PDB being overwritten by Launcher PDB

### DIFF
--- a/GWToolbox/GWToolbox.vcxproj
+++ b/GWToolbox/GWToolbox.vcxproj
@@ -63,6 +63,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>dbghelp.lib;d3d9.lib;d3dx9.lib;GWCAd.lib;Shlwapi.lib;Urlmon.lib;Wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ProgramDatabaseFile>$(OutDir)$(TargetFileName).pdb</ProgramDatabaseFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
VS default is to use $(TargetName) which would result in two GWToolbox.pdb (one from Launcher and one from the DLL) files being created in the same folder.
Replaced with $(TargetFileName) for the DLL project.