### PR TITLE
Ctrl Shift Click item to open wiki

### DIFF
--- a/GWToolbox/GWToolbox/Modules/GameSettings.h
+++ b/GWToolbox/GWToolbox/Modules/GameSettings.h
@@ -48,6 +48,7 @@ public:
 	bool auto_url = false;
 	// bool select_with_chat_doubleclick = false;
 	bool move_item_on_ctrl_click = false;
+	bool wiki_item_on_ctrl_shift_click = false;
 
 	bool flash_window_on_pm = false;
 	bool flash_window_on_party_invite = false;


### PR DESCRIPTION
Adding option to ctrl shift click an item to open the wiki page for that item.

This is just an idea I had when i was going through a bunch of items in my storage, cleaning things out. Feel free to discuss the feature and try it out for yourself.

I added the option right next to ctrl+click items to move to storage, and used functionality similar to the scwiki chat command to perform opening the wiki in a browser.