### PR TITLE
Fix the display of Kegs of Aged Hunter's Ale

### DIFF
--- a/GWToolbox/GWToolbox/Windows/Pcons.cpp
+++ b/GWToolbox/GWToolbox/Windows/Pcons.cpp
@@ -284,10 +284,19 @@ int PconAlcohol::QuantityForEach(const GW::Item* item) const {
 	case ItemID::SpikedEggnog:
 	case ItemID::AgedDwarvenAle:
 	case ItemID::AgedHungersAle:
-	case ItemID::Keg:
 	case ItemID::FlaskOfFirewater:
 	case ItemID::KrytanBrandy:
 		return 5;
+	case ItemID::Keg: {
+		GW::ItemModifier *mod = item->ModStruct;
+		for (DWORD i = 0; i < item->ModStructSize; i++) {
+			if (mod->identifier() == 581) {
+				return mod->arg3() * 5;
+			}
+			mod++;
+		}
+		return 5; // this should never happen, but we keep it as a fallback
+	}
 	default:
 		return 0;
 	}

--- a/GWToolbox/GWToolbox/Windows/Pcons.cpp
+++ b/GWToolbox/GWToolbox/Windows/Pcons.cpp
@@ -289,6 +289,9 @@ int PconAlcohol::QuantityForEach(const GW::Item* item) const {
 		return 5;
 	case ItemID::Keg: {
 		GW::ItemModifier *mod = item->ModStruct;
+		// we don't think this will ever happen
+		if (mod == nullptr) return 5;
+
 		for (DWORD i = 0; i < item->ModStructSize; i++) {
 			if (mod->identifier() == 581) {
 				return mod->arg3() * 5;


### PR DESCRIPTION
They are now taken correctly into account when displaying the remaining
minutes in the Pcons window.

Closes #255