### PR TITLE
Hotkey on toolkit start

### DIFF
--- a/GWToolboxdll/Windows/Hotkeys.cpp
+++ b/GWToolboxdll/Windows/Hotkeys.cpp
@@ -95,6 +95,9 @@ TBHotkey::TBHotkey(CSimpleIni *ini, const char *section)
             section, VAR_NAME(trigger_on_explorable), trigger_on_explorable);
         trigger_on_outpost = ini->GetBoolValue(
             section, VAR_NAME(trigger_on_outpost), trigger_on_outpost);
+        trigger_on_toolbox_start = ini->GetBoolValue(
+            section, VAR_NAME(trigger_on_toolbox_start), trigger_on_toolbox_start);
+        
     }
 }
 bool TBHotkey::CanUse()
@@ -117,6 +120,8 @@ void TBHotkey::Save(CSimpleIni *ini, const char *section) const
                       trigger_on_explorable);
     ini->SetBoolValue(section, VAR_NAME(trigger_on_outpost),
                       trigger_on_outpost);
+    ini->SetBoolValue(section, VAR_NAME(trigger_on_toolbox_start),
+                      trigger_on_toolbox_start);
 }
 static const char *professions[] = {"Any",          "Warrior",     "Ranger",
                                     "Monk",         "Necromancer", "Mesmer",
@@ -197,6 +202,9 @@ void TBHotkey::Draw(Op *op)
             hotkeys_changed = true;
         if (ImGui::Checkbox("Trigger hotkey when entering outpost",
                             &trigger_on_outpost))
+            hotkeys_changed = true;
+        if (ImGui::Checkbox("Trigger hotkey when Toolbox starts or settings are reloaded",
+                            &trigger_on_toolbox_start))
             hotkeys_changed = true;
         if (ImGui::InputInt("Map ID", &map_id))
             hotkeys_changed = true;

--- a/GWToolboxdll/Windows/Hotkeys.h
+++ b/GWToolboxdll/Windows/Hotkeys.h
@@ -35,6 +35,7 @@ public:
     bool block_gw = false; // true to consume the keypress before passing to gw.
     bool trigger_on_explorable = false; // Trigger when entering explorable area
     bool trigger_on_outpost = false; // Trigger when entering outpost area
+    bool trigger_on_toolbox_start = false; // Trigger when toolbox starts or settings are loaded
 
     int map_id = 0;
     int prof_id = 0;

--- a/GWToolboxdll/Windows/HotkeysWindow.cpp
+++ b/GWToolboxdll/Windows/HotkeysWindow.cpp
@@ -155,6 +155,16 @@ void HotkeysWindow::LoadSettings(CSimpleIni* ini) {
         TBHotkey* hk = TBHotkey::HotkeyFactory(ini, entry.pItem);
         if (hk) hotkeys.push_back(hk);
     }
+    
+	for (TBHotkey* h : hotkeys) {
+		if (!block_hotkeys && h->active && h->trigger_on_toolbox_start && !h->pressed) {
+			h->pressed = true;
+			current_hotkey = hk;
+			h->Execute();
+			current_hotkey = nullptr;
+			h->pressed = false;
+		}
+	}
 
     TBHotkey::hotkeys_changed = false;
 }

--- a/GWToolboxdll/Windows/HotkeysWindow.cpp
+++ b/GWToolboxdll/Windows/HotkeysWindow.cpp
@@ -155,16 +155,16 @@ void HotkeysWindow::LoadSettings(CSimpleIni* ini) {
         TBHotkey* hk = TBHotkey::HotkeyFactory(ini, entry.pItem);
         if (hk) hotkeys.push_back(hk);
     }
-    
-	for (TBHotkey* h : hotkeys) {
-		if (!block_hotkeys && h->active && h->trigger_on_toolbox_start && !h->pressed) {
-			h->pressed = true;
-			current_hotkey = hk;
-			h->Execute();
-			current_hotkey = nullptr;
-			h->pressed = false;
-		}
-	}
+
+    for (TBHotkey *h : hotkeys) {
+        if (!block_hotkeys && h->active && h->trigger_on_toolbox_start && !h->pressed) {
+            h->pressed = true;
+            current_hotkey = h;
+            h->Execute();
+            current_hotkey = nullptr;
+            h->pressed = false;
+        }
+    }
 
     TBHotkey::hotkeys_changed = false;
 }


### PR DESCRIPTION
This is something I added for debugging purposes but I feel might be useful as a general feature. When adding new commands, it's convenient to have those commands execute at startup.
