### PR TITLE
Dungeon Objective Timer

### DIFF
--- a/GWToolbox/GWToolbox/Modules/GameSettings.cpp
+++ b/GWToolbox/GWToolbox/Modules/GameSettings.cpp
@@ -781,6 +781,7 @@ void GameSettings::Initialize() {
 	GW::StoC::RegisterPacketCallback<GW::Packet::StoC::SpeechBubble>(&SpeechBubble_Entry, OnSpeechBubble);
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::DisplayDialogue>(&DisplayDialogue_Entry, OnSpeechDialogue);
 	GW::StoC::RegisterPacketCallback<GW::Packet::StoC::VanquishComplete>(&VanquishComplete_Entry, OnVanquishComplete);
+	GW::StoC::RegisterPacketCallback<GW::Packet::StoC::DungeonReward>(&VanquishComplete_Entry, OnDungeonReward);
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::MessageServer>(&MessageServer_Entry, OnServerMessage);
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::MessageNPC>(&MessageNPC_Entry,OnNPCChatMessage);
 	GW::StoC::RegisterPacketCallback<GW::Packet::StoC::MessageLocal>(&MessageLocal_Entry, OnLocalChatMessage);
@@ -949,7 +950,8 @@ void GameSettings::LoadSettings(CSimpleIni* ini) {
     notify_when_players_join_outpost = ini->GetBoolValue(Name(), VAR_NAME(notify_when_players_join_outpost), notify_when_players_join_outpost);
     notify_when_players_leave_outpost = ini->GetBoolValue(Name(), VAR_NAME(notify_when_players_leave_outpost), notify_when_players_leave_outpost);
 
-    auto_age_on_vanquish = ini->GetBoolValue(Name(), VAR_NAME(auto_age_on_vanquish), auto_age_on_vanquish);
+	auto_age_on_vanquish = ini->GetBoolValue(Name(), VAR_NAME(auto_age_on_vanquish), auto_age_on_vanquish);
+	hide_dungeon_chest_popup = ini->GetBoolValue(Name(), VAR_NAME(hide_dungeon_chest_popup), hide_dungeon_chest_popup);
 	auto_age2_on_age = ini->GetBoolValue(Name(), VAR_NAME(auto_age2_on_age), auto_age2_on_age);
 	auto_accept_invites = ini->GetBoolValue(Name(), VAR_NAME(auto_accept_invites), auto_accept_invites);
 	auto_accept_join_requests = ini->GetBoolValue(Name(), VAR_NAME(auto_accept_join_requests), auto_accept_join_requests);
@@ -1051,7 +1053,8 @@ void GameSettings::SaveSettings(CSimpleIni* ini) {
     ini->SetBoolValue(Name(), VAR_NAME(notify_when_players_join_outpost), notify_when_players_join_outpost);
     ini->SetBoolValue(Name(), VAR_NAME(notify_when_players_leave_outpost), notify_when_players_leave_outpost);
 
-    ini->SetBoolValue(Name(), VAR_NAME(auto_age_on_vanquish), auto_age_on_vanquish);
+	ini->SetBoolValue(Name(), VAR_NAME(auto_age_on_vanquish), auto_age_on_vanquish);
+	ini->SetBoolValue(Name(), VAR_NAME(hide_dungeon_chest_popup), hide_dungeon_chest_popup);
 	ini->SetBoolValue(Name(), VAR_NAME(auto_age2_on_age), auto_age2_on_age);
 	ini->SetBoolValue(Name(), VAR_NAME(auto_accept_invites), auto_accept_invites);
 	ini->SetBoolValue(Name(), VAR_NAME(auto_accept_join_requests), auto_accept_join_requests);
@@ -1222,6 +1225,7 @@ void GameSettings::DrawSettingInternal() {
 		"Disable the confirmation request when\n"
 		"selling Gold and Green items introduced\n"
 		"in February 5, 2019 update.");
+	ImGui::Checkbox("Hide dungeon chest popup", &hide_dungeon_chest_popup);
 	if (ImGui::Checkbox("Set Guild Wars window title as current logged-in character", &set_window_title_as_charname)) {
 		SetWindowTitle(set_window_title_as_charname);
 	}
@@ -1758,6 +1762,11 @@ void GameSettings::OnVanquishComplete(GW::HookStatus* status, GW::Packet::StoC::
 	if (!Instance().auto_age_on_vanquish)
 		return;
 	GW::Chat::SendChat('/', "age");
+}
+
+void GameSettings::OnDungeonReward(GW::HookStatus* status, GW::Packet::StoC::DungeonReward*) {
+	if (Instance().hide_dungeon_chest_popup)
+		status->blocked = true;
 }
 
 // Flash/focus window on trade

--- a/GWToolbox/GWToolbox/Modules/GameSettings.h
+++ b/GWToolbox/GWToolbox/Modules/GameSettings.h
@@ -170,6 +170,7 @@ public:
 	static void OnFactionDonate(GW::HookStatus*, uint32_t dialog_id);
 	static void OnPartyDefeated(GW::HookStatus*, GW::Packet::StoC::PartyDefeated*);
 	static void OnVanquishComplete(GW::HookStatus*, GW::Packet::StoC::VanquishComplete*);
+	static void OnDungeonReward(GW::HookStatus*, GW::Packet::StoC::DungeonReward*);
 	static void OnMapLoaded(GW::HookStatus*, GW::Packet::StoC::MapLoaded*);
 	static void OnCinematic(GW::HookStatus*, GW::Packet::StoC::CinematicPlay*);
 	static void OnMapTravel(GW::HookStatus*, GW::Packet::StoC::GameSrvTransfer*);
@@ -263,6 +264,7 @@ private:
     bool redirect_npc_messages_to_emote_chat = false;
 	bool auto_age2_on_age = true;
 	bool auto_age_on_vanquish = false;
+	bool hide_dungeon_chest_popup = false;
 	bool skip_entering_name_for_faction_donate = false;
 
 	void DrawChannelColor(const char *name, GW::Chat::Channel chan);

--- a/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.cpp
+++ b/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.cpp
@@ -85,6 +85,59 @@ namespace {
 		L"\x533C\xDD33\xA330\x4E27", // Room 14 "I will fill your hearts with visions of horror and despair that will haunt you for all of your days."
 		L"\x533D\x9EB1\x8BEE\x2637"	 // Kanaxai "What gives you the right to enter my lair? I shall kill you for your audacity, after I destroy your mind with my horrifying visions, of course."
 	};
+
+    const std::map<GW::Constants::MapID, uint32_t> dungeonLevels = {
+        {GW::Constants::MapID::Catacombs_of_Kathandrax_Level_1, 1},
+        {GW::Constants::MapID::Catacombs_of_Kathandrax_Level_2, 2},
+        {GW::Constants::MapID::Catacombs_of_Kathandrax_Level_3, 3},
+        {GW::Constants::MapID::Rragars_Menagerie_Level_1, 1},
+        {GW::Constants::MapID::Rragars_Menagerie_Level_2, 2},
+        {GW::Constants::MapID::Rragars_Menagerie_Level_3, 3},
+        {GW::Constants::MapID::Cathedral_of_Flames_Level_1, 1},
+        {GW::Constants::MapID::Cathedral_of_Flames_Level_2, 2},
+        {GW::Constants::MapID::Cathedral_of_Flames_Level_3, 3},
+        {GW::Constants::MapID::Ooze_Pit, 1},
+        {GW::Constants::MapID::Darkrime_Delves_Level_1, 1},
+        {GW::Constants::MapID::Darkrime_Delves_Level_2, 2},
+        {GW::Constants::MapID::Darkrime_Delves_Level_3, 3},
+        {GW::Constants::MapID::Frostmaws_Burrows_Level_1, 1},
+        {GW::Constants::MapID::Frostmaws_Burrows_Level_2, 2},
+        {GW::Constants::MapID::Frostmaws_Burrows_Level_3, 3},
+        {GW::Constants::MapID::Frostmaws_Burrows_Level_4, 4},
+        {GW::Constants::MapID::Frostmaws_Burrows_Level_5, 5},
+        {GW::Constants::MapID::Sepulchre_of_Dragrimmar_Level_1, 1},
+        {GW::Constants::MapID::Sepulchre_of_Dragrimmar_Level_2, 2},
+        {GW::Constants::MapID::Ravens_Point_Level_1, 1},
+        {GW::Constants::MapID::Ravens_Point_Level_2, 2},
+        {GW::Constants::MapID::Ravens_Point_Level_3, 3},
+        {GW::Constants::MapID::Vloxen_Excavations_Level_1, 1},
+        {GW::Constants::MapID::Vloxen_Excavations_Level_2, 2},
+        {GW::Constants::MapID::Vloxen_Excavations_Level_3, 3},
+        {GW::Constants::MapID::Bogroot_Growths_Level_1, 1},
+        {GW::Constants::MapID::Bogroot_Growths_Level_2, 2},
+        {GW::Constants::MapID::Bloodstone_Caves_Level_1, 1},
+        {GW::Constants::MapID::Bloodstone_Caves_Level_2, 2},
+        {GW::Constants::MapID::Bloodstone_Caves_Level_3, 3},
+        {GW::Constants::MapID::Shards_of_Orr_Level_1, 1},
+        {GW::Constants::MapID::Shards_of_Orr_Level_2, 2},
+        {GW::Constants::MapID::Shards_of_Orr_Level_3, 3},
+        {GW::Constants::MapID::Oolas_Lab_Level_1, 1},
+        {GW::Constants::MapID::Oolas_Lab_Level_2, 2},
+        {GW::Constants::MapID::Oolas_Lab_Level_3, 3},
+        {GW::Constants::MapID::Arachnis_Haunt_Level_1, 1},
+        {GW::Constants::MapID::Arachnis_Haunt_Level_2, 2},
+        {GW::Constants::MapID::Slavers_Exile_Level_1, 1},
+        {GW::Constants::MapID::Slavers_Exile_Level_2, 2},
+        {GW::Constants::MapID::Slavers_Exile_Level_3, 3},
+        {GW::Constants::MapID::Slavers_Exile_Level_4, 4},
+        {GW::Constants::MapID::Slavers_Exile_Level_5, 5},
+        {GW::Constants::MapID::Fronis_Irontoes_Lair_mission, 1},
+        {GW::Constants::MapID::Secret_Lair_of_the_Snowmen, 1},
+        {GW::Constants::MapID::Heart_of_the_Shiverpeaks_Level_1, 1},
+        {GW::Constants::MapID::Heart_of_the_Shiverpeaks_Level_2, 2},
+        {GW::Constants::MapID::Heart_of_the_Shiverpeaks_Level_3, 3},
+    };
+
     void PrintTime(char* buf, size_t size, DWORD time, bool show_ms = true) {
         if (time == TIME_UNKNOWN) {
             GuiUtils::StrCopy(buf, "--:--", size);
@@ -454,92 +507,40 @@ void ObjectiveTimerWindow::AddFoWObjectiveSet() {
 }
 
 void ObjectiveTimerWindow::HandleMapChange(GW::Constants::MapID map_id, bool start) {
-    uint32_t objective_id = 0;
-
     switch (map_id) {
         case GW::Constants::MapID::Urgozs_Warren:
             if (start) AddUrgozObjectiveSet();
-            break;
+            return;
         case GW::Constants::MapID::The_Deep:
             if (start) AddDeepObjectiveSet();
-            break;
+            return;
         case GW::Constants::MapID::The_Fissure_of_Woe:
             if (start) AddFoWObjectiveSet();
-            break;
+            return;
         case GW::Constants::MapID::The_Underworld:
             if (start) AddUWObjectiveSet();
-            break;
-        case GW::Constants::MapID::Catacombs_of_Kathandrax_Level_1:
-        case GW::Constants::MapID::Rragars_Menagerie_Level_1:
-        case GW::Constants::MapID::Cathedral_of_Flames_Level_1:
-        case GW::Constants::MapID::Ooze_Pit:
-        case GW::Constants::MapID::Darkrime_Delves_Level_1:
-        case GW::Constants::MapID::Frostmaws_Burrows_Level_1:
-        case GW::Constants::MapID::Sepulchre_of_Dragrimmar_Level_1:
-        case GW::Constants::MapID::Ravens_Point_Level_1:
-        case GW::Constants::MapID::Vloxen_Excavations_Level_1:
-        case GW::Constants::MapID::Bogroot_Growths_Level_1:
-        case GW::Constants::MapID::Bloodstone_Caves_Level_1:
-        case GW::Constants::MapID::Shards_of_Orr_Level_1:
-        case GW::Constants::MapID::Oolas_Lab_Level_1:
-        case GW::Constants::MapID::Arachnis_Haunt_Level_1:
-        case GW::Constants::MapID::Slavers_Exile_Level_5:
-        case GW::Constants::MapID::Fronis_Irontoes_Lair_mission:
-        case GW::Constants::MapID::Secret_Lair_of_the_Snowmen:
-        case GW::Constants::MapID::Heart_of_the_Shiverpeaks_Level_1:
-            if (start) AddDungeonObjectiveSet(map_id);
-            break;
-        case GW::Constants::MapID::Catacombs_of_Kathandrax_Level_2:
-        case GW::Constants::MapID::Rragars_Menagerie_Level_2:
-        case GW::Constants::MapID::Cathedral_of_Flames_Level_2:
-        case GW::Constants::MapID::Darkrime_Delves_Level_2:
-        case GW::Constants::MapID::Frostmaws_Burrows_Level_2:
-        case GW::Constants::MapID::Sepulchre_of_Dragrimmar_Level_2:
-        case GW::Constants::MapID::Ravens_Point_Level_2:
-        case GW::Constants::MapID::Vloxen_Excavations_Level_2:
-        case GW::Constants::MapID::Bogroot_Growths_Level_2:
-        case GW::Constants::MapID::Shards_of_Orr_Level_2:
-        case GW::Constants::MapID::Oolas_Lab_Level_2:
-        case GW::Constants::MapID::Arachnis_Haunt_Level_2:
-        case GW::Constants::MapID::Heart_of_the_Shiverpeaks_Level_2:
-            objective_id = start ? 2 : 1;
-            break;
-        case GW::Constants::MapID::Catacombs_of_Kathandrax_Level_3:
-        case GW::Constants::MapID::Rragars_Menagerie_Level_3:
-        case GW::Constants::MapID::Cathedral_of_Flames_Level_3:
-        case GW::Constants::MapID::Darkrime_Delves_Level_3:
-        case GW::Constants::MapID::Frostmaws_Burrows_Level_3:
-        case GW::Constants::MapID::Ravens_Point_Level_3:
-        case GW::Constants::MapID::Vloxen_Excavations_Level_3:
-        case GW::Constants::MapID::Bloodstone_Caves_Level_3:
-        case GW::Constants::MapID::Shards_of_Orr_Level_3:
-        case GW::Constants::MapID::Oolas_Lab_Level_3:
-        case GW::Constants::MapID::Heart_of_the_Shiverpeaks_Level_3:
-            objective_id = start ? 3 : 2;
-            break;
-        case GW::Constants::MapID::Frostmaws_Burrows_Level_4:
-            objective_id = start ? 4 : 3;
-            break;
-        case GW::Constants::MapID::Frostmaws_Burrows_Level_5:
-            objective_id = start ? 5 : 4;
-            break;
+            return;
         default:
-            if (start) break;
-            if (current_objective_set) {
-                current_objective_set->StopObjectives();
+            auto dungeonLevel = dungeonLevels.find(map_id);
+            if (dungeonLevel == dungeonLevels.end()) {
+                if (current_objective_set) {
+                    current_objective_set->StopObjectives();
+                }
+                current_objective_set = nullptr;
+                return;
+            };
+            if (start && !current_objective_set) {
+                AddDungeonObjectiveSet(map_id);
+                return;
             }
-            current_objective_set = nullptr;
-    }
-
-    if (objective_id) {
-        Objective* obj = GetCurrentObjective(objective_id);
-        if (obj) {
-            if (start) {
-                if (!obj->IsStarted()) obj->SetStarted();
-            } else {
-                obj->SetDone();
+            Objective* obj = GetCurrentObjective(start ? dungeonLevel->second : dungeonLevel->second - 1);
+            if (obj) {
+                if (start) {
+                    if (!obj->IsStarted()) obj->SetStarted();
+                } else {
+                    obj->SetDone();
+                }
             }
-        }
     }
 }
 

--- a/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.cpp
+++ b/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.cpp
@@ -570,7 +570,9 @@ void ObjectiveTimerWindow::AddDungeonObjectiveSet(GW::Constants::MapID map_id) {
         case GW::Constants::MapID::Secret_Lair_of_the_Snowmen:
             os->objectives.emplace(os->objectives.begin(), 1, "Level 1");
             break;
-        case GW::Constants::MapID::Slavers_Exile_Level_1: // figure out how to time this
+        case GW::Constants::MapID::Slavers_Exile_Level_5:
+            // figure out how to do the other levels
+            os->objectives.emplace_back(5, "Duncan");
             break;
     }
 

--- a/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.cpp
+++ b/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.cpp
@@ -213,6 +213,7 @@ void ObjectiveTimerWindow::Initialize() {
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::DungeonReward>(&DungeonReward_Entry,
     [this](GW::HookStatus* status, GW::Packet::StoC::DungeonReward* packet) -> void {
         ObjectiveTimerWindow::ObjectiveSet* os = GetCurrentObjectiveSet();
+        if (!os) return;
         os->objectives.back().SetDone();
         os->CheckSetDone();
     });

--- a/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.cpp
+++ b/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.cpp
@@ -483,7 +483,7 @@ void ObjectiveTimerWindow::HandleMapChange(GW::Constants::MapID map_id, bool sta
         case GW::Constants::MapID::Shards_of_Orr_Level_1:
         case GW::Constants::MapID::Oolas_Lab_Level_1:
         case GW::Constants::MapID::Arachnis_Haunt_Level_1:
-        case GW::Constants::MapID::Slavers_Exile_Level_1:
+        case GW::Constants::MapID::Slavers_Exile_Level_5:
         case GW::Constants::MapID::Fronis_Irontoes_Lair_mission:
         case GW::Constants::MapID::Secret_Lair_of_the_Snowmen:
         case GW::Constants::MapID::Heart_of_the_Shiverpeaks_Level_1:
@@ -576,11 +576,14 @@ void ObjectiveTimerWindow::AddDungeonObjectiveSet(GW::Constants::MapID map_id) {
             break;
     }
 
-    if (!os->objectives.empty()) {
-        ::AsyncGetMapName(os->name, sizeof(os->name));
-        os->objectives.front().SetStarted();
-        AddObjectiveSet(os);
+    if (os->objectives.empty()) {
+        delete os;
+        return;
     }
+
+    ::AsyncGetMapName(os->name, sizeof(os->name));
+    os->objectives.front().SetStarted();
+    AddObjectiveSet(os);
 }
 
 void ObjectiveTimerWindow::AddObjectiveSet(ObjectiveSet* os) {

--- a/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.cpp
+++ b/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.cpp
@@ -458,16 +458,16 @@ void ObjectiveTimerWindow::HandleMapChange(GW::Constants::MapID map_id, bool sta
 
     switch (map_id) {
         case GW::Constants::MapID::Urgozs_Warren:
-            AddUrgozObjectiveSet();
+            if (start) AddUrgozObjectiveSet();
             break;
         case GW::Constants::MapID::The_Deep:
-            AddDeepObjectiveSet();
+            if (start) AddDeepObjectiveSet();
             break;
         case GW::Constants::MapID::The_Fissure_of_Woe:
-            AddFoWObjectiveSet();
+            if (start) AddFoWObjectiveSet();
             break;
         case GW::Constants::MapID::The_Underworld:
-            AddUWObjectiveSet();
+            if (start) AddUWObjectiveSet();
             break;
         case GW::Constants::MapID::Catacombs_of_Kathandrax_Level_1:
         case GW::Constants::MapID::Rragars_Menagerie_Level_1:
@@ -487,7 +487,7 @@ void ObjectiveTimerWindow::HandleMapChange(GW::Constants::MapID map_id, bool sta
         case GW::Constants::MapID::Fronis_Irontoes_Lair_mission:
         case GW::Constants::MapID::Secret_Lair_of_the_Snowmen:
         case GW::Constants::MapID::Heart_of_the_Shiverpeaks_Level_1:
-            AddDungeonObjectiveSet(map_id);
+            if (start) AddDungeonObjectiveSet(map_id);
             break;
         case GW::Constants::MapID::Catacombs_of_Kathandrax_Level_2:
         case GW::Constants::MapID::Rragars_Menagerie_Level_2:

--- a/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.cpp
+++ b/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.cpp
@@ -522,12 +522,11 @@ void ObjectiveTimerWindow::HandleMapChange(GW::Constants::MapID map_id, bool sta
             return;
         default:
             auto dungeonLevel = dungeonLevels.find(map_id);
-            if (dungeonLevel == dungeonLevels.end()) {
+            if (dungeonLevel == dungeonLevels.end() || dungeonLevel->second == 1) {
                 if (current_objective_set) {
                     current_objective_set->StopObjectives();
                 }
                 current_objective_set = nullptr;
-                return;
             };
             if (start && !current_objective_set) {
                 AddDungeonObjectiveSet(map_id);

--- a/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.h
+++ b/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.h
@@ -2,6 +2,7 @@
 
 #include <Defines.h>
 
+#include <GWCA\Constants\Maps.h>
 #include <GWCA\Utilities\Hook.h>
 #include <GWCA\GameContainers\GamePos.h>
 #include <GWCA\Packets\StoC.h>
@@ -129,7 +130,10 @@ private:
     void AddDoAObjectiveSet(GW::Vec2f spawn);
     void AddFoWObjectiveSet();
     void AddUWObjectiveSet();
+    void AddDungeonObjectiveSet(GW::Constants::MapID map_id);
+    bool UpdateDungeonObjectiveSet(GW::Constants::MapID map_id);
     void AddObjectiveSet(ObjectiveSet* os);
+    void HandleMapChange(GW::Constants::MapID map_id, bool start);
 	void DoorOpened(uint32_t door_id);
 	void DoorClosed(uint32_t door_id);
 	void DisplayDialogue(GW::Packet::StoC::DisplayDialogue* packet);
@@ -150,4 +154,5 @@ private:
 	GW::HookEntry MessageServer_Entry;
 	GW::HookEntry InstanceLoadInfo_Entry;
 	GW::HookEntry ManipulateMapObject_Entry;
+    GW::HookEntry DungeonReward_Entry;
 };

--- a/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.h
+++ b/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.h
@@ -130,7 +130,8 @@ private:
     void AddDoAObjectiveSet(GW::Vec2f spawn);
     void AddFoWObjectiveSet();
     void AddUWObjectiveSet();
-    void AddDungeonObjectiveSet(GW::Constants::MapID map_id);
+    void AddSlaversObjectiveSet();
+    void AddDungeonObjectiveSet(int levels);
     void AddObjectiveSet(ObjectiveSet* os);
     void HandleMapChange(GW::Constants::MapID map_id, bool start);
 	void DoorOpened(uint32_t door_id);

--- a/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.h
+++ b/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.h
@@ -112,6 +112,8 @@ private:
         // todo: print to file
 		// an internal id to ensure interface consistency
 		const unsigned int ui_id = 0;
+
+        bool single_instance = true;
     private:
 
         static unsigned int cur_ui_id;

--- a/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.h
+++ b/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.h
@@ -131,7 +131,6 @@ private:
     void AddFoWObjectiveSet();
     void AddUWObjectiveSet();
     void AddDungeonObjectiveSet(GW::Constants::MapID map_id);
-    bool UpdateDungeonObjectiveSet(GW::Constants::MapID map_id);
     void AddObjectiveSet(ObjectiveSet* os);
     void HandleMapChange(GW::Constants::MapID map_id, bool start);
 	void DoorOpened(uint32_t door_id);

--- a/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.h
+++ b/GWToolbox/GWToolbox/Windows/ObjectiveTimerWindow.h
@@ -141,6 +141,7 @@ private:
 	void DisplayDialogue(GW::Packet::StoC::DisplayDialogue* packet);
     void AddDeepObjectiveSet();
     void AddUrgozObjectiveSet();
+    void AddToPKObjectiveSet();
     void ClearObjectiveSets();
     
 
@@ -157,4 +158,5 @@ private:
 	GW::HookEntry InstanceLoadInfo_Entry;
 	GW::HookEntry ManipulateMapObject_Entry;
     GW::HookEntry DungeonReward_Entry;
+    GW::HookEntry CountdownStart_Enty;
 };


### PR DESCRIPTION
- [x] ~option to hide dungeon chest popup (#406)~ already merged
- [x] add dungeons to the objective timer (#221)
- [x] ~Figure out how to handle Slavers (currently only includes Duncan)~ (See [here](https://github.com/HasKha/GWToolboxpp/pull/414#issuecomment-625772413))
- [x] ~Include the dungeon name when pinging levels? Not sure how useful that is as you'll only ping them when talking about that dungeon anyways.~ (See [here](https://github.com/HasKha/GWToolboxpp/pull/414#issuecomment-625772413))
- [x] Show the sum of all levels in the header