### PR TITLE
TradeWindow stability changes post decltype.org issues

### DIFF
--- a/GWToolbox/GWToolbox/Windows/TradeWindow.cpp
+++ b/GWToolbox/GWToolbox/Windows/TradeWindow.cpp
@@ -2,23 +2,37 @@
 #include "TradeWindow.h"
 
 #include <WinSock2.h>
+#include <sstream>
+#include <algorithm>
+#include <iterator>
+#include <string>
 
 #include <imgui.h>
 #include <imgui_internal.h>
 
 #include <GWCA\Constants\Constants.h>
+
 #include <GWCA\GameContainers\Array.h>
+
+#include <GWCA\Context\GameContext.h>
+#include <GWCA\Context\WorldContext.h>
+
+#include <GWCA\Packets\StoC.h>
 
 #include <GWCA\Managers\UIMgr.h>
 #include <GWCA\Managers\MapMgr.h>
 #include <GWCA\Managers\ChatMgr.h>
 #include <GWCA\Managers\GameThreadMgr.h>
+#include <GWCA\Managers\StoCMgr.h>
+#include <GWCA\Managers\PlayerMgr.h>
 
 #include <Modules\Resources.h>
 
 #include "logger.h"
 #include "GuiUtils.h"
 #include "GWToolbox.h"
+
+#define TRADE_LOG_FILENAME "trade_log.txt"
 
 using easywsclient::WebSocket;
 using nlohmann::json;
@@ -35,8 +49,11 @@ void TradeWindow::Initialize() {
 		printf("WSAStartup Failed.\n");
 		return;
 	}
-
+	
 	messages = CircularBuffer<Message>(100);
+	outpost_messages = CircularBuffer<Message>(500); // May want to increase size > 500 for a bigger log?
+	outpost_messages_filtered_a = CircularBuffer<Message>(100); // Limit to last 100 matches
+	outpost_messages_filtered_b = CircularBuffer<Message>(100); // Limit to last 100 matches
 
 	should_stop = false;
 	worker = std::thread([this]() {
@@ -51,6 +68,53 @@ void TradeWindow::Initialize() {
 	});
 
 	if (print_game_chat) AsyncChatConnect();
+
+	// Callback to store trade messages when in Kamadan ae1.
+	// This is a fallback for when kamadan.decltype.org goes down; trade window will still work in ae1
+	// NOTE: Timestamps are based on received time; better to use a hook to `PrintChat` from the ChatMgr module when its exposed.
+	GW::StoC::RegisterPacketCallback<GW::Packet::StoC::MessageLocal>(&MessageLocal_Entry, [this](GW::HookStatus* status, GW::Packet::StoC::MessageLocal* pak) {
+		if (pak->type != GW::Chat::CHANNEL_TRADE)
+			return;
+		if (!GetInKamadanAE1() && false)
+			return;
+		GW::Array<wchar_t>* buff = &GW::GameContext::instance()->world->message_buff;
+		if (!buff->m_buffer || buff->m_size < 5)
+			return; // No message, may have been cleared by another hook.
+		Message m;
+		m.timestamp = time(nullptr); // This could be better
+		// wchar_t* from message buffer to Message.message
+		std::wstring message;
+		if (buff->m_buffer[0] == 0x108) {
+			// Trade chat message (not party search window)
+			message = std::wstring(&buff->m_buffer[2]);
+		}
+		else {
+			// Trade chat message (via party search window)
+			message = std::wstring(&buff->m_buffer[3]);
+		}
+		if (message.size() < 2)
+			return;
+		message[message.size() - 1] = '\0';
+		if (message.empty())
+			return;
+		std::wstring player_name(GW::PlayerMgr::GetPlayerName(pak->id));
+		if (player_name.empty())
+			return;
+		int size_needed = WideCharToMultiByte(CP_UTF8, 0, &message[0], (int)message.size(), NULL, 0, NULL, NULL);
+		m.message = std::string(size_needed, 0);
+		WideCharToMultiByte(CP_UTF8, 0, &message[0], (int)message.size(), &m.message[0], size_needed, NULL, NULL);
+
+		size_needed = WideCharToMultiByte(CP_UTF8, 0, &player_name[0], (int)player_name.size(), NULL, 0, NULL, NULL);
+		m.name = std::string(size_needed, 0);
+		WideCharToMultiByte(CP_UTF8, 0, &player_name[0], (int)player_name.size(), &m.name[0], size_needed, NULL, NULL);
+
+		outpost_messages.add(m);
+		if (m.contains(searched_message)) {
+			search_pending = true;
+			search_local(searched_message);
+		}
+		localtradelogfile_dirty = true;
+		});
 }
 
 void TradeWindow::Terminate() {
@@ -73,6 +137,10 @@ TradeWindow::~TradeWindow() {
 	Terminate();
 }
 
+bool TradeWindow::GetInKamadanAE1() {
+	return 	GetInKamadan() && GW::Map::GetDistrict() == 1 &&
+		GW::Map::GetRegion() == GW::Constants::Region::America;
+}
 bool TradeWindow::GetInKamadan() {
 	using namespace GW::Constants;
 	switch (GW::Map::GetMapID()) {
@@ -96,14 +164,14 @@ void TradeWindow::Update(float delta) {
 	}
 
 	// do not display trade chat while in kamadan AE district 1
-	if (GetInKamadan() && GW::Map::GetDistrict() == 1 &&
-		GW::Map::GetRegion() == GW::Constants::Region::America) {
+	if (GetInKamadanAE1()) {
 		if (ws_chat) ws_chat->close();
 		return;
 	}
 	
 	if (!ws_chat && !ws_chat_connecting) {
-		AsyncChatConnect();
+		if (clock() > socket_retry_clock + socket_retry_interval) 
+			AsyncChatConnect(); // Only retry connection after retry timeout.
 		return;
 	}
 
@@ -174,16 +242,31 @@ void TradeWindow::fetch() {
 		}
 	});
 }
-
+void TradeWindow::ConnectionFailed(bool forced) {
+	printf("Couldn't connect to the host '%s'\n", ws_host);
+	socket_retry_interval += 5 * CLOCKS_PER_SEC;
+	if (socket_retry_interval > 120 * CLOCKS_PER_SEC)
+		socket_retry_interval = 120 * CLOCKS_PER_SEC; // Retry interval of 120 seconds at most.
+	socket_fail_count++;
+	if (forced) {
+		// If player attempted to connect directly, show an error.
+		GW::GameThread::Enqueue([this]() {
+			Log::Error("%s Failed to connect to kamadan.decltype.org", Name(), socket_fail_count);
+			});
+	}
+}
 void TradeWindow::search(std::string query) {
-	if (!ws_window || ws_window->getReadyState() != WebSocket::OPEN)
-		return;
-
 	// for now we won't allow to enqueue more than 1 search, it shouldn't change anything because how fast we get the answers
 	if (search_pending)
 		return;
 
 	search_pending = true;
+	if (!ws_window || ws_window->getReadyState() != WebSocket::OPEN) {
+		search_local(query);
+		return;
+	}
+
+	
 
 	/*
 	 * The protocol is the following:
@@ -201,11 +284,35 @@ void TradeWindow::search(std::string query) {
 	request["suggest"] = 0;
 	ws_window->send(request.dump());
 }
+void TradeWindow::search_local(std::string query) {
+	
+	thread_jobs.push([this,query]() {
+		CircularBuffer<Message>* filter_ptr = &outpost_messages_filtered_a;
+		if (outpost_messages_filtered_ptr == filter_ptr)
+			filter_ptr = &outpost_messages_filtered_b;
+		filter_ptr->clear();
+		if (query.empty()) {
+			search_pending = false;
+			searched_message = query;
+			return;
+		}
+		unsigned int size = outpost_messages.size();
+		for (unsigned int i = 0; i < size; i++) {
+			if (!outpost_messages[i].contains(query))
+				continue;
+			filter_ptr->add(outpost_messages[i]);
+		}
+		outpost_messages_filtered_ptr = filter_ptr;
+		search_pending = false;
+		searched_message = query;
+		});
+}
 
 void TradeWindow::Draw(IDirect3DDevice9* device) {
 	if (visible) {
 		if (ws_window == nullptr) {
-			AsyncWindowConnect();
+			if (clock() > socket_retry_clock + socket_retry_interval)
+				AsyncWindowConnect(); // Only retry connection after retry timeout.
 		}
 	} else { // not visible
 		if (ws_window) {
@@ -227,7 +334,6 @@ void TradeWindow::Draw(IDirect3DDevice9* device) {
 	ImGui::SetNextWindowSize(ImVec2(700, 400), ImGuiSetCond_FirstUseEver);
 	if (ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
 		/* Search bar header */
-		static char search_buffer[256];
 		ImGui::PushItemWidth((ImGui::GetWindowContentRegionWidth() - 80.0f - 80.0f - 80.0f - ImGui::GetStyle().ItemInnerSpacing.x * 6));
 		if (ImGui::InputText("", search_buffer, 256, ImGuiInputTextFlags_EnterReturnsTrue)) {
 			search(search_buffer);
@@ -246,22 +352,27 @@ void TradeWindow::Draw(IDirect3DDevice9* device) {
 			show_alert_window = !show_alert_window;
 		}
 
+		CircularBuffer<Message>* messages_ptr = nullptr;
+
 		/* Main trade chat area */
 		ImGui::BeginChild("trade_scroll", ImVec2(0, -20.0f - ImGui::GetStyle().ItemInnerSpacing.y));
 		/* Connection checks */
-		if (!ws_window && !ws_window_connecting) {
-			ImGui::SetCursorPosX((ImGui::GetWindowWidth() - ImGui::CalcTextSize("The connection to kamadan.decltype.com has timed out.").x) / 2);
+		if(!ws_window && !ws_window_connecting) {
+			messages_ptr = searched_message.size() ? outpost_messages_filtered_ptr : &outpost_messages;
+			/*ImGui::SetCursorPosX((ImGui::GetWindowWidth() - ImGui::CalcTextSize("The connection to kamadan.decltype.com has timed out.").x) / 2);
 			ImGui::SetCursorPosY(ImGui::GetWindowHeight() / 2);
 			ImGui::Text("The connection to kamadan.decltype.com has timed out.");
 			ImGui::SetCursorPosX((ImGui::GetWindowWidth() - ImGui::CalcTextSize("Click to reconnect").x) / 2);
 			if (ImGui::Button("Click to reconnect")) {
 				AsyncWindowConnect();
-			}
+			}*/
 		} else if (ws_window_connecting || (ws_window && ws_window->getReadyState() == WebSocket::CONNECTING)) {
-			ImGui::SetCursorPosX((ImGui::GetWindowWidth() - ImGui::CalcTextSize("Connecting...").x)/2);
+			messages_ptr = searched_message.size() ? outpost_messages_filtered_ptr : &outpost_messages;
+			/*ImGui::SetCursorPosX((ImGui::GetWindowWidth() - ImGui::CalcTextSize("Connecting...").x) / 2);
 			ImGui::SetCursorPosY(ImGui::GetWindowHeight() / 2);
-			ImGui::Text("Connecting...");
-		} else {
+			ImGui::Text("Connecting...");*/
+		}
+		if(messages_ptr) {
 			/* Display trade messages */
 			bool show_time = ImGui::GetWindowWidth() > 600.0f;
 
@@ -274,9 +385,9 @@ void TradeWindow::Draw(IDirect3DDevice9* device) {
 			const float playernamewidth = 160.0f;
 			const float message_left = playername_left + playernamewidth + innerspacing;
 
-			size_t size = messages.size();
+			size_t size = messages_ptr->size();
 			for (unsigned int i = size - 1; i < size; i--) {
-				Message &msg = messages[i];
+				Message &msg = (*messages_ptr)[i];
 				ImGui::PushID(i);
 
 				// ==== time elapsed column ====
@@ -326,11 +437,38 @@ void TradeWindow::Draw(IDirect3DDevice9* device) {
 			}
 		}
 		ImGui::EndChild();
+		if (ws_window) {
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0, 1, 0, 1));
+			ImGui::Button("Connected to https://kamadan.decltype.org", ImVec2(0, 20.0f));
+			ImGui::PopStyleColor();
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip("GWToolbox is fetching new trade messages from https://kamadan.decltype.org");
 
-		/* Link to website footer */
-		if (ImGui::Button("Powered by https://kamadan.decltype.org", ImVec2(ImGui::GetWindowContentRegionWidth(), 20.0f))){ 
-			CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-			ShellExecuteA(NULL, "open", "https://kamadan.decltype.org", NULL, NULL, SW_SHOWNORMAL);
+			/* Link to website footer */
+			ImGui::SameLine(ImGui::GetContentRegionAvailWidth() - 300.0f * ImGui::GetIO().FontGlobalScale, 0);
+			if (ImGui::Button("Powered by https://kamadan.decltype.org", ImVec2(300.0f * ImGui::GetIO().FontGlobalScale, 20.0f))) {
+				CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+				ShellExecuteA(NULL, "open", "https://kamadan.decltype.org", NULL, NULL, SW_SHOWNORMAL);
+			}
+		} else if (ws_window_connecting) {
+			ImGui::Button("Connecting...", ImVec2(0,20.0f));
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip("GWToolbox is trying to connect to https://kamadan.decltype.org");
+		}
+		else if (messages_ptr && GetInKamadanAE1()) {
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0, 1, 0, 1));
+			ImGui::Button("Connected Locally", ImVec2(0, 20.0f));
+			ImGui::PopStyleColor();
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip("GWToolbox is fetching new trade messages from Trade chat in this outpost");
+		}
+		else {
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1, 0, 0, 1));
+			if (ImGui::Button("Not Connected", ImVec2(0, 20.0f)))
+				AsyncWindowConnect(true);
+			ImGui::PopStyleColor();
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip("GWToolbox isn't fetching new trade messages.\nClick to re-connect to https://kamadan.decltype.org");
 		}
 
 		/* Alerts window */
@@ -365,7 +503,7 @@ void TradeWindow::DrawSettingInternal() {
 void TradeWindow::LoadSettings(CSimpleIni* ini) {
 	ToolboxWindow::LoadSettings(ini);
 	print_game_chat = ini->GetBoolValue(Name(), VAR_NAME(print_game_chat), false);
-	filter_alerts   = ini->GetBoolValue(Name(), VAR_NAME(filter_alerts), false);
+	filter_alerts = ini->GetBoolValue(Name(), VAR_NAME(filter_alerts), false);
 
 	std::ifstream alert_file;
 	alert_file.open(Resources::GetPath(L"AlertKeywords.txt"));
@@ -375,6 +513,39 @@ void TradeWindow::LoadSettings(CSimpleIni* ini) {
 		ParseBuffer(alert_buf, alert_words);
 	}
 	alert_file.close();
+	// Load local trade log
+	{
+		outpost_messages.clear();
+		std::ifstream local_trade_log_file(Resources::GetPath(L"LocalTradeLog.txt"));
+		std::vector<std::vector<std::string> > dataList;
+		std::string line = "";
+		std::string delim("\x1");
+		// Iterate through each line and split the content using delimeter
+		while (getline(local_trade_log_file, line))
+		{
+			std::size_t current, previous = 0;
+			current = line.find_first_of(delim);
+			Message m;
+			if(current != std::string::npos) {
+				m.timestamp = stol(line.substr(previous, current - previous));
+				previous = current + 1;
+				current = line.find_first_of(delim, previous);
+			}
+			if (current != std::string::npos) {
+				m.name = line.substr(previous, current - previous);
+				previous = current + 1;
+				current = line.find_first_of(delim, previous);
+			}
+			m.message = line.substr(previous, current - previous);
+			if (m.timestamp && !m.name.empty() && !m.message.empty()) {
+				outpost_messages.add(m);
+			}
+		}
+		// Close the File
+		local_trade_log_file.close();
+	}
+	search_pending = true;
+	search_local(search_buffer);
 }
 
 
@@ -391,6 +562,32 @@ void TradeWindow::SaveSettings(CSimpleIni* ini) {
 			bycontent_file.write(alert_buf, strlen(alert_buf));
 			bycontent_file.close();
 			alertfile_dirty = false;
+		}
+	}
+	// Save local trade log
+	if (localtradelogfile_dirty) {
+		std::ofstream file1;
+		file1.open(Resources::GetPath(L"LocalTradeLog.txt"));
+		if (file1.is_open()) {
+			std::string output_str;
+			unsigned int size = outpost_messages.size();
+			for (unsigned int i = 0; i < size; i++) {
+				output_str += std::to_string(outpost_messages[i].timestamp);
+				output_str += "\x1";
+				output_str += outpost_messages[i].name;
+				output_str += "\x1";
+				output_str += outpost_messages[i].message;
+				output_str += "\n";
+				if (output_str.size() > 1024000) {
+					file1.write(output_str.c_str(), output_str.size());
+					output_str.clear();
+				}
+			}
+			if (output_str.size()) {
+				file1.write(output_str.c_str(), output_str.size());
+				output_str.clear();
+			}
+			file1.close();
 		}
 	}
 }
@@ -416,25 +613,41 @@ void TradeWindow::ParseBuffer(std::fstream stream, std::vector<std::string>& wor
 	}
 }
 
-void TradeWindow::AsyncChatConnect() {
+void TradeWindow::AsyncChatConnect(bool force) {
 	if (ws_chat) return;
 	if (ws_chat_connecting) return;
+	if (socket_fail_count >= 4 && !force) return;
 	ws_chat_connecting = true;
-	thread_jobs.push([this]() {
+	thread_jobs.push([this, force]() {
+		socket_retry_clock = clock();
 		if (!(ws_chat = WebSocket::from_url(ws_host))) {
-			printf("Couldn't connect to the host '%s'", ws_host);
+			ConnectionFailed(force);
+		}
+		else {
+			logged_socket_fail_error = false;
+			socket_retry_interval = 0;
+			socket_retry_clock = 0;
+			socket_fail_count = 0;
 		}
 		ws_chat_connecting = false;
 	});
 }
 
-void TradeWindow::AsyncWindowConnect() {
+void TradeWindow::AsyncWindowConnect(bool force) {
 	if (ws_window) return;
 	if (ws_window_connecting) return;
+	if (socket_fail_count >= 4 && !force) return;
 	ws_window_connecting = true;
-	thread_jobs.push([this]() {
+	thread_jobs.push([this, force]() {
+		socket_retry_clock = clock();
 		if (!(ws_window = WebSocket::from_url(ws_host))) {
-			printf("Couldn't connect to the host '%s'", ws_host);
+			ConnectionFailed(force);
+		}
+		else {
+			logged_socket_fail_error = false;
+			socket_retry_interval = 0;
+			socket_retry_clock = 0;
+			socket_fail_count = 0;
 		}
 		ws_window_connecting = false;
 	});

--- a/GWToolbox/GWToolbox/Windows/TradeWindow.h
+++ b/GWToolbox/GWToolbox/Windows/TradeWindow.h
@@ -12,6 +12,8 @@
 #include <easywsclient\easywsclient.hpp>
 #include <CircurlarBuffer.h>
 
+#include <GWCA\Utilities\Hook.h>
+
 class TradeWindow : public ToolboxWindow {
 	TradeWindow() {};
 	~TradeWindow();
@@ -38,6 +40,14 @@ private:
         uint32_t    timestamp;
         std::string name;
         std::string message;
+		inline bool contains(std::string search) {
+			auto it = std::search(
+				message.begin(), message.end(),
+				search.begin(), search.end(),
+				[](char ch1, char ch2) { return std::toupper(ch1) == std::toupper(ch2); }
+			);
+			return (it != message.end());
+		};
     };
 
 	bool show_alert_window = false;
@@ -52,36 +62,67 @@ private:
 	char alert_buf[ALERT_BUF_SIZE];
 	// set when the alert_buf was modified
 	bool alertfile_dirty = false;
+	bool localtradelogfile_dirty = false;
 
 	std::vector<std::string> alert_words;
 
 	void DrawAlertsWindowContent(bool ownwindow);
 
     static bool GetInKamadan();
+	static bool GetInKamadanAE1();
 
     // Since we are connecting in an other thread, the following attributes/methods avoid spamming connection requests
-    void AsyncChatConnect();
-    void AsyncWindowConnect();
+    void AsyncChatConnect(bool force = false);
+    void AsyncWindowConnect(bool force = false);
+	void ConnectionFailed(bool forced = false);
+
     bool ws_chat_connecting = false;
     bool ws_window_connecting = false;
 
     easywsclient::WebSocket *ws_chat = NULL;
     easywsclient::WebSocket *ws_window = NULL;
 
+	// When was last connect attempted?
+	clock_t socket_retry_clock = 0;
+	// Exponential backoff for failed connection
+	long socket_retry_interval = 0;
+	// Number of connection fails.
+	unsigned int socket_fail_count = 0;
+	// Have we told the user?
+	bool logged_socket_fail_error = false;
+
     bool search_pending;
     void search(std::string);
+	void search_local(std::string);
+	bool searching = true;
     void fetch();
 
+	CSimpleIni* trade_log_ini;
+
     static Message parse_json_message(nlohmann::json js);
+	// Messages from kamadan.decltype.org
     CircularBuffer<Message> messages;
+	// Messages from within kamadan ae1, used as a fallback. Records a log of ALL trade messages, not just searched ones.
+	CircularBuffer<Message> outpost_messages;
+	// Used for searching outpost_messages
+	CircularBuffer<Message> outpost_messages_tmp;
+	// 2 copies of this to allow search to run on another thread without locking Draw()
+	CircularBuffer<Message> outpost_messages_filtered_a;
+	CircularBuffer<Message> outpost_messages_filtered_b;
+	CircularBuffer<Message>* outpost_messages_filtered_ptr;
+	std::string searched_message;
 
     // tasks to be done async by the worker thread
 	std::queue<std::function<void()>> thread_jobs;
     bool should_stop = false;
 	std::thread worker;
 
+	char search_buffer[256];
+
 	void ParseBuffer(const char *text, std::vector<std::string> &words);
 	void ParseBuffer(std::fstream stream, std::vector<std::string>& words);
 
     static void DeleteWebSocket(easywsclient::WebSocket *ws);
+
+	GW::HookEntry MessageLocal_Entry;
 };


### PR DESCRIPTION
Added local trade chat log to TradeWindow module
Exponential backoff for re-connecting to kamadan.decltype.org - max 120 second retry
Added status button bottom left of trade window
Local trade chat log saved/loaded to LocalTradeLog.txt as a backup.
When kamadan.decltype.org is not connected, uses a local trade log as a fallback.