### PR TITLE
Additional Range Indicators

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
@@ -24,8 +24,8 @@ public:
 	uint32_t auto_target_id = 0;
 
 private:
-	static const size_t shape_size = 5;
-	enum Shape_e { Tear, Circle, Quad, BigCircle, EmptyCircle };
+	static const size_t shape_size = 4;
+	enum Shape_e { Tear, Circle, Quad, BigCircle };
 	enum Color_Modifier {
 		None, // rgb 0,0,0
 		Dark, // user defined
@@ -90,7 +90,6 @@ private:
 	Shape_e GetShape(const GW::Agent* agent, const CustomAgent* ca = nullptr) const;
 
 	void Enqueue(Shape_e shape, const GW::Agent* agent, float size, Color color);
-	void EnqueueCircle(const GW::Agent* agent, float radius, Color color);
 
 	D3DVertex* vertices = nullptr;	// vertices array
 	unsigned int vertices_count = 0;// count of vertices
@@ -115,7 +114,6 @@ private:
 	Color color_ally_spirit = 0;
 	Color color_ally_minion = 0;
 	Color color_ally_dead = 0;
-	Color color_range_aggro = 0;
 
 	Color profession_colors[11] = {
 		0xFF666666,

--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
@@ -24,8 +24,8 @@ public:
 	uint32_t auto_target_id = 0;
 
 private:
-	static const size_t shape_size = 4;
-	enum Shape_e { Tear, Circle, Quad, BigCircle };
+	static const size_t shape_size = 5;
+	enum Shape_e { Tear, Circle, Quad, BigCircle, EmptyCircle };
 	enum Color_Modifier {
 		None, // rgb 0,0,0
 		Dark, // user defined
@@ -90,6 +90,7 @@ private:
 	Shape_e GetShape(const GW::Agent* agent, const CustomAgent* ca = nullptr) const;
 
 	void Enqueue(Shape_e shape, const GW::Agent* agent, float size, Color color);
+	void EnqueueCircle(const GW::Agent* agent, float radius, Color color);
 
 	D3DVertex* vertices = nullptr;	// vertices array
 	unsigned int vertices_count = 0;// count of vertices
@@ -114,6 +115,7 @@ private:
 	Color color_ally_spirit = 0;
 	Color color_ally_minion = 0;
 	Color color_ally_dead = 0;
+	Color color_range_aggro = 0;
 
 	Color profession_colors[11] = {
 		0xFF666666,

--- a/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
@@ -196,8 +196,6 @@ void PingsLinesRenderer::Render(IDirect3DDevice9* device) {
 	HRESULT res = buffer->Lock(0, sizeof(D3DVertex) * vertices_max, (VOID**)&vertices, D3DLOCK_DISCARD);
 	if (FAILED(res)) printf("PingsLinesRenderer Lock() error: HRESULT 0x%lX\n", res);
 
-	// DrawTargetRange(device);
-
 	DrawShadowstepLine(device);
 
 	DrawRecallLine(device);
@@ -213,26 +211,6 @@ void PingsLinesRenderer::Render(IDirect3DDevice9* device) {
 		device->SetStreamSource(0, buffer, 0, sizeof(D3DVertex));
 		device->DrawPrimitive(type, 0, vertices_count / 2);
 		vertices_count = 0;
-	}
-}
-
-void PingsLinesRenderer::DrawTargetRange(IDirect3DDevice9* device) {
-	if (GW::Map::GetInstanceType() != GW::Constants::InstanceType::Explorable) return;
-
-	GW::AgentLiving* player = GW::Agents::GetPlayerAsAgentLiving();
-	GW::AgentLiving* target = GW::Agents::GetTargetAsAgentLiving();
-	if (target) {
-		if (target == player) return;
-		if (target->GetAsAgentLiving() == nullptr) return;
-
-		float range = target->allegiance == 0x3 ? 700.0f : 1010.0f;
-
-		D3DXMATRIX translate, scale, world;
-		D3DXMatrixTranslation(&translate, target->x, target->y, 0.0f);
-		D3DXMatrixScaling(&scale, range, range, 1.0f);
-		world = scale * translate;
-		device->SetTransform(D3DTS_WORLD, &world);
-		rangemarker.Render(device);
 	}
 }
 

--- a/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
@@ -49,7 +49,7 @@ void PingsLinesRenderer::DrawSettings() {
 		marker.color = Colors::ARGB(200, 128, 0, 128);
 		color_shadowstep_line = Colors::ARGB(48, 128, 0, 128);
 		color_shadowstep_line_maxrange = Colors::ARGB(48, 128, 0, 128);
-		rangemarker.color = Colors::ARGB(255, 153, 68, 68);
+		rangemarker.color = Colors::ARGB(200, 128, 0, 128);
 		ping_circle.Invalidate();
 		marker.Invalidate();
 		rangemarker.Invalidate();

--- a/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.h
@@ -108,7 +108,7 @@ public:
 private:
 	void Initialize(IDirect3DDevice9* device) override;
 
-	void DrawTargetChainAggro(IDirect3DDevice9* device);
+	void DrawTargetRange(IDirect3DDevice9* device);
 	void DrawPings(IDirect3DDevice9* device);
 	void DrawShadowstepMarker(IDirect3DDevice9* device);
 	void DrawShadowstepLine(IDirect3DDevice9* device);

--- a/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.h
@@ -73,6 +73,11 @@ class PingsLinesRenderer : public VBuffer {
 	public:
 		Color color = 0;
 	};
+	class RangeMarker : public VBuffer {
+		void Initialize(IDirect3DDevice9* device) override;
+	public:
+		Color color = 0;
+	};
 
 public:
 	PingsLinesRenderer();
@@ -103,6 +108,7 @@ public:
 private:
 	void Initialize(IDirect3DDevice9* device) override;
 
+	void DrawTargetChainAggro(IDirect3DDevice9* device);
 	void DrawPings(IDirect3DDevice9* device);
 	void DrawShadowstepMarker(IDirect3DDevice9* device);
 	void DrawShadowstepLine(IDirect3DDevice9* device);
@@ -144,6 +150,7 @@ private:
 
 	// for markers
 	Marker marker;
+	RangeMarker rangemarker;
 	GW::Vec2f shadowstep_location;
 	DWORD recall_target = 0;
 

--- a/GWToolboxdll/Widgets/Minimap/RangeRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/RangeRenderer.cpp
@@ -239,9 +239,13 @@ void RangeRenderer::DrawTargetRange(IDirect3DDevice9* device) {
 	GW::AgentLiving* target = GW::Agents::GetTargetAsAgentLiving();
 	if (!target) return;
 	if (target == player) return;
-	if (target->GetAsAgentLiving() == nullptr) return;
 
-	float range = target->allegiance == 0x3 ? 700.0f : 1010.0f;
+	float range = 0;
+
+	if (target->allegiance == 0x3) range = 700.0f;
+	if (target->allegiance == 0x1 && target->GetIsDead()) range = 1010.0f;
+
+	if (!range) return;
 
 	D3DXMATRIX translate, scale, world;
 	D3DXMatrixTranslation(&translate, target->x, target->y, 0.0f);

--- a/GWToolboxdll/Widgets/Minimap/RangeRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/RangeRenderer.cpp
@@ -53,7 +53,7 @@ void RangeRenderer::DrawSettings() {
 	changed |= Colors::DrawSettingHueWheel("Compass range", &color_range_compass);
 	if (changed) Invalidate();
 
-	if (Colors::DrawSetting("Target Range", &targetRange.color)) {
+	if (Colors::DrawSetting("Target range", &targetRange.color)) {
 		targetRange.Invalidate();
 
 	}

--- a/GWToolboxdll/Widgets/Minimap/RangeRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/RangeRenderer.cpp
@@ -70,8 +70,8 @@ void RangeRenderer::Initialize(IDirect3DDevice9* device) {
 	checkforhos_ = true;
 	havehos_ = false;
 
-	D3DVertex* vertices = nullptr;
-	unsigned int vertex_count = count + num_circles + num_circles + 1;
+	vertices = nullptr;
+	vertex_count = count + num_circles + num_circles + 1;
 
 	device->CreateVertexBuffer(sizeof(D3DVertex) * vertex_count, D3DUSAGE_WRITEONLY,
 		D3DFVF_CUSTOMVERTEX, D3DPOOL_MANAGED, &buffer, NULL);

--- a/GWToolboxdll/Widgets/Minimap/RangeRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/RangeRenderer.cpp
@@ -17,7 +17,6 @@
 #include "GuiUtils.h"
 #include "RangeRenderer.h"
 
-
 void RangeRenderer::LoadSettings(CSimpleIni* ini, const char* section) {
 	color_range_hos = Colors::Load(ini, section, "color_range_hos", 0xFF881188);
 	color_range_aggro = Colors::Load(ini, section, "color_range_aggro", 0xFF994444);

--- a/GWToolboxdll/Widgets/Minimap/RangeRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/RangeRenderer.h
@@ -7,9 +7,11 @@
 
 class RangeRenderer : public VBuffer {
 private:
-	static const size_t num_circles = 5;
+	static const size_t num_circles = 6;
 	static const size_t circle_points = 64;
 	static const size_t circle_vertices = 65;
+	unsigned int vertex_count;
+	D3DVertex* vertices;
 
 public:
 	void Render(IDirect3DDevice9* device) override;

--- a/GWToolboxdll/Widgets/Minimap/RangeRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/RangeRenderer.h
@@ -10,8 +10,6 @@ class RangeRenderer : public VBuffer {
 		void Initialize(IDirect3DDevice9* device) override;
 	public:
 		Color color = 0;
-		float radius = 0;
-
 	};
 private:
 	static const size_t num_circles = 6;

--- a/GWToolboxdll/Widgets/Minimap/RangeRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/RangeRenderer.h
@@ -10,6 +10,8 @@ class RangeRenderer : public VBuffer {
 		void Initialize(IDirect3DDevice9* device) override;
 	public:
 		Color color = 0;
+		float radius = 0;
+
 	};
 private:
 	static const size_t num_circles = 6;
@@ -38,7 +40,8 @@ private:
 
 	bool draw_center_ = false;
 
-	TargetRange targetRange;
+	TargetRange chainAggroRange;
+	TargetRange rezzAggroRange;
 
 	Color color_range_hos = 0;
 	Color color_range_aggro = 0;

--- a/GWToolboxdll/Widgets/Minimap/RangeRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/RangeRenderer.h
@@ -6,6 +6,11 @@
 
 
 class RangeRenderer : public VBuffer {
+	class TargetRange : public VBuffer {
+		void Initialize(IDirect3DDevice9* device) override;
+	public:
+		Color color = 0;
+	};
 private:
 	static const size_t num_circles = 6;
 	static const size_t circle_points = 64;
@@ -23,6 +28,7 @@ public:
 
 private:
 	void CreateCircle(D3DVertex* vertices, float radius, DWORD color);
+	void DrawTargetRange(IDirect3DDevice9* device);
 	void Initialize(IDirect3DDevice9* device) override;
 
 	bool HaveHos();
@@ -31,6 +37,8 @@ private:
 	bool havehos_ = false;
 
 	bool draw_center_ = false;
+
+	TargetRange targetRange;
 
 	Color color_range_hos = 0;
 	Color color_range_aggro = 0;


### PR DESCRIPTION
This adds a few additional range indicators:
- Shadowstep aggro range: 1010 (aggro range) around your shadow step marker, to help with not breaking the stance into aggro
- Rezz aggro range: 1010 (aggro range) around your targeted dead ally, to help with rezzing them outside aggro
- Chain aggro range: 700 range around targeted foes, to help seeing when it is safe to be attacked