### PR TITLE
Fixed ctrl+click store items into new storage panes/material storage

### DIFF
--- a/GWToolbox/GWToolbox/Modules/GameSettings.cpp
+++ b/GWToolbox/GWToolbox/Modules/GameSettings.cpp
@@ -192,16 +192,12 @@ namespace {
 
 	void move_item_to_storage_page(GW::Item *item, int page) {
 		assert(item && item->quantity);
-		// 9 being the material storage
-		if (page < 0 || 9 < page) return;
-
-		if (page == 9) {
+		if (page == static_cast<int>(GW::Constants::StoragePane::Material_Storage)) {
 			if (!item->GetIsMaterial()) return;
 			move_materials_to_storage(item);
 			return;
 		}
-
-		assert(0 <= page && page < 9);
+		assert(page >= static_cast<int>(GW::Constants::StoragePane::Storage_1) && page <= static_cast<int>(GW::Constants::StoragePane::Storage_14));
 		const int storage1 = (int)GW::Constants::Bag::Storage_1;
 		const int bag_index = storage1 + page;
 		assert(GW::Items::GetBag(bag_index));
@@ -456,13 +452,13 @@ void GameSettings::Initialize() {
 		printf("[SCAN] StoragePatch = %p\n", (void *)found);
 
 		// Xunlai Chest has a behavior where if you
-		// 1. Open chest on page 1 to 8
+		// 1. Open chest on page 1 to 14
 		// 2. Close chest & open it again
 		// -> You should still be on the same page
 		// But, if you try with the material page (or anniversary page in the case when you bought all other storage page)
 		// you will get back the the page 1. I think it was a intended use for material page & forgot to fix it
 		// when they added anniversary page so we do it ourself.
-		DWORD page_max = 8;
+		DWORD page_max = 14;
 		ctrl_click_patch = new GW::MemoryPatcher(found, &page_max, 1);
 		ctrl_click_patch->TooglePatch(true);
 	}


### PR DESCRIPTION
Overlooked this when we were fixing for the extra 5 storage panes. Ctrl click isn't working properly when storing into these new panes/storage pane.

Will also make small PR for GWCA