### PR TITLE
Split Terminate() functionality.

### DIFF
--- a/GWToolbox/GWToolbox/GWToolbox.cpp
+++ b/GWToolbox/GWToolbox/GWToolbox.cpp
@@ -475,18 +475,23 @@ void GWToolbox::Draw(IDirect3DDevice9* device) {
         ImGui_ImplDX9_RenderDrawData(draw_data);
     }
 
-    // === destruction ===
-    if (tb_initialized && GWToolbox::Instance().must_self_destruct) {
-        GWToolbox::Instance().Terminate();
+	// === destruction ===
+	if (tb_initialized && GWToolbox::Instance().must_self_destruct) {
+		for (ToolboxModule* module : GWToolbox::Instance().modules) {
+			if (!module->CanTerminate())
+				return;
+		}
 
-        ImGui_ImplDX9_Shutdown();
-        ImGui::DestroyContext();
+		GWToolbox::Instance().Terminate();
 
-        Log::Log("Restoring input hook\n");
-        SetWindowLongPtr(gw_window_handle, GWL_WNDPROC, (long)OldWndProc);
-        
-        GW::DisableHooks();
-        tb_initialized = false;
-        tb_destroyed = true;
-    }
+		ImGui_ImplDX9_Shutdown();
+		ImGui::DestroyContext();
+
+		Log::Log("Restoring input hook\n");
+		SetWindowLongPtr(gw_window_handle, GWL_WNDPROC, (long)OldWndProc);
+
+		GW::DisableHooks();
+		tb_initialized = false;
+		tb_destroyed = true;
+	}
 }

--- a/GWToolbox/GWToolbox/GWToolbox.h
+++ b/GWToolbox/GWToolbox/GWToolbox.h
@@ -29,7 +29,12 @@ public:
 	void LoadModuleSettings();
 	void SaveSettings();
 
-	void StartSelfDestruct() { must_self_destruct = true; }
+	void StartSelfDestruct() {
+		for (ToolboxModule* module : modules) {
+			module->SignalTerminate();
+		}
+		must_self_destruct = true;
+	}
 	bool must_self_destruct = false;	// is true when toolbox should quit
 
 	void RegisterModule(ToolboxModule* m) { modules.push_back(m); }

--- a/GWToolbox/GWToolbox/ToolboxModule.h
+++ b/GWToolbox/GWToolbox/ToolboxModule.h
@@ -16,6 +16,12 @@ public:
 	// Initialize module
 	virtual void Initialize();
 
+	// Send termination signal to module.
+	virtual void SignalTerminate() {};
+
+	// Can we terminate this module?
+	virtual bool CanTerminate() { return true; };
+
 	// Terminate module
 	virtual void Terminate() {};
 


### PR DESCRIPTION
Allows modules to delay termination until something else has been done