### PR TITLE
Configurable modifiers for minimap clicks.

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -793,8 +793,8 @@ void Minimap::RenderSetupProjection(IDirect3DDevice9* device) {
 }
 
 bool Minimap::IsKeyDown(MinimapModifierBehaviour mmb) {
-    return key_none_behavior  == mmb or
-          (key_ctrl_behavior  == mmb and ImGui::IsKeyDown(VK_CONTROL)) or
-          (key_shift_behavior == mmb and ImGui::IsKeyDown(VK_SHIFT)) or
-          (key_alt_behavior   == mmb and ImGui::IsKeyDown(VK_MENU));
+    return (key_none_behavior  == mmb and not ImGui::IsKeyDown(VK_CONTROL) and not ImGui::IsKeyDown(VK_SHIFT) and not ImGui::IsKeyDown(VK_MENU)) or
+           (key_ctrl_behavior  == mmb and ImGui::IsKeyDown(VK_CONTROL)) or
+           (key_shift_behavior == mmb and ImGui::IsKeyDown(VK_SHIFT)) or
+           (key_alt_behavior   == mmb and ImGui::IsKeyDown(VK_MENU));
 }

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -175,6 +175,8 @@ void Minimap::Initialize() {
 }
 
 void Minimap::DrawSettingInternal() {
+    static char const *minimap_modifier_behavior_combo_str = "Disabled\0Draw\0Target\0Move\0Walk\0\0";
+
     ImGui::Text("General");
     ImGui::DragFloat("Scale", &scale, 0.01f, 0.1f);
     ImGui::Text("You can set the color alpha to 0 to disable any minimap feature.");

--- a/GWToolboxdll/Widgets/Minimap/Minimap.h
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.h
@@ -86,7 +86,7 @@ private:
     GW::Vec2f InterfaceToWorldPoint(Vec2i pos) const;
     GW::Vec2f InterfaceToWorldVector(Vec2i pos) const;
     void SelectTarget(GW::Vec2f pos);
-    bool Minimap::IsKeyDown(MinimapModifierBehaviour mmb);
+    bool IsKeyDown(MinimapModifierBehaviour mmb);
 
     bool mousedown = false;
 

--- a/GWToolboxdll/Widgets/Minimap/Minimap.h
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.h
@@ -78,6 +78,7 @@ private:
     GW::Vec2f InterfaceToWorldPoint(Vec2i pos) const;
     GW::Vec2f InterfaceToWorldVector(Vec2i pos) const;
     void SelectTarget(GW::Vec2f pos);
+    bool IsKeyDown(int key);
 
     bool mousedown = false;
 
@@ -96,7 +97,10 @@ private:
     bool mouse_clickthrough = false;
     bool mouse_clickthrough_in_outpost = false;
     bool rotate_minimap = true;
-    bool alt_click_to_move = false;
+    int key_draw_selected = 1;
+    int key_target_selected = 2;
+    int key_move_selected = 3;
+    int key_walk_selected = 4;
     bool is_observing = false;
 
     bool hero_flag_controls_show = false;

--- a/GWToolboxdll/Widgets/Minimap/Minimap.h
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.h
@@ -29,6 +29,14 @@ public:
         return instance;
     }
 
+    enum class MinimapModifierBehaviour : int {
+        Disabled,
+        Draw,
+        Target,
+        Move,
+        Walk
+    };
+
     const int ms_before_back = 1000; // time before we snap back to player
     const float acceleration = 0.5f;
     const float max_speed = 15.0f; // game units per frame
@@ -78,7 +86,7 @@ private:
     GW::Vec2f InterfaceToWorldPoint(Vec2i pos) const;
     GW::Vec2f InterfaceToWorldVector(Vec2i pos) const;
     void SelectTarget(GW::Vec2f pos);
-    bool IsKeyDown(int key);
+    bool Minimap::IsKeyDown(MinimapModifierBehaviour mmb);
 
     bool mousedown = false;
 
@@ -97,10 +105,10 @@ private:
     bool mouse_clickthrough = false;
     bool mouse_clickthrough_in_outpost = false;
     bool rotate_minimap = true;
-    int key_draw_selected = 1;
-    int key_target_selected = 2;
-    int key_move_selected = 3;
-    int key_walk_selected = 4;
+    MinimapModifierBehaviour key_none_behavior  = MinimapModifierBehaviour::Draw;
+    MinimapModifierBehaviour key_ctrl_behavior  = MinimapModifierBehaviour::Target;
+    MinimapModifierBehaviour key_shift_behavior = MinimapModifierBehaviour::Move;
+    MinimapModifierBehaviour key_alt_behavior   = MinimapModifierBehaviour::Walk;
     bool is_observing = false;
 
     bool hero_flag_controls_show = false;


### PR DESCRIPTION
- [x] flagging heroes is mixed in the modifier logic: if "Target" or "Walk" is set to "None", the "Draw" modifier must be pressed
- [x] "Disable" does not work as expected

Made the modifier clicks configurable through a dropdown menu under minimap. 

![afbeelding](https://user-images.githubusercontent.com/61383644/82753993-5b5d0980-9dca-11ea-95d6-11de2b9cbdd5.png)

The defaults are set to what is currently the default, ie. none=draw, control=target, shift=move map, alt=walk. I left the logic untouched, so if the defaults are also untouched, the behavior is the same as it is now. Setting target to None and move to Shift requires to let go of Shift to target. Setting target to Control and move to Shift works with Control + Shift as before.

Removed alt_click_to_move boolean.