### PR TITLE
Hotkey on toolkit start

### DIFF
--- a/GWToolboxdll/GWToolboxdll.vcxproj
+++ b/GWToolboxdll/GWToolboxdll.vcxproj
@@ -44,7 +44,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>false</LinkIncremental>
+    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -56,7 +56,7 @@ namespace {
 
     static bool IsMapReady()
     {
-        return GW::Map::GetInstanceType() != GW::Constants::InstanceType::Loading && !GW::Map::GetIsObserving()  && GW::MemoryMgr::GetGWWindowHandle() == GetActiveWindow();
+        return GW::Map::GetInstanceType() != GW::Constants::InstanceType::Loading && !GW::Map::GetIsObserving();
     }
 
     static void TargetNearest(uint32_t model_id = 0, uint32_t type = 0xDB)

--- a/GWToolboxdll/Modules/GameSettings.h
+++ b/GWToolboxdll/Modules/GameSettings.h
@@ -200,7 +200,7 @@ public:
     bool flash_window_on_party_invite = false;
     bool flash_window_on_zoning = false;
     bool focus_window_on_zoning = false;
-    bool flash_window_on_cinematic = true;
+    bool flash_window_on_cinematic = false;
     bool flash_window_on_trade = true;
     bool focus_window_on_trade = false;
     bool flash_window_on_name_ping = true;

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -30,7 +30,7 @@ namespace {
     };
     static bool IsMapReady()
     {
-        return GW::Map::GetInstanceType() != GW::Constants::InstanceType::Loading && !GW::Map::GetIsObserving() && GW::MemoryMgr::GetGWWindowHandle() == GetActiveWindow();
+        return GW::Map::GetInstanceType() != GW::Constants::InstanceType::Loading && !GW::Map::GetIsObserving();
     }
 } // namespace
 InventoryManager::InventoryManager()

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -177,7 +177,12 @@ void InventoryManager::IdentifyAll(IdentifyAllType type) {
         CancelIdentify();
         return;
     }
+
     Item *kit = context_item.item();
+
+    if (!kit)
+        kit = GetIdentificationKit();
+
     if (!kit || !kit->IsIdentificationKit()) {
         CancelIdentify();
         Log::Warning("The identification kit was consumed");

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -68,7 +68,8 @@ void InventoryManager::CmdSalvage(const wchar_t *message, int argc, LPWSTR *argv
     im->CancelSalvage();
     const wchar_t *arg2 = argc > 1 ? argv[1] : L"";
     if (wcscmp(arg2, L"white") == 0) {
-        im->SalvageAll(SalvageAllType::White, true);
+        //im->SalvageAll(SalvageAllType::White, true);
+        Log::Warning("/salvage white");
     } else if (wcscmp(arg2, L"blue") == 0) {
         im->SalvageAll(SalvageAllType::BlueAndLower, true);
     } else if (wcscmp(arg2, L"purple") == 0) {

--- a/GWToolboxdll/Modules/InventoryManager.h
+++ b/GWToolboxdll/Modules/InventoryManager.h
@@ -46,7 +46,7 @@ public:
     void Draw(IDirect3DDevice9* device) override;
 
     void IdentifyAll(IdentifyAllType type);
-    void SalvageAll(SalvageAllType type);
+    void SalvageAll(SalvageAllType type, bool noConfirmationPopup = false);
     bool IsPendingIdentify();
     bool IsPendingSalvage();
     bool HasSettings() { return true; };
@@ -55,6 +55,9 @@ public:
     void DrawSettingInternal() override;
     void LoadSettings(CSimpleIni* ini) override;
     void SaveSettings(CSimpleIni* ini) override;
+
+    static void CmdIdentify(const wchar_t *message, int argc, LPWSTR *argv);
+    static void CmdSalvage(const wchar_t *message, int argc, LPWSTR *argv);
 
     // Find an empty (or partially empty) inventory slot that this item can go into
     std::pair<GW::Bag*, uint32_t> GetAvailableInventorySlot(GW::Item* like_item = nullptr);
@@ -148,7 +151,11 @@ public:
             return interaction & 0x20000;
         }
     };
+
 public:
+    Item*GetSalvageKit(bool only_superior_kits = false);
+    Item* GetIdentificationKit();
+    GW::Item* GetSameItem(GW::Item *like_item, GW::Bag *bag);
     Item* GetNextUnsalvagedItem(Item* salvage_kit = nullptr, Item* start_after_item = nullptr);
     Item* GetNextUnidentifiedItem(Item* start_after_item = nullptr);
     void Identify(Item* item, Item* kit);

--- a/GWToolboxdll/Windows/Hotkeys.cpp
+++ b/GWToolboxdll/Windows/Hotkeys.cpp
@@ -99,7 +99,7 @@ TBHotkey::TBHotkey(CSimpleIni *ini, const char *section)
 }
 bool TBHotkey::CanUse()
 {
-    return !isLoading() && !GW::Map::GetIsObserving() && GW::MemoryMgr::GetGWWindowHandle() == GetActiveWindow();
+    return !isLoading() && !GW::Map::GetIsObserving();
 }
 void TBHotkey::Save(CSimpleIni *ini, const char *section) const
 {

--- a/GWToolboxdll/Windows/Hotkeys.cpp
+++ b/GWToolboxdll/Windows/Hotkeys.cpp
@@ -203,7 +203,7 @@ void TBHotkey::Draw(Op *op)
         if (ImGui::Checkbox("Trigger hotkey when entering outpost",
                             &trigger_on_outpost))
             hotkeys_changed = true;
-        if (ImGui::Checkbox("Trigger hotkey when Toolbox starts",
+        if (ImGui::Checkbox("Trigger hotkey when Toolbox starts or settings are reloaded",
                             &trigger_on_toolbox_start))
             hotkeys_changed = true;
         if (ImGui::InputInt("Map ID", &map_id))

--- a/GWToolboxdll/Windows/Hotkeys.h
+++ b/GWToolboxdll/Windows/Hotkeys.h
@@ -35,7 +35,7 @@ public:
     bool block_gw = false; // true to consume the keypress before passing to gw.
     bool trigger_on_explorable = false; // Trigger when entering explorable area
     bool trigger_on_outpost = false; // Trigger when entering outpost area
-    bool trigger_on_toolbox_start = false; // Trigger once when toolbox starts
+    bool trigger_on_toolbox_start = false; // Trigger when toolbox starts or settings are loaded
 
     int map_id = 0;
     int prof_id = 0;

--- a/GWToolboxdll/Windows/HotkeysWindow.cpp
+++ b/GWToolboxdll/Windows/HotkeysWindow.cpp
@@ -186,8 +186,6 @@ bool HotkeysWindow::WndProc(UINT Message, WPARAM wParam, LPARAM lParam) {
     UNREFERENCED_PARAMETER(lParam);
     if (GW::Chat::GetIsTyping())
         return false;
-    if (GW::MemoryMgr::GetGWWindowHandle() != GetActiveWindow())
-        return false;
     long keyData = 0;
     switch (Message) {
     case WM_KEYDOWN:

--- a/GWToolboxdll/Windows/HotkeysWindow.cpp
+++ b/GWToolboxdll/Windows/HotkeysWindow.cpp
@@ -22,18 +22,6 @@ void HotkeysWindow::Initialize() {
     Resources::Instance().LoadTextureAsync(&button_texture, Resources::GetPath(L"img/icons", L"keyboard.png"), IDB_Icon_Keyboard);
     clickerTimer = TIMER_INIT();
     dropCoinsTimer = TIMER_INIT();
-
- //   Log::Info("HotkeysWindow::Initialize");
-
-	//for (TBHotkey* hk : hotkeys) {
-	//	if (!block_hotkeys && hk->active && hk->trigger_on_toolbox_start && !hk->pressed) {
-	//		hk->pressed = true;
-	//		current_hotkey = hk;
-	//		hk->Execute();
-	//		current_hotkey = nullptr;
-	//		hk->pressed = false;
-	//	}
-	//}
 }
 void HotkeysWindow::Terminate() {
     ToolboxWindow::Terminate();
@@ -167,6 +155,16 @@ void HotkeysWindow::LoadSettings(CSimpleIni* ini) {
         TBHotkey* hk = TBHotkey::HotkeyFactory(ini, entry.pItem);
         if (hk) hotkeys.push_back(hk);
     }
+    
+	for (TBHotkey* hk : hotkeys) {
+		if (!block_hotkeys && hk->active && hk->trigger_on_toolbox_start && !hk->pressed) {
+			hk->pressed = true;
+			current_hotkey = hk;
+			hk->Execute();
+			current_hotkey = nullptr;
+			hk->pressed = false;
+		}
+	}
 
     TBHotkey::hotkeys_changed = false;
 }

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,6 +6,6 @@ show_downloads: true
 google_analytics: UA-75239620-2
 theme: jekyll-theme-midnight
 
-download_url: https://github.com/HasKha/GWToolboxpp/releases/download/3.6_Release/GWToolbox.exe
+download_url: https://github.com/HasKha/GWToolboxpp/releases/download/3.8.1_Release/GWToolbox.exe
 discord_url: https://discord.gg/pGS5pFn
 toolbox_version: "3.8.1"


### PR DESCRIPTION
Adds a hotkey option to trigger when toolbox starts or settings are loaded.

This is something I added for debugging purposes but I feel might be useful as a general feature. When adding new commands, it's convenient to have those commands execute at startup.
