### PR TITLE
Added buffer flushing for log entries

### DIFF
--- a/GWToolboxdll/Logger.cpp
+++ b/GWToolboxdll/Logger.cpp
@@ -117,6 +117,7 @@ void Log::Log(const char* msg, ...) {
     va_start(args, msg);
     vfprintf(logfile, msg, args);
     va_end(args);
+    fflush(logfile);
 }
 
 void Log::LogW(const wchar_t* msg, ...) {
@@ -127,6 +128,7 @@ void Log::LogW(const wchar_t* msg, ...) {
     va_start(args, msg);
     vfwprintf(logfile, msg, args);
     va_end(args);
+    fflush(logfile);
 }
 
 // === Game chat logging ===


### PR DESCRIPTION
Added buffer flushing after every entry written to the log file to ensure that information related to unexpected crashes is saved to disk.

While looking into issues after a crash, I found that the log was incomplete due to it only being flushed when the file was closed on a clean termination. This almost guarantees that the log file will be incomplete on an abnormal shutdown due to a crash or assertion.
