### PR TITLE
Ignore spiritual possession post processing for drunk timer/pcon

### DIFF
--- a/GWToolbox/GWToolbox.vcxproj
+++ b/GWToolbox/GWToolbox.vcxproj
@@ -60,6 +60,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ForcedIncludeFiles>GWCA\Utilities\Export.h</ForcedIncludeFiles>
       <ShowIncludes>false</ShowIncludes>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/GWToolbox/GWToolbox/Widgets/AlcoholWidget.cpp
+++ b/GWToolbox/GWToolbox/Widgets/AlcoholWidget.cpp
@@ -19,6 +19,9 @@ void AlcoholWidget::Initialize() {
 }
 
 bool AlcoholWidget::AlcUpdate(GW::Packet::StoC::PostProcess *packet) {
+	if (packet->tint == 6) {
+		return false; // Tint effect 6 is spiritual possession (5 is grog); this isn't drunk.
+	}
 	// if the player used a drink
 	if (packet->level > alcohol_level){
 		// if the player already had a drink going

--- a/GWToolbox/GWToolbox/Widgets/AlcoholWidget.cpp
+++ b/GWToolbox/GWToolbox/Widgets/AlcoholWidget.cpp
@@ -2,8 +2,11 @@
 
 #include <GWCA\Managers\StoCMgr.h>
 #include <GWCA\Managers\MapMgr.h>
+#include <GWCA\Context\GameContext.h>
+#include <Windows\PconsWindow.h>
 
 #include <GuiUtils.h>
+#include <logger.h>
 
 #include <ctime>
 
@@ -17,11 +20,41 @@ void AlcoholWidget::Initialize() {
 	GW::StoC::AddCallback<GW::Packet::StoC::PostProcess>(
 		std::bind(&AlcoholWidget::AlcUpdate, this, std::placeholders::_1));
 }
-
-bool AlcoholWidget::AlcUpdate(GW::Packet::StoC::PostProcess *packet) {
-	if (packet->tint == 6) {
-		return false; // Tint effect 6 is spiritual possession (5 is grog); this isn't drunk.
+long AlcoholWidget::GetAlcoholTitlePoints() {
+	GW::GameContext* gameContext = GW::GameContext::instance();
+	if (!gameContext || !gameContext->world || !gameContext->world->titles.valid())
+		return 0;	// Sanity checks; context not ready.
+	return gameContext->world->titles[7].currentpoints;
+}
+long AlcoholWidget::GetAlcoholTitlePointsGained() {
+	long current_title_points = GetAlcoholTitlePoints();
+	long points_gained = current_title_points - prev_alcohol_title_points;
+	prev_alcohol_title_points = current_title_points; // Update previous variable.
+	return points_gained <= 0 ? 0 : points_gained;
+}
+void AlcoholWidget::Update(float delta) {
+	if (map_id != GW::Map::GetMapID() && GW::Map::GetInstanceType() != GW::Constants::InstanceType::Loading) {
+		map_id = GW::Map::GetMapID();
+		prev_alcohol_title_points = GetAlcoholTitlePoints(); // Fetch base alcohol points at start of map.
 	}
+}
+DWORD AlcoholWidget::GetAlcoholLevel() {
+	return this->alcohol_level;
+}
+bool AlcoholWidget::AlcUpdate(GW::Packet::StoC::PostProcess *packet) {
+	long pts_gained = GetAlcoholTitlePointsGained();
+	//Log::Info("Drunk effect %d / %d, %d pts gained", packet->tint, packet->level, pts_gained);
+	if (packet->tint == 6) {
+		// Tint 6, level 5 - the trouble zone for lunars!
+		if (packet->level == 5 && (prev_packet_tint_6_level < packet->level-1 || (prev_packet_tint_6_level == 5 && pts_gained < 1))) {
+			// If we've jumped a level, or the last packet was also level 5 and no points were gained, then its not alcohol.
+			// NOTE: All alcohol progresses from 1 to 5, but lunars just dive in at level 5.
+			//Log::Info("Lunars detected");
+			return false;
+		}
+		prev_packet_tint_6_level = packet->level;
+	}
+	
 	// if the player used a drink
 	if (packet->level > alcohol_level){
 		// if the player already had a drink going

--- a/GWToolbox/GWToolbox/Widgets/AlcoholWidget.h
+++ b/GWToolbox/GWToolbox/Widgets/AlcoholWidget.h
@@ -3,6 +3,7 @@
 #include "ToolboxWidget.h"
 
 #include <GWCA\Packets\StoC.h>
+#include <GWCA\Constants\Maps.h>
 
 
 class AlcoholWidget : public ToolboxWidget {
@@ -12,16 +13,22 @@ private:
 	DWORD alcohol_level;
 	time_t last_alcohol;
 	long alcohol_time;
+	long GetAlcoholTitlePointsGained(); // Returns amount of alcohol points gained since last check (or map load)
+	long prev_alcohol_title_points = 0; // Used in GetAlcoholTitlePointsGained
+	GW::Constants::MapID map_id;
+	DWORD prev_packet_tint_6_level=0; // Record what last post processing packet was - for lunars check
 public:
 	static AlcoholWidget& Instance() {
 		static AlcoholWidget instance;
 		return instance;
 	}
-
+	
 	const char* Name() const override { return "Alcohol"; }
 
 	void Initialize() override;
-
+	void Update(float delta) override;
+	DWORD GetAlcoholLevel();
+	long GetAlcoholTitlePoints(); // Gets current alcohol title points.
 	bool AlcUpdate(GW::Packet::StoC::PostProcess *packet);
 
 	// Draw user interface. Will be called every frame if the element is visible

--- a/GWToolbox/GWToolbox/Windows/PconsWindow.cpp
+++ b/GWToolbox/GWToolbox/Windows/PconsWindow.cpp
@@ -118,6 +118,9 @@ void PconsWindow::Initialize() {
 	});
 	GW::StoC::AddCallback<GW::Packet::StoC::PostProcess>(
 		[&](GW::Packet::StoC::PostProcess *pak) -> bool {
+		if (pak->tint == 6) {
+			return PconAlcohol::suppress_drunk_effect; // Tint effect 6 is spiritual possession (5 is grog); this isn't drunk.
+		}
 		PconAlcohol::alcohol_level = pak->level;
 		//printf("Level = %d, tint = %d\n", pak->level, pak->tint);
 		if (enabled) pcon_alcohol->Update();

--- a/GWToolbox/GWToolbox/Windows/PconsWindow.cpp
+++ b/GWToolbox/GWToolbox/Windows/PconsWindow.cpp
@@ -8,12 +8,14 @@
 #include <GWCA\Managers\PartyMgr.h>
 #include <GWCA\Managers\StoCMgr.h>
 #include <GWCA\Managers\ChatMgr.h>
+#include <GWCA\Context\GameContext.h>
 #include <imgui_internal.h>
 
 #include <logger.h>
 #include "GuiUtils.h"
 #include "Windows\MainWindow.h"
 #include <Modules\Resources.h>
+#include <Widgets\AlcoholWidget.h>
 
 using namespace GW::Constants;
 
@@ -116,13 +118,9 @@ void PconsWindow::Initialize() {
 		}
 		return false;
 	});
-	GW::StoC::AddCallback<GW::Packet::StoC::PostProcess>(
-		[&](GW::Packet::StoC::PostProcess *pak) -> bool {
-		if (pak->tint == 6) {
-			return PconAlcohol::suppress_drunk_effect; // Tint effect 6 is spiritual possession (5 is grog); this isn't drunk.
-		}
-		PconAlcohol::alcohol_level = pak->level;
-		//printf("Level = %d, tint = %d\n", pak->level, pak->tint);
+	GW::StoC::AddCallback<GW::Packet::StoC::PostProcess>([&](GW::Packet::StoC::PostProcess *pak) -> bool {
+		//Log::Info("Level = %d, tint = %d\n", pak->level, pak->tint);
+		PconAlcohol::alcohol_level = AlcoholWidget::Instance().GetAlcoholLevel();
 		if (enabled) pcon_alcohol->Update();
 		return PconAlcohol::suppress_drunk_effect;
 	});
@@ -223,6 +221,8 @@ void PconsWindow::Initialize() {
 	});
 }
 
+
+
 bool PconsWindow::DrawTabButton(IDirect3DDevice9* device, 
 	bool show_icon, bool show_text) {
 
@@ -265,10 +265,6 @@ void PconsWindow::Draw(IDirect3DDevice9* device) {
 		}
 	}
 	ImGui::End();
-
-	if (!alcohol_enabled_before && pcon_alcohol->enabled) {
-		CheckIfWeJustEnabledAlcoholWithLunarsOn();
-	}
 }
 
 void PconsWindow::Update(float delta) {
@@ -306,21 +302,7 @@ bool PconsWindow::SetEnabled(bool b) {
 	if (tick_with_pcons && GW::Map::GetInstanceType() == GW::Constants::InstanceType::Outpost) {
 		GW::PartyMgr::Tick(enabled);
 	}
-	CheckIfWeJustEnabledAlcoholWithLunarsOn();
 	return enabled;
-}
-
-void PconsWindow::CheckIfWeJustEnabledAlcoholWithLunarsOn() {
-	if (enabled
-		&& GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable
-		&& pcon_alcohol->enabled
-		&& Pcon::alcohol_level == 5) {
-		// we just re-enabled pcons and we need to pop alcohol, but the alcohol level 
-		// is 5 already, which means it's very likely that we have Spiritual Possession on.
-		// Force usage of alcohol to be sure.
-		// Note: if we're dead this will fail and alcohol will never be used.
-		pcon_alcohol->ForceUse();
-	}
 }
 
 void PconsWindow::LoadSettings(CSimpleIni* ini) {

--- a/GWToolbox/GWToolbox/Windows/PconsWindow.h
+++ b/GWToolbox/GWToolbox/Windows/PconsWindow.h
@@ -36,8 +36,6 @@ public:
 	void DrawSettingInternal() override;
 
 private:
-	void CheckIfWeJustEnabledAlcoholWithLunarsOn();
-
 	std::vector<Pcon*> pcons;
 	PconAlcohol* pcon_alcohol = nullptr;
 	GW::Constants::InstanceType current_map_type;


### PR DESCRIPTION
Tint 6 is the spiritual possession post processing. Other alcohol still sends through the correct packet level by the minute/use, so can still use it to figure out alcohol amount.