### PR TITLE
InfoWindow does not display the model_id of item agents

### DIFF
--- a/GWToolboxdll/Windows/InfoWindow.cpp
+++ b/GWToolboxdll/Windows/InfoWindow.cpp
@@ -321,7 +321,12 @@ void InfoWindow::Draw(IDirect3DDevice9* pDevice) {
                 snprintf(y_buf, 32, "%.2f", target->pos.y);
                 float s = sqrtf(target->move_x * target->move_x + target->move_y * target->move_y);
                 snprintf(s_buf, 32, "%.3f", s / 288.0f);
-                snprintf(agentid_buf, 32, "%d", target->agent_id);
+                
+                if (target->GetIsItemType())
+                    snprintf(modelid_buf, 32, "%d", target_item ? GW::Items::GetItemById(target_item->item_id)->model_id : 0);
+                else
+                    snprintf(modelid_buf, 32, "%d", target_living ? target_living->player_number : 0);
+                
                 snprintf(modelid_buf, 32, "%d", target_living ? target_living->player_number : 0);
                 wchar_t* enc_name = GW::Agents::GetAgentEncName(target);
                 if (enc_name) {


### PR DESCRIPTION
The InfoWindow was only displaying the model_id of living agents. This patch allows the model_id of item agents to be displayed as well. I wasn't able to find a source for gadget agents so they will display 0 as before.