### PR TITLE
option to color the background where no terrain is & circular map

### DIFF
--- a/GWToolboxdll/GWToolboxdll.vcxproj
+++ b/GWToolboxdll/GWToolboxdll.vcxproj
@@ -43,9 +43,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>false</LinkIncremental>
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <TargetName>$(ProjectName)</TargetName>

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -168,6 +168,16 @@ void Minimap::DrawSettingInternal()
 {
     static char const *minimap_modifier_behavior_combo_str = "Disabled\0Draw\0Target\0Move\0Walk\0\0";
 
+    ImVec2 winsize(100.0f, 100.0f);
+    ImGuiWindow *window = ImGui::FindWindowByName(Name());
+    if (window) {
+        winsize = window->Size;
+    }
+    if (ImGui::DragFloat("Size", reinterpret_cast<float*>(&winsize), 1.0f, 0.0f, 0.0f, "%.0f")) {
+        winsize.y = winsize.x;
+        ImGui::SetWindowSize(Name(), winsize);
+    }
+
     ImGui::Text("General");
     ImGui::DragFloat("Scale", &scale, 0.01f, 0.1f);
     ImGui::Text("You can set the color alpha to 0 to disable any minimap feature.");
@@ -409,7 +419,7 @@ void Minimap::Draw(IDirect3DDevice9 *device)
                     device->SetRenderState(D3DRS_STENCILREF, 1);
                     device->SetRenderState(D3DRS_STENCILFUNC, D3DCMP_ALWAYS);
                     device->SetRenderState(D3DRS_STENCILPASS, D3DSTENCILOP_REPLACE); // write ref value into stencil buffer when passed
-                    auto radius = Instance().size.x / 2;
+                    auto radius = static_cast<int>(ceil(Instance().size.x / 2)) + 1; // rounding error in viewmatrix transformation
                     FillCircle(Instance().location.x + radius, Instance().location.y + radius, radius, color); // draw circle with chosen background color into stencil buffer, fills buffer with 1's
 
                     device->SetRenderState(D3DRS_STENCILFUNC, D3DCMP_EQUAL); // only draw where 1 is in the buffer

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -13,12 +13,12 @@
 #include <GWCA/Context/PartyContext.h>
 #include <GWCA/Context/WorldContext.h>
 
-#include <GWCA/Managers/MapMgr.h>
-#include <GWCA/Managers/ChatMgr.h>
-#include <GWCA/Managers/StoCMgr.h>
 #include <GWCA/Managers/AgentMgr.h>
-#include <GWCA/Managers/PartyMgr.h>
 #include <GWCA/Managers/CameraMgr.h>
+#include <GWCA/Managers/ChatMgr.h>
+#include <GWCA/Managers/MapMgr.h>
+#include <GWCA/Managers/PartyMgr.h>
+#include <GWCA/Managers/StoCMgr.h>
 
 #include <GuiUtils.h>
 #include <ImGuiAddons.h>
@@ -38,74 +38,63 @@ void Minimap::Terminate()
     effect_renderer.Invalidate();
 }
 
-void Minimap::Initialize() {
+void Minimap::Initialize()
+{
     ToolboxWidget::Initialize();
-    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::AgentPinged>(&AgentPinged_Entry,
-    [this](GW::HookStatus *, GW::Packet::StoC::AgentPinged *pak) -> void {
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::AgentPinged>(&AgentPinged_Entry, [this](GW::HookStatus *, GW::Packet::StoC::AgentPinged *pak) -> void {
         if (visible) {
             pingslines_renderer.P046Callback(pak);
         }
     });
-    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::CompassEvent>(&CompassEvent_Entry,
-    [this](GW::HookStatus *, GW::Packet::StoC::CompassEvent *pak) -> void {
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::CompassEvent>(&CompassEvent_Entry, [this](GW::HookStatus *, GW::Packet::StoC::CompassEvent *pak) -> void {
         if (visible) {
             pingslines_renderer.P138Callback(pak);
         }
     });
-    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::PlayEffect>(&CompassEvent_Entry,
-        [this](GW::HookStatus* status, GW::Packet::StoC::PlayEffect* pak) -> void {
-            UNREFERENCED_PARAMETER(status);
-            if (visible) {
-                if(GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable)
-                    effect_renderer.PacketCallback(pak);
-            }
-        });
-    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValue>(&GenericValueTarget_Entry,
-        [this](GW::HookStatus* s, GW::Packet::StoC::GenericValue* pak) -> void {
-            UNREFERENCED_PARAMETER(s);
-            if (visible) {
-                if (GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable)
-                    effect_renderer.PacketCallback(pak);
-            }
-        });
-    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValueTarget>(&GenericValueTarget_Entry,
-    [this](GW::HookStatus * s, GW::Packet::StoC::GenericValueTarget *pak) -> void {
-            UNREFERENCED_PARAMETER(s);
-            if (visible) {
-                pingslines_renderer.P153Callback(pak);
-                if (GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable)
-                    effect_renderer.PacketCallback(pak);
-            }
-        });
-    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::SkillActivate>(&SkillActivate_Entry,
-    [this](GW::HookStatus *, GW::Packet::StoC::SkillActivate *pak) -> void {
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::PlayEffect>(&CompassEvent_Entry, [this](GW::HookStatus *status, GW::Packet::StoC::PlayEffect *pak) -> void {
+        UNREFERENCED_PARAMETER(status);
+        if (visible) {
+            if (GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable)
+                effect_renderer.PacketCallback(pak);
+        }
+    });
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValue>(&GenericValueTarget_Entry, [this](GW::HookStatus *s, GW::Packet::StoC::GenericValue *pak) -> void {
+        UNREFERENCED_PARAMETER(s);
+        if (visible) {
+            if (GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable)
+                effect_renderer.PacketCallback(pak);
+        }
+    });
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValueTarget>(&GenericValueTarget_Entry, [this](GW::HookStatus *s, GW::Packet::StoC::GenericValueTarget *pak) -> void {
+        UNREFERENCED_PARAMETER(s);
+        if (visible) {
+            pingslines_renderer.P153Callback(pak);
+            if (GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable)
+                effect_renderer.PacketCallback(pak);
+        }
+    });
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::SkillActivate>(&SkillActivate_Entry, [this](GW::HookStatus *, GW::Packet::StoC::SkillActivate *pak) -> void {
         if (visible) {
             pingslines_renderer.P221Callback(pak);
         }
     });
-    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::InstanceLoadInfo>(&InstanceLoadInfo_Entry,
-        [this](GW::HookStatus*, GW::Packet::StoC::InstanceLoadInfo* packet) -> void {
-            is_observing = packet->is_observer != 0;
-        });
-    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::InstanceLoadFile>(&InstanceLoadFile_Entry,
-        [this](GW::HookStatus *, GW::Packet::StoC::InstanceLoadFile *packet) -> void {
-            UNREFERENCED_PARAMETER(packet);
-            pmap_renderer.Invalidate();
-            loading = false;
-        });
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::InstanceLoadInfo>(&InstanceLoadInfo_Entry, [this](GW::HookStatus *, GW::Packet::StoC::InstanceLoadInfo *packet) -> void { is_observing = packet->is_observer != 0; });
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::InstanceLoadFile>(&InstanceLoadFile_Entry, [this](GW::HookStatus *, GW::Packet::StoC::InstanceLoadFile *packet) -> void {
+        UNREFERENCED_PARAMETER(packet);
+        pmap_renderer.Invalidate();
+        loading = false;
+    });
 
-    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GameSrvTransfer>(&GameSrvTransfer_Entry,
-        [this](GW::HookStatus *, GW::Packet::StoC::GameSrvTransfer *pak) -> void {
-            UNREFERENCED_PARAMETER(pak);
-            loading = true;
-            agent_renderer.auto_target_id = 0;
-        });
-    GW::UI::RegisterUIMessageCallback(&UIMsg_Entry, 
-    [this](GW::HookStatus *, uint32_t msgid, void* lParam, void*) -> void {
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GameSrvTransfer>(&GameSrvTransfer_Entry, [this](GW::HookStatus *, GW::Packet::StoC::GameSrvTransfer *pak) -> void {
+        UNREFERENCED_PARAMETER(pak);
+        loading = true;
+        agent_renderer.auto_target_id = 0;
+    });
+    GW::UI::RegisterUIMessageCallback(&UIMsg_Entry, [this](GW::HookStatus *, uint32_t msgid, void *lParam, void *) -> void {
         if (msgid != GW::UI::kAutoTargetAgent || !lParam)
             return;
-        agent_renderer.auto_target_id = *(uint32_t*)lParam;
-        });
+        agent_renderer.auto_target_id = *static_cast<uint32_t *>(lParam);
+    });
 
     last_moved = TIMER_INIT();
 
@@ -125,7 +114,7 @@ void Minimap::OnFlagHeroCmd(const wchar_t *message, int argc, LPWSTR *argv)
         Instance().FlagHero(0); // "/flag"
         return;
     }
-    std::wstring arg1 = GuiUtils::ToLower(argv[1]);
+    const std::wstring arg1 = GuiUtils::ToLower(argv[1]);
     float x;
     float y;
     unsigned int n_heros = 0; // Count of heros available
@@ -142,7 +131,7 @@ void Minimap::OnFlagHeroCmd(const wchar_t *message, int argc, LPWSTR *argv)
         GW::PartyMgr::FlagAll(GW::GamePos(x, y, 0)); // "/flag all -2913.41 3004.78"
         return;
     }
-    auto heroarray = GW::GameContext::instance()->party->player_party->heroes;
+    const auto heroarray = GW::GameContext::instance()->party->player_party->heroes;
     if (heroarray.valid())
         n_heros = heroarray.size();
     if (n_heros < 1) {
@@ -163,7 +152,7 @@ void Minimap::OnFlagHeroCmd(const wchar_t *message, int argc, LPWSTR *argv)
         Instance().FlagHero(f_hero); // "/flag 5"
         return;
     }
-    std::wstring arg2 = GuiUtils::ToLower(argv[2]);
+    const std::wstring arg2 = GuiUtils::ToLower(argv[2]);
     if (arg2 == L"clear") {
         GW::PartyMgr::UnflagHero(f_hero); // "/flag 5 clear"
         return;
@@ -175,7 +164,8 @@ void Minimap::OnFlagHeroCmd(const wchar_t *message, int argc, LPWSTR *argv)
     GW::PartyMgr::FlagHeroAgent(GW::Agents::GetHeroAgentID(f_hero), GW::GamePos(x, y, 0)); // "/flag 5 -2913.41 3004.78"
 }
 
-void Minimap::DrawSettingInternal() {
+void Minimap::DrawSettingInternal()
+{
     static char const *minimap_modifier_behavior_combo_str = "Disabled\0Draw\0Target\0Move\0Walk\0\0";
 
     ImGui::Text("General");
@@ -231,10 +221,10 @@ void Minimap::DrawSettingInternal() {
                     "Target: click to target agent.\n"
                     "Move: move the minimap outside of compass range.\n"
                     "Walk: start walking character to selected location.\n");
-    ImGui::Combo("None",    reinterpret_cast<int*>(&key_none_behavior),  minimap_modifier_behavior_combo_str);
-    ImGui::Combo("Control", reinterpret_cast<int*>(&key_ctrl_behavior),  minimap_modifier_behavior_combo_str);
-    ImGui::Combo("Shift",   reinterpret_cast<int*>(&key_shift_behavior), minimap_modifier_behavior_combo_str);
-    ImGui::Combo("Alt",     reinterpret_cast<int*>(&key_alt_behavior),   minimap_modifier_behavior_combo_str);
+    ImGui::Combo("None", reinterpret_cast<int *>(&key_none_behavior), minimap_modifier_behavior_combo_str);
+    ImGui::Combo("Control", reinterpret_cast<int *>(&key_ctrl_behavior), minimap_modifier_behavior_combo_str);
+    ImGui::Combo("Shift", reinterpret_cast<int *>(&key_shift_behavior), minimap_modifier_behavior_combo_str);
+    ImGui::Combo("Alt", reinterpret_cast<int *>(&key_alt_behavior), minimap_modifier_behavior_combo_str);
     if (mouse_clickthrough) {
         ImGui::PopItemFlag();
         ImGui::PopStyleVar();
@@ -243,23 +233,25 @@ void Minimap::DrawSettingInternal() {
     ImGui::ShowHelp("Additional pings on the same agents will increase the duration of the existing ping, rather than create a new one.");
     ImGui::Checkbox("Map Rotation", &rotate_minimap);
     ImGui::ShowHelp("Map rotation on (e.g. Compass), or off (e.g. Mission Map).");
+    ImGui::Checkbox("Circular", &circular_map);
+    ImGui::ShowHelp("Whether the map should be circular like the compass or a square (default).");
 }
 
-void Minimap::LoadSettings(CSimpleIni* ini) {
+void Minimap::LoadSettings(CSimpleIni *ini)
+{
     ToolboxWidget::LoadSettings(ini);
-    scale = (float)ini->GetDoubleValue(Name(), VAR_NAME(scale), 1.0);
+    scale = static_cast<float>(ini->GetDoubleValue(Name(), VAR_NAME(scale), 1.0));
     hero_flag_controls_show = ini->GetBoolValue(Name(), VAR_NAME(hero_flag_controls_show), true);
     hero_flag_window_attach = ini->GetBoolValue(Name(), VAR_NAME(hero_flag_window_attach), true);
-    hero_flag_window_background = Colors::Load(ini, Name(), "hero_flag_controls_background",
-        ImColor(ImGui::GetStyle().Colors[ImGuiCol_WindowBg]));
+    hero_flag_window_background = Colors::Load(ini, Name(), "hero_flag_controls_background", ImColor(ImGui::GetStyle().Colors[ImGuiCol_WindowBg]));
     mouse_clickthrough = ini->GetBoolValue(Name(), VAR_NAME(mouse_clickthrough), false);
     mouse_clickthrough_in_outpost = ini->GetBoolValue(Name(), VAR_NAME(mouse_clickthrough_in_outpost), mouse_clickthrough_in_outpost);
     rotate_minimap = ini->GetBoolValue(Name(), VAR_NAME(rotate_minimap), true);
     circular_map = ini->GetBoolValue(Name(), VAR_NAME(circular_map), false);
-    key_none_behavior  = static_cast<MinimapModifierBehaviour>(ini->GetLongValue(Name(), VAR_NAME(key_none_behavior), 1));
-    key_ctrl_behavior  = static_cast<MinimapModifierBehaviour>(ini->GetLongValue(Name(), VAR_NAME(key_ctrl_behavior), 2));
+    key_none_behavior = static_cast<MinimapModifierBehaviour>(ini->GetLongValue(Name(), VAR_NAME(key_none_behavior), 1));
+    key_ctrl_behavior = static_cast<MinimapModifierBehaviour>(ini->GetLongValue(Name(), VAR_NAME(key_ctrl_behavior), 2));
     key_shift_behavior = static_cast<MinimapModifierBehaviour>(ini->GetLongValue(Name(), VAR_NAME(key_shift_behavior), 3));
-    key_alt_behavior   = static_cast<MinimapModifierBehaviour>(ini->GetLongValue(Name(), VAR_NAME(key_alt_behavior), 4));
+    key_alt_behavior = static_cast<MinimapModifierBehaviour>(ini->GetLongValue(Name(), VAR_NAME(key_alt_behavior), 4));
     pingslines_renderer.reduce_ping_spam = ini->GetBoolValue(Name(), VAR_NAME(reduce_ping_spam), false);
     range_renderer.LoadSettings(ini, Name());
     pmap_renderer.LoadSettings(ini, Name());
@@ -270,7 +262,8 @@ void Minimap::LoadSettings(CSimpleIni* ini) {
     effect_renderer.LoadSettings(ini, Name());
 }
 
-void Minimap::SaveSettings(CSimpleIni* ini) {
+void Minimap::SaveSettings(CSimpleIni *ini)
+{
     ToolboxWidget::SaveSettings(ini);
     ini->SetDoubleValue(Name(), VAR_NAME(scale), scale);
     ini->SetBoolValue(Name(), VAR_NAME(hero_flag_controls_show), hero_flag_controls_show);
@@ -278,10 +271,10 @@ void Minimap::SaveSettings(CSimpleIni* ini) {
     Colors::Save(ini, Name(), VAR_NAME(hero_flag_window_background), hero_flag_window_background);
     ini->SetBoolValue(Name(), VAR_NAME(mouse_clickthrough), mouse_clickthrough);
     ini->SetBoolValue(Name(), VAR_NAME(mouse_clickthrough_in_outpost), mouse_clickthrough_in_outpost);
-    ini->SetLongValue(Name(), VAR_NAME(key_none_behavior),  static_cast<long>(key_none_behavior));
-    ini->SetLongValue(Name(), VAR_NAME(key_ctrl_behavior),  static_cast<long>(key_ctrl_behavior));
+    ini->SetLongValue(Name(), VAR_NAME(key_none_behavior), static_cast<long>(key_none_behavior));
+    ini->SetLongValue(Name(), VAR_NAME(key_ctrl_behavior), static_cast<long>(key_ctrl_behavior));
     ini->SetLongValue(Name(), VAR_NAME(key_shift_behavior), static_cast<long>(key_shift_behavior));
-    ini->SetLongValue(Name(), VAR_NAME(key_alt_behavior),   static_cast<long>(key_alt_behavior)); 
+    ini->SetLongValue(Name(), VAR_NAME(key_alt_behavior), static_cast<long>(key_alt_behavior));
     ini->SetBoolValue(Name(), VAR_NAME(reduce_ping_spam), pingslines_renderer.reduce_ping_spam);
     ini->SetBoolValue(Name(), VAR_NAME(rotate_minimap), rotate_minimap);
     ini->SetBoolValue(Name(), VAR_NAME(circular_map), circular_map);
@@ -294,12 +287,15 @@ void Minimap::SaveSettings(CSimpleIni* ini) {
     effect_renderer.SaveSettings(ini, Name());
 }
 
-void Minimap::GetPlayerHeroes(GW::PartyInfo *party, std::vector<GW::AgentID>& _player_heroes) {
+void Minimap::GetPlayerHeroes(GW::PartyInfo *party, std::vector<GW::AgentID> &_player_heroes)
+{
     _player_heroes.clear();
-    if (!party) return;
-    GW::AgentLiving* player = GW::Agents::GetPlayerAsAgentLiving();
-    if (!player) return;
-    uint32_t player_id = player->login_number;
+    if (!party)
+        return;
+    GW::AgentLiving *player = GW::Agents::GetPlayerAsAgentLiving();
+    if (!player)
+        return;
+    const uint32_t player_id = player->login_number;
     auto heroes = party->heroes;
     _player_heroes.reserve(heroes.size());
     for (GW::HeroPartyMember &hero : heroes) {
@@ -307,21 +303,25 @@ void Minimap::GetPlayerHeroes(GW::PartyInfo *party, std::vector<GW::AgentID>& _p
             _player_heroes.push_back(hero.agent_id);
     }
 }
-float Minimap::GetMapRotation() {
-    return rotate_minimap ? GW::CameraMgr::GetYaw() : (float)1.5708;
-}
-void Minimap::Draw(IDirect3DDevice9* device) {
-    if (!IsActive()) return;
 
-    GW::Agent* me = GW::Agents::GetPlayer();
-    if (me == nullptr) return;
+float Minimap::GetMapRotation() const
+{
+    return rotate_minimap ? GW::CameraMgr::GetYaw() : static_cast<float>(1.5708);
+}
+
+void Minimap::Draw(IDirect3DDevice9 *device)
+{
+    if (!IsActive())
+        return;
+
+    GW::Agent *me = GW::Agents::GetPlayer();
+    if (me == nullptr)
+        return;
 
     // if not center and want to move, move center towards player
-    if ((translation.x != 0 || translation.y != 0)
-        && (me->move_x != 0 || me->move_y != 0)
-        && TIMER_DIFF(last_moved) > ms_before_back) {
-        GW::Vec2f v(translation.x, translation.y);
-        float speed = std::min((TIMER_DIFF(last_moved) - ms_before_back) * acceleration, 500.0f);
+    if ((translation.x != 0 || translation.y != 0) && (me->move_x != 0 || me->move_y != 0) && TIMER_DIFF(last_moved) > ms_before_back) {
+        const GW::Vec2f v(translation.x, translation.y);
+        const float speed = std::min((TIMER_DIFF(last_moved) - ms_before_back) * acceleration, 500.0f);
         GW::Vec2f d = v;
         d = GW::Normalize(d) * speed;
         if (std::abs(d.x) > std::abs(v.x)) {
@@ -334,19 +334,21 @@ void Minimap::Draw(IDirect3DDevice9* device) {
     ImGui::SetNextWindowSize(ImVec2(500.0f, 500.0f), ImGuiSetCond_FirstUseEver);
     if (ImGui::Begin(Name(), nullptr, GetWinFlags(ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoBringToFrontOnFocus))) {
         // window pos are already rounded by imgui, so casting is no big deal
-        location.x = (int)ImGui::GetWindowPos().x;
-        location.y = (int)ImGui::GetWindowPos().y;
-        size.x = (int)ImGui::GetWindowSize().x;
-        size.y = (int)ImGui::GetWindowSize().y;
-        ImGui::GetWindowDrawList()->AddCallback([](const ImDrawList* parent_list, const ImDrawCmd* cmd) -> void {
+        location.x = static_cast<int>(ImGui::GetWindowPos().x);
+        location.y = static_cast<int>(ImGui::GetWindowPos().y);
+        size.x = static_cast<int>(ImGui::GetWindowSize().x);
+        size.y = static_cast<int>(ImGui::GetWindowSize().y);
+        ImGui::GetWindowDrawList()->AddCallback(
+            [](const ImDrawList *parent_list, const ImDrawCmd *cmd) -> void {
                 UNREFERENCED_PARAMETER(parent_list);
 
-                IDirect3DDevice9* device = (IDirect3DDevice9*)cmd->UserCallbackData;
-                GW::Agent* me = GW::Agents::GetPlayer();
-                if (me == nullptr) return;
+                auto device = static_cast<IDirect3DDevice9*>(cmd->UserCallbackData);
+                GW::Agent *me = GW::Agents::GetPlayer();
+                if (me == nullptr)
+                    return;
 
                 // Backup the DX9 state
-                IDirect3DStateBlock9* d3d9_state_block = NULL;
+                IDirect3DStateBlock9 *d3d9_state_block = nullptr;
                 if (device->CreateStateBlock(D3DSBT_ALL, &d3d9_state_block) < 0)
                     return;
 
@@ -354,8 +356,8 @@ void Minimap::Draw(IDirect3DDevice9* device) {
                 device->SetFVF(D3DFVF_CUSTOMVERTEX);
                 device->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, true);
                 device->SetRenderState(D3DRS_FILLMODE, D3DFILL_SOLID);
-                device->SetPixelShader(NULL);
-                device->SetVertexShader(NULL);
+                device->SetPixelShader(nullptr);
+                device->SetVertexShader(nullptr);
                 device->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
                 device->SetRenderState(D3DRS_LIGHTING, false);
                 device->SetRenderState(D3DRS_ZENABLE, false);
@@ -364,7 +366,6 @@ void Minimap::Draw(IDirect3DDevice9* device) {
                 device->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD);
                 device->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
                 device->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
-                device->SetRenderState(D3DRS_SCISSORTESTENABLE, true);
                 device->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
                 device->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
                 device->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_DIFFUSE);
@@ -374,37 +375,49 @@ void Minimap::Draw(IDirect3DDevice9* device) {
                 device->SetSamplerState(0, D3DSAMP_MINFILTER, D3DTEXF_LINEAR);
                 device->SetSamplerState(0, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
 
-                auto FillRect = [&device](D3DCOLOR color, int x, int y, int w, int h) {
-                    D3DVertex vertices[6] = {{(float)x, (float)y, 1.0f, color}, {(float)x + w, (float)y, 1.0f, color}, {(float)x, (float)y + h, 1.0f, color}, {(float)x + w, (float)y + h, 1.0f, color}, {(float)x, (float)y, 1.0f, color}, {(float)x + w, (float)y, 1.0f, color}};
+                auto FillRect = [&device](const D3DCOLOR color, const int x, const int y, const int w, const int h) {
+                    D3DVertex vertices[6] = {{static_cast<float>(x), static_cast<float>(y), 1.0f, color},         {static_cast<float>(x) + w, static_cast<float>(y), 1.0f, color}, {static_cast<float>(x), static_cast<float>(y) + h, 1.0f, color},
+                                             {static_cast<float>(x) + w, static_cast<float>(y) + h, 1.0f, color}, {static_cast<float>(x), static_cast<float>(y), 1.0f, color},     {static_cast<float>(x) + w, static_cast<float>(y), 1.0f, color}};
                     device->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 4, vertices, sizeof(D3DVertex));
                 };
 
-                auto FillCircle = [&device](int x, int y, int radius, Color clr, int resolution) {
-                    resolution = std::min(resolution, 197);
+                auto FillCircle = [&device](const int x, const int y, const int radius, const Color clr, int resolution = 199) {
+                    resolution = std::min(resolution, 199);
                     D3DVertex vertices[200];
                     for (auto i = 0; i <= resolution; ++i) {
-                        vertices[i] = {x + radius * cos(D3DX_PI * (i / (resolution / 2.f))), y + radius * sin(D3DX_PI * (i / (resolution / 2.f))), 0, clr};
+                        vertices[i] = {float(radius) * cos(D3DX_PI * (i / (float(resolution) / 2.f))) + float(x), float(y) + float(radius) * sin(D3DX_PI * (i / (float(resolution) / 2.f))), 0, clr};
                     }
                     device->DrawPrimitiveUP(D3DPT_TRIANGLEFAN, static_cast<unsigned int>(resolution), vertices, sizeof(D3DVertex));
                 };
 
                 D3DCOLOR color = Instance().pmap_renderer.GetBackgroundColor();
-                if (Instance().circular_map) {
-                    auto radius = Instance().size.x / 2;
-                    FillCircle(Instance().location.x + radius, Instance().location.y + radius, radius, color, 200);
-                } else {
+                if (!Instance().circular_map) {
+                    auto &style = ImGui::GetStyle();
+                    RECT clipping;
+                    clipping.left = static_cast<long>(cmd->ClipRect.x - style.WindowPadding.x / 2); // > 0 ? cmd->ClipRect.x : 0);
+                    clipping.right = static_cast<long>(cmd->ClipRect.z + style.WindowPadding.x / 2 + 1);
+                    clipping.top = static_cast<long>(cmd->ClipRect.y);
+                    clipping.bottom = static_cast<long>(cmd->ClipRect.w);
+                    device->SetScissorRect(&clipping);
+                    device->SetRenderState(D3DRS_SCISSORTESTENABLE, true);
                     FillRect(color, Instance().location.x, Instance().location.y, Instance().size.x, Instance().size.y);
+                } else {
+                    device->SetRenderState(D3DRS_STENCILENABLE, true); // enable stencil writing
+                    device->SetRenderState(D3DRS_STENCILMASK, 0xffffffff);
+                    device->SetRenderState(D3DRS_STENCILWRITEMASK, 0xffffffff);
+                    device->Clear(0, nullptr, D3DCLEAR_ZBUFFER | D3DCLEAR_STENCIL, 0x00000000, 1.0f, 0); // clear depth and stencil buffer
+                    device->SetRenderState(D3DRS_STENCILREF, 1);
+                    device->SetRenderState(D3DRS_STENCILFUNC, D3DCMP_ALWAYS);
+                    device->SetRenderState(D3DRS_STENCILPASS, D3DSTENCILOP_REPLACE);
+                    auto radius = Instance().size.x / 2;
+                    FillCircle(Instance().location.x + radius, Instance().location.y + radius, radius, color); // draw transparent circle into stencil buffer - fill with 1's
+
+                    device->SetRenderState(D3DRS_STENCILFUNC, D3DCMP_EQUAL); // only draw where 1 is in the buffer
+                    device->SetRenderState(D3DRS_STENCILFAIL, D3DSTENCILOP_ZERO);
+                    device->SetRenderState(D3DRS_STENCILZFAIL, D3DSTENCILOP_ZERO);
+                    device->SetRenderState(D3DRS_STENCILPASS, D3DSTENCILOP_REPLACE);
                 }
 
-                ImGuiStyle& style = ImGui::GetStyle();
-                RECT old_clipping, clipping;
-                device->GetScissorRect(&old_clipping);
-                clipping.left = (long)(cmd->ClipRect.x - style.WindowPadding.x / 2); // > 0 ? cmd->ClipRect.x : 0);
-                clipping.right = (long)(cmd->ClipRect.z + style.WindowPadding.x / 2 + 1);
-                clipping.top = (long)(cmd->ClipRect.y);
-                clipping.bottom = (long)(cmd->ClipRect.w);
-                device->SetScissorRect(&clipping);
-                device->SetRenderState(D3DRS_SCISSORTESTENABLE, TRUE);
                 Instance().RenderSetupProjection(device);
 
                 D3DXMATRIX view;
@@ -417,7 +430,7 @@ void Minimap::Draw(IDirect3DDevice9* device) {
                 D3DXMatrixTranslation(&translate_char, -me->pos.x, -me->pos.y, 0);
 
                 D3DXMATRIX rotate_char;
-                D3DXMatrixRotationZ(&rotate_char, -Instance().GetMapRotation()+ (float)M_PI_2);
+                D3DXMatrixRotationZ(&rotate_char, -Instance().GetMapRotation() + static_cast<float>(M_PI_2));
 
                 D3DXMATRIX scaleM, translationM;
                 D3DXMatrixScaling(&scaleM, Instance().scale, Instance().scale, 1.0f);
@@ -454,60 +467,65 @@ void Minimap::Draw(IDirect3DDevice9* device) {
 
                 Instance().pingslines_renderer.Render(device);
 
+                if (Instance().circular_map) {
+                    device->SetRenderState(D3DRS_STENCILENABLE, false);
+                }
+
                 // Restore the DX9 state
                 d3d9_state_block->Apply();
                 d3d9_state_block->Release();
-
-            }, (void*)device);
+            },
+            static_cast<void *>(device));
     }
     ImGui::End();
     ImGui::PopStyleColor();
 
     if (hero_flag_controls_show && GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable) {
         // @Cleanup: Maybe not lambda, but realy adapted in this case.
-        auto GetPlayerParty = [] () -> GW::PartyInfo* {
+        auto GetPlayerParty = []() -> GW::PartyInfo * {
             GW::GameContext *gamectx = GW::GameContext::instance();
-            if (!(gamectx && gamectx->party)) return nullptr;
+            if (!(gamectx && gamectx->party))
+                return nullptr;
             return gamectx->party->player_party;
         };
 
-        auto playerparty = GetPlayerParty();
+        const auto playerparty = GetPlayerParty();
         GetPlayerHeroes(playerparty, player_heroes);
         bool player_has_henchmans = false;
         if (playerparty && playerparty->henchmen.size() && GW::PartyMgr::GetPlayerIsLeader())
             player_has_henchmans = true;
 
-        if (playerparty && (player_has_henchmans || player_heroes.size())) {
+        if (playerparty && (player_has_henchmans || !player_heroes.empty())) {
             if (hero_flag_window_attach) {
-                ImGui::SetNextWindowPos(ImVec2((float)location.x, (float)(location.y + size.y)));
-                ImGui::SetNextWindowSize(ImVec2((float)size.x, 40.0f));
+                ImGui::SetNextWindowPos(ImVec2(static_cast<float>(location.x), static_cast<float>(location.y + size.y)));
+                ImGui::SetNextWindowSize(ImVec2(static_cast<float>(size.x), 40.0f));
             }
             ImGui::PushStyleColor(ImGuiCol_WindowBg, ImColor(hero_flag_window_background).Value);
-            if (ImGui::Begin("Hero Controls", nullptr, GetWinFlags(
-                hero_flag_window_attach ? ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove : 0, false))) {
-                static const char* flag_txt[] = {
-                    "All", "1", "2", "3", "4", "5", "6", "7", "8"
-                };
+            if (ImGui::Begin("Hero Controls", nullptr, GetWinFlags(hero_flag_window_attach ? ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove : 0, false))) {
+                static const char *flag_txt[] = {"All", "1", "2", "3", "4", "5", "6", "7", "8"};
                 GW::Vec3f allflag = GW::GameContext::instance()->world->all_flag;
-                unsigned int num_heroflags = player_heroes.size() + 1;
-                float w_but = (ImGui::GetWindowContentRegionWidth() 
-                    - ImGui::GetStyle().ItemSpacing.x * (num_heroflags)) / (num_heroflags + 1);
+                const unsigned int num_heroflags = player_heroes.size() + 1;
+                const float w_but = (ImGui::GetWindowContentRegionWidth() - ImGui::GetStyle().ItemSpacing.x * (num_heroflags)) / (num_heroflags + 1);
 
                 for (unsigned int i = 0; i < num_heroflags; ++i) {
-                    if (i > 0) ImGui::SameLine();
-                    bool old_flagging = flagging[i];
-                    if (old_flagging) ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyle().Colors[ImGuiCol_ButtonHovered]);
+                    if (i > 0)
+                        ImGui::SameLine();
+                    const bool old_flagging = flagging[i];
+                    if (old_flagging)
+                        ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyle().Colors[ImGuiCol_ButtonHovered]);
 
                     if (ImGui::Button(flag_txt[i], ImVec2(w_but, 0))) {
                         flagging[i] ^= 1;
                     }
-                    if (old_flagging) ImGui::PopStyleColor();
+                    if (old_flagging)
+                        ImGui::PopStyleColor();
 
                     if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(0)) {
-                        if (i == 0) GW::PartyMgr::UnflagAll();
-                        else GW::PartyMgr::UnflagHero(i);
+                        if (i == 0)
+                            GW::PartyMgr::UnflagAll();
+                        else
+                            GW::PartyMgr::UnflagHero(i);
                     }
-
                 }
                 ImGui::SameLine();
                 if (ImGui::Button("Clear", ImVec2(-1, 0))) {
@@ -523,11 +541,13 @@ void Minimap::Draw(IDirect3DDevice9* device) {
     }
 }
 
-GW::Vec2f Minimap::InterfaceToWorldPoint(Vec2i pos) const {
-    GW::Agent* me = GW::Agents::GetPlayer();
-    if (me == nullptr) return GW::Vec2f(0, 0);
-    
-    GW::Vec2f v((float)pos.x, (float)pos.y);
+GW::Vec2f Minimap::InterfaceToWorldPoint(Vec2i pos) const
+{
+    GW::Agent *me = GW::Agents::GetPlayer();
+    if (me == nullptr)
+        return GW::Vec2f(0, 0);
+
+    GW::Vec2f v(static_cast<float>(pos.x), static_cast<float>(pos.y));
 
     // Invert viewport projection
     v.x = v.x - location.x;
@@ -538,7 +558,7 @@ GW::Vec2f Minimap::InterfaceToWorldPoint(Vec2i pos) const {
     v.y = (2.0f * v.y / size.x + 1.0f);
 
     // scale up to [-w, w]
-    float w = 5000.0f;
+    const float w = 5000.0f;
     v *= w;
 
     // translate by camera
@@ -548,9 +568,9 @@ GW::Vec2f Minimap::InterfaceToWorldPoint(Vec2i pos) const {
     v /= scale;
 
     // rotate by current camera rotation
-    float angle = Instance().GetMapRotation() - (float)M_PI_2;
-    float x1 = v.x * std::cos(angle) - v.y * std::sin(angle);
-    float y1 = v.x * std::sin(angle) + v.y * std::cos(angle);
+    const float angle = Instance().GetMapRotation() - static_cast<float>(M_PI_2);
+    const float x1 = v.x * std::cos(angle) - v.y * std::sin(angle);
+    const float y1 = v.x * std::sin(angle) + v.y * std::cos(angle);
     v = GW::Vec2f(x1, y1);
 
     // translate by character position
@@ -559,8 +579,9 @@ GW::Vec2f Minimap::InterfaceToWorldPoint(Vec2i pos) const {
     return v;
 }
 
-GW::Vec2f Minimap::InterfaceToWorldVector(Vec2i pos) const {
-    GW::Vec2f v((float)pos.x, (float)pos.y);
+GW::Vec2f Minimap::InterfaceToWorldVector(Vec2i pos) const
+{
+    GW::Vec2f v(static_cast<float>(pos.x), static_cast<float>(pos.y));
 
     // Invert y direction
     v.y = -v.y;
@@ -570,60 +591,73 @@ GW::Vec2f Minimap::InterfaceToWorldVector(Vec2i pos) const {
     v.y = (2.0f * v.y / size.x);
 
     // scale up to [-w, w]
-    float w = 5000.0f;
+    const float w = 5000.0f;
     v *= w;
 
     return v;
 }
 
-void Minimap::SelectTarget(GW::Vec2f pos) {
+void Minimap::SelectTarget(GW::Vec2f pos)
+{
     GW::AgentArray agents = GW::Agents::GetAgentArray();
-    if (!agents.valid()) return;
+    if (!agents.valid())
+        return;
 
     float distance = 600.0f * 600.0f;
-    size_t closest = (size_t)-1;
+    size_t closest = static_cast<size_t>(-1);
 
     for (size_t i = 0; i < agents.size(); ++i) {
-        GW::Agent* agent = agents[i];
-        if (agent == nullptr) continue;
-        GW::AgentLiving* living = agent->GetAsAgentLiving();
-        if (living && living->GetIsDead()) continue;
-        if (agent->GetIsItemType()) continue;
-        if (agent->GetIsGadgetType() && agent->GetAsAgentGadget()->gadget_id != 8141) continue; // allow locked chests
-        if (living && (living->player_number >= 230 && living->player_number <= 346)) continue; // block all useless minis
-        float newDistance = GW::GetSquareDistance(pos, agents[i]->pos);
+        GW::Agent *agent = agents[i];
+        if (agent == nullptr)
+            continue;
+        GW::AgentLiving *living = agent->GetAsAgentLiving();
+        if (living && living->GetIsDead())
+            continue;
+        if (agent->GetIsItemType())
+            continue;
+        if (agent->GetIsGadgetType() && agent->GetAsAgentGadget()->gadget_id != 8141)
+            continue; // allow locked chests
+        if (living && (living->player_number >= 230 && living->player_number <= 346))
+            continue; // block all useless minis
+        const float newDistance = GW::GetSquareDistance(pos, agents[i]->pos);
         if (distance > newDistance) {
             distance = newDistance;
             closest = i;
         }
     }
 
-    if (closest != (size_t)-1) {
+    if (closest != static_cast<size_t>(-1)) {
         GW::Agents::ChangeTarget(agents[closest]);
     }
 }
 
-bool Minimap::WndProc(UINT Message, WPARAM wParam, LPARAM lParam) {
+bool Minimap::WndProc(UINT Message, WPARAM wParam, LPARAM lParam)
+{
     if (is_observing)
         return false;
     if (mouse_clickthrough)
         return Message == WM_LBUTTONDOWN && FlagHeros(lParam);
-    if (mouse_clickthrough_in_outpost && GW::Map::GetInstanceType() == GW::Constants::InstanceType::Outpost) 
+    if (mouse_clickthrough_in_outpost && GW::Map::GetInstanceType() == GW::Constants::InstanceType::Outpost)
         return false;
     switch (Message) {
-    case WM_MOUSEMOVE: return OnMouseMove(Message, wParam, lParam);
-    case WM_LBUTTONDOWN: return OnMouseDown(Message, wParam, lParam);
-    case WM_MOUSEWHEEL: return OnMouseWheel(Message, wParam, lParam);
-    case WM_LBUTTONDBLCLK: return OnMouseDblClick(Message, wParam, lParam);
-    case WM_LBUTTONUP: return OnMouseUp(Message, wParam, lParam);
-    default:
-        return false;
+        case WM_MOUSEMOVE:
+            return OnMouseMove(Message, wParam, lParam);
+        case WM_LBUTTONDOWN:
+            return OnMouseDown(Message, wParam, lParam);
+        case WM_MOUSEWHEEL:
+            return OnMouseWheel(Message, wParam, lParam);
+        case WM_LBUTTONDBLCLK:
+            return OnMouseDblClick(Message, wParam, lParam);
+        case WM_LBUTTONUP:
+            return OnMouseUp(Message, wParam, lParam);
+        default:
+            return false;
     }
 }
 bool Minimap::FlagHeros(LPARAM lParam)
 {
-    int x = GET_X_LPARAM(lParam);
-    int y = GET_Y_LPARAM(lParam);
+    const int x = GET_X_LPARAM(lParam);
+    const int y = GET_Y_LPARAM(lParam);
     if (!IsInside(x, y))
         return false;
 
@@ -644,18 +678,21 @@ bool Minimap::FlagHeros(LPARAM lParam)
     }
     return flagged;
 }
-bool Minimap::OnMouseDown(UINT Message, WPARAM wParam, LPARAM lParam) {
+bool Minimap::OnMouseDown(UINT Message, WPARAM wParam, LPARAM lParam)
+{
     UNREFERENCED_PARAMETER(Message);
     UNREFERENCED_PARAMETER(wParam);
-    if (!IsActive()) return false;
+    if (!IsActive())
+        return false;
     if (FlagHeros(lParam))
         return true;
-    int x = GET_X_LPARAM(lParam);
-    int y = GET_Y_LPARAM(lParam);
-    if (!IsInside(x, y)) return false;
+    const int x = GET_X_LPARAM(lParam);
+    const int y = GET_Y_LPARAM(lParam);
+    if (!IsInside(x, y))
+        return false;
 
     mousedown = true;
-    GW::Vec2f worldpos = InterfaceToWorldPoint(Vec2i(x, y));
+    const GW::Vec2f worldpos = InterfaceToWorldPoint(Vec2i(x, y));
 
     if (IsKeyDown(MinimapModifierBehaviour::Target)) {
         SelectTarget(worldpos);
@@ -668,28 +705,31 @@ bool Minimap::OnMouseDown(UINT Message, WPARAM wParam, LPARAM lParam) {
         return true;
     }
 
-
-
     drag_start.x = x;
     drag_start.y = y;
 
-    if (IsKeyDown(MinimapModifierBehaviour::Move)) return true;
+    if (IsKeyDown(MinimapModifierBehaviour::Move))
+        return true;
 
-    if (!lock_move) return true;
+    if (!lock_move)
+        return true;
 
     pingslines_renderer.OnMouseDown(worldpos.x, worldpos.y);
 
     return true;
 }
 
-bool Minimap::OnMouseDblClick(UINT Message, WPARAM wParam, LPARAM lParam) {
+bool Minimap::OnMouseDblClick(UINT Message, WPARAM wParam, LPARAM lParam)
+{
     UNREFERENCED_PARAMETER(Message);
     UNREFERENCED_PARAMETER(wParam);
-    if (!IsActive()) return false;
+    if (!IsActive())
+        return false;
 
-    int x = GET_X_LPARAM(lParam);
-    int y = GET_Y_LPARAM(lParam);
-    if (!IsInside(x, y)) return false;
+    const int x = GET_X_LPARAM(lParam);
+    const int y = GET_Y_LPARAM(lParam);
+    if (!IsInside(x, y))
+        return false;
 
     if (IsKeyDown(MinimapModifierBehaviour::Target)) {
         SelectTarget(InterfaceToWorldPoint(Vec2i(x, y)));
@@ -699,30 +739,36 @@ bool Minimap::OnMouseDblClick(UINT Message, WPARAM wParam, LPARAM lParam) {
     return true;
 }
 
-bool Minimap::OnMouseUp(UINT Message, WPARAM wParam, LPARAM lParam) {
+bool Minimap::OnMouseUp(UINT Message, WPARAM wParam, LPARAM lParam)
+{
     UNREFERENCED_PARAMETER(Message);
     UNREFERENCED_PARAMETER(wParam);
     UNREFERENCED_PARAMETER(lParam);
-    if (!IsActive()) return false;
+    if (!IsActive())
+        return false;
 
-    if (!mousedown) return false;
+    if (!mousedown)
+        return false;
 
     mousedown = false;
 
     return pingslines_renderer.OnMouseUp();
 }
 
-bool Minimap::OnMouseMove(UINT Message, WPARAM wParam, LPARAM lParam) {
+bool Minimap::OnMouseMove(UINT Message, WPARAM wParam, LPARAM lParam)
+{
     UNREFERENCED_PARAMETER(Message);
     UNREFERENCED_PARAMETER(wParam);
     UNREFERENCED_PARAMETER(lParam);
-    if (!IsActive()) return false;
+    if (!IsActive())
+        return false;
 
-    if (!mousedown) return false;
-    
-    int x = GET_X_LPARAM(lParam);
-    int y = GET_Y_LPARAM(lParam);
-    //if (!IsInside(x, y)) return false;
+    if (!mousedown)
+        return false;
+
+    const int x = GET_X_LPARAM(lParam);
+    const int y = GET_Y_LPARAM(lParam);
+    // if (!IsInside(x, y)) return false;
 
     if (IsKeyDown(MinimapModifierBehaviour::Target)) {
         SelectTarget(InterfaceToWorldPoint(Vec2i(x, y)));
@@ -730,30 +776,33 @@ bool Minimap::OnMouseMove(UINT Message, WPARAM wParam, LPARAM lParam) {
     }
 
     if (IsKeyDown(MinimapModifierBehaviour::Move)) {
-        Vec2i diff = Vec2i(x - drag_start.x, y - drag_start.y);
+        const Vec2i diff = Vec2i(x - drag_start.x, y - drag_start.y);
         translation += InterfaceToWorldVector(diff);
         drag_start = Vec2i(x, y);
         last_moved = TIMER_INIT();
         return true;
     }
 
-    GW::Vec2f v = InterfaceToWorldPoint(Vec2i(x, y));
+    const GW::Vec2f v = InterfaceToWorldPoint(Vec2i(x, y));
     return pingslines_renderer.OnMouseMove(v.x, v.y);
 }
 
-bool Minimap::OnMouseWheel(UINT Message, WPARAM wParam, LPARAM lParam) {
+bool Minimap::OnMouseWheel(UINT Message, WPARAM wParam, LPARAM lParam)
+{
     UNREFERENCED_PARAMETER(Message);
     UNREFERENCED_PARAMETER(lParam);
-    if (!IsActive()) return false;
+    if (!IsActive())
+        return false;
 
     // Mouse wheel x and y are in absolute coords, not window coords! (Windows why...)
     const ImVec2 mouse = ImGui::GetMousePos();
-    if (!IsInside((int)mouse.x, (int)mouse.y)) return false;
-    
-    int zDelta = GET_WHEEL_DELTA_WPARAM(wParam);
+    if (!IsInside(static_cast<int>(mouse.x), static_cast<int>(mouse.y)))
+        return false;
+
+    const int zDelta = GET_WHEEL_DELTA_WPARAM(wParam);
 
     if (IsKeyDown(MinimapModifierBehaviour::Move)) {
-        float delta = zDelta > 0 ? 1.024f : 0.9765625f;
+        const float delta = zDelta > 0 ? 1.024f : 0.9765625f;
         scale *= delta;
         return true;
     }
@@ -761,67 +810,60 @@ bool Minimap::OnMouseWheel(UINT Message, WPARAM wParam, LPARAM lParam) {
     return false;
 }
 
-bool Minimap::IsInside(int x, int y) const {
+bool Minimap::IsInside(int x, int y) const
+{
     // if outside square, return false
-    if (x < location.x) return false;
-    if (x > location.x + size.x) return false;
-    if (y < location.y) return false;
-    if (y > location.y + size.y) return false;
+    if (x < location.x)
+        return false;
+    if (x > location.x + size.x)
+        return false;
+    if (y < location.y)
+        return false;
+    if (y > location.y + size.y)
+        return false;
 
     // if centered, use radar range
     if (translation.x == 0 && translation.y == 0) {
-        GW::Vec2f gamepos = InterfaceToWorldPoint(Vec2i(x, y));
-        GW::Agent* me = GW::Agents::GetPlayer();
-        if (!me) return false;
-        float sqrdst = GW::GetSquareDistance(me->pos, gamepos);
+        const GW::Vec2f gamepos = InterfaceToWorldPoint(Vec2i(x, y));
+        GW::Agent *me = GW::Agents::GetPlayer();
+        if (!me)
+            return false;
+        const float sqrdst = GW::GetSquareDistance(me->pos, gamepos);
         return sqrdst < GW::Constants::SqrRange::Compass;
     }
     return true;
 }
-bool Minimap::IsActive() const {
-    return visible
-        && !loading
-        && GW::Map::GetIsMapLoaded()
-        && GW::Map::GetInstanceType() != GW::Constants::InstanceType::Loading
-        && GW::Agents::GetPlayerId() != 0;
+bool Minimap::IsActive() const
+{
+    return visible && !loading && GW::Map::GetIsMapLoaded() && GW::Map::GetInstanceType() != GW::Constants::InstanceType::Loading && GW::Agents::GetPlayerId() != 0;
 }
 
-void Minimap::RenderSetupProjection(IDirect3DDevice9* device) {
+void Minimap::RenderSetupProjection(IDirect3DDevice9 *device) const
+{
     D3DVIEWPORT9 viewport;
     device->GetViewport(&viewport);
 
-    float w = 5000.0f * 2;
+    const float w = 5000.0f * 2;
     // IMPORTANT: we are setting z-near to 0.0f and z-far to 1.0f
-    D3DXMATRIX ortho_matrix(
-        2 / w, 0, 0, 0,
-        0, 2 / w, 0, 0,
-        0, 0, 1, 0,
-        0, 0, 0, 1
-    );
+    const D3DXMATRIX ortho_matrix(2 / w, 0, 0, 0, 0, 2 / w, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
 
     //// note: manually craft the projection to viewport instead of using
-    //// SetViewport to allow target regions outside the viewport 
+    //// SetViewport to allow target regions outside the viewport
     //// e.g. negative x/y for slightly offscreen map
-    float xscale = (float)size.x / viewport.Width;
-    float yscale = (float)size.x / viewport.Height;
-    float xtrans = (float)(location.x * 2 + size.x) / viewport.Width - 1.0f;
-    float ytrans = -(float)(location.y * 2 + size.x) / viewport.Height + 1.0f;
+    const float xscale = static_cast<float>(size.x) / viewport.Width;
+    const float yscale = static_cast<float>(size.x) / viewport.Height;
+    const float xtrans = static_cast<float>(location.x * 2 + size.x) / viewport.Width - 1.0f;
+    const float ytrans = -static_cast<float>(location.y * 2 + size.x) / viewport.Height + 1.0f;
     ////IMPORTANT: we are basically setting z-near to 0 and z-far to 1
-    D3DXMATRIX viewport_matrix(
-        xscale, 0, 0, 0,
-        0, yscale, 0, 0,
-        0, 0, 1, 0,
-        xtrans, ytrans, 0, 1
-    );
+    const D3DXMATRIX viewport_matrix(xscale, 0, 0, 0, 0, yscale, 0, 0, 0, 0, 1, 0, xtrans, ytrans, 0, 1);
 
     D3DXMATRIX proj = ortho_matrix * viewport_matrix;
 
     device->SetTransform(D3DTS_PROJECTION, &proj);
 }
 
-bool Minimap::IsKeyDown(MinimapModifierBehaviour mmb) {
-    return (key_none_behavior  == mmb and not ImGui::IsKeyDown(VK_CONTROL) and not ImGui::IsKeyDown(VK_SHIFT) and not ImGui::IsKeyDown(VK_MENU)) or
-           (key_ctrl_behavior  == mmb and ImGui::IsKeyDown(VK_CONTROL)) or
-           (key_shift_behavior == mmb and ImGui::IsKeyDown(VK_SHIFT)) or
-           (key_alt_behavior   == mmb and ImGui::IsKeyDown(VK_MENU));
+bool Minimap::IsKeyDown(const MinimapModifierBehaviour mmb) const
+{
+    return (key_none_behavior == mmb and not ImGui::IsKeyDown(VK_CONTROL) and not ImGui::IsKeyDown(VK_SHIFT) and not ImGui::IsKeyDown(VK_MENU)) or (key_ctrl_behavior == mmb and ImGui::IsKeyDown(VK_CONTROL)) or (key_shift_behavior == mmb and ImGui::IsKeyDown(VK_SHIFT)) or
+           (key_alt_behavior == mmb and ImGui::IsKeyDown(VK_MENU));
 }

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -287,7 +287,7 @@ void Minimap::SaveSettings(CSimpleIni *ini)
     effect_renderer.SaveSettings(ini, Name());
 }
 
-void Minimap::GetPlayerHeroes(GW::PartyInfo *party, std::vector<GW::AgentID> &_player_heroes)
+void Minimap::GetPlayerHeroes(GW::PartyInfo* party, std::vector<GW::AgentID>& _player_heroes)
 {
     _player_heroes.clear();
     if (!party)
@@ -400,17 +400,17 @@ void Minimap::Draw(IDirect3DDevice9 *device)
                     clipping.bottom = static_cast<long>(cmd->ClipRect.w);
                     device->SetScissorRect(&clipping);
                     device->SetRenderState(D3DRS_SCISSORTESTENABLE, true);
-                    FillRect(color, Instance().location.x, Instance().location.y, Instance().size.x, Instance().size.y);
+                    FillRect(color, Instance().location.x, Instance().location.y, Instance().size.x, Instance().size.y); // fill rect with chosen background color
                 } else {
-                    device->SetRenderState(D3DRS_STENCILENABLE, true); // enable stencil writing
+                    device->SetRenderState(D3DRS_STENCILENABLE, true); // enable stencil testing
                     device->SetRenderState(D3DRS_STENCILMASK, 0xffffffff);
                     device->SetRenderState(D3DRS_STENCILWRITEMASK, 0xffffffff);
                     device->Clear(0, nullptr, D3DCLEAR_ZBUFFER | D3DCLEAR_STENCIL, 0x00000000, 1.0f, 0); // clear depth and stencil buffer
                     device->SetRenderState(D3DRS_STENCILREF, 1);
                     device->SetRenderState(D3DRS_STENCILFUNC, D3DCMP_ALWAYS);
-                    device->SetRenderState(D3DRS_STENCILPASS, D3DSTENCILOP_REPLACE);
+                    device->SetRenderState(D3DRS_STENCILPASS, D3DSTENCILOP_REPLACE); // write ref value into stencil buffer when passed
                     auto radius = Instance().size.x / 2;
-                    FillCircle(Instance().location.x + radius, Instance().location.y + radius, radius, color); // draw transparent circle into stencil buffer - fill with 1's
+                    FillCircle(Instance().location.x + radius, Instance().location.y + radius, radius, color); // draw circle with chosen background color into stencil buffer, fills buffer with 1's
 
                     device->SetRenderState(D3DRS_STENCILFUNC, D3DCMP_EQUAL); // only draw where 1 is in the buffer
                     device->SetRenderState(D3DRS_STENCILFAIL, D3DSTENCILOP_ZERO);

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -257,7 +257,7 @@ void Minimap::LoadSettings(CSimpleIni *ini)
     mouse_clickthrough = ini->GetBoolValue(Name(), VAR_NAME(mouse_clickthrough), false);
     mouse_clickthrough_in_outpost = ini->GetBoolValue(Name(), VAR_NAME(mouse_clickthrough_in_outpost), mouse_clickthrough_in_outpost);
     rotate_minimap = ini->GetBoolValue(Name(), VAR_NAME(rotate_minimap), true);
-    circular_map = ini->GetBoolValue(Name(), VAR_NAME(circular_map), false);
+    circular_map = ini->GetBoolValue(Name(), VAR_NAME(circular_map), true);
     key_none_behavior = static_cast<MinimapModifierBehaviour>(ini->GetLongValue(Name(), VAR_NAME(key_none_behavior), 1));
     key_ctrl_behavior = static_cast<MinimapModifierBehaviour>(ini->GetLongValue(Name(), VAR_NAME(key_ctrl_behavior), 2));
     key_shift_behavior = static_cast<MinimapModifierBehaviour>(ini->GetLongValue(Name(), VAR_NAME(key_shift_behavior), 3));

--- a/GWToolboxdll/Widgets/Minimap/Minimap.h
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.h
@@ -106,6 +106,7 @@ private:
     bool mouse_clickthrough = false;
     bool mouse_clickthrough_in_outpost = false;
     bool rotate_minimap = true;
+    bool circular_map = false;
     MinimapModifierBehaviour key_none_behavior  = MinimapModifierBehaviour::Draw;
     MinimapModifierBehaviour key_ctrl_behavior  = MinimapModifierBehaviour::Target;
     MinimapModifierBehaviour key_shift_behavior = MinimapModifierBehaviour::Move;

--- a/GWToolboxdll/Widgets/Minimap/Minimap.h
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.h
@@ -14,7 +14,7 @@
 #include <Widgets/Minimap/SymbolsRenderer.h>
 #include <Widgets/Minimap/VBuffer.h>
 
-class Minimap : public ToolboxWidget {
+class Minimap final : public ToolboxWidget {
     struct Vec2i {
         Vec2i(int _x, int _y) : x(_x), y(_y) {}
         Vec2i() : x(0), y(0) {}
@@ -49,7 +49,7 @@ public:
     void Terminate() override;
 
     void Draw(IDirect3DDevice9* device) override;
-    void RenderSetupProjection(IDirect3DDevice9* device);
+    void RenderSetupProjection(IDirect3DDevice9* device) const;
     
     bool FlagHeros(LPARAM lParam);
     bool OnMouseDown(UINT Message, WPARAM wParam, LPARAM lParam);
@@ -64,7 +64,7 @@ public:
     void SaveSettings(CSimpleIni* ini) override;
     void DrawSettingInternal() override;
 
-    float GetMapRotation();
+    float GetMapRotation() const;
 
     // 0 is 'all' flag, 1 to 7 is each hero
     void FlagHero(unsigned int idx) {
@@ -87,7 +87,7 @@ private:
     GW::Vec2f InterfaceToWorldPoint(Vec2i pos) const;
     GW::Vec2f InterfaceToWorldVector(Vec2i pos) const;
     void SelectTarget(GW::Vec2f pos);
-    bool IsKeyDown(MinimapModifierBehaviour mmb);
+    bool IsKeyDown(MinimapModifierBehaviour mmb) const;
 
     bool mousedown = false;
 

--- a/GWToolboxdll/Widgets/Minimap/Minimap.h
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.h
@@ -108,7 +108,7 @@ private:
     bool mouse_clickthrough = false;
     bool mouse_clickthrough_in_outpost = false;
     bool rotate_minimap = true;
-    bool circular_map = false;
+    bool circular_map = true;
     MinimapModifierBehaviour key_none_behavior  = MinimapModifierBehaviour::Draw;
     MinimapModifierBehaviour key_ctrl_behavior  = MinimapModifierBehaviour::Target;
     MinimapModifierBehaviour key_shift_behavior = MinimapModifierBehaviour::Move;

--- a/GWToolboxdll/Widgets/Minimap/Minimap.h
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.h
@@ -20,7 +20,9 @@ class Minimap final : public ToolboxWidget {
         Vec2i() : x(0), y(0) {}
         int x, y;
     };
-    Minimap() {};
+    Minimap() {
+        is_resizable = false;
+    };
     Minimap(const Minimap&) = delete;
     ~Minimap() {};
 public:

--- a/GWToolboxdll/Widgets/Minimap/PmapRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/PmapRenderer.cpp
@@ -56,7 +56,7 @@ void PmapRenderer::Initialize(IDirect3DDevice9* device) {
 
     // get the number of trapezoids, need it to allocate the vertex buffer
     trapez_count_ = 0;
-    for (auto &map : path_map) {
+    for (const GW::PathingMap& map : path_map) {
         trapez_count_ += map.trapezoid_count;
     }
     if (trapez_count_ == 0) return;
@@ -122,7 +122,7 @@ void PmapRenderer::Initialize(IDirect3DDevice9* device) {
 
     // populate vertex buffer
     for (auto k = 0; k < (shadow_show ? 2 : 1); ++k) {
-        for (auto pmap : path_map) {
+        for (const GW::PathingMap& pmap : path_map) {
             for (size_t j = 0; j < pmap.trapezoid_count; ++j) {
                 GW::PathingTrapezoid& trap = pmap.trapezoids[j];
 

--- a/GWToolboxdll/Widgets/Minimap/PmapRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/PmapRenderer.h
@@ -12,12 +12,14 @@ public:
     void DrawSettings();
     void LoadSettings(CSimpleIni* ini, const char* section);
     void SaveSettings(CSimpleIni* ini, const char* section) const;
+    Color GetBackgroundColor() { return color_mapbackground; }
 
 protected:
     void Initialize(IDirect3DDevice9* device) override;
 private:
     Color color_map = 0;
     Color color_mapshadow = 0;
+    Color color_mapbackground = 0;
 
     size_t trapez_count_ = 0;
     size_t tri_count_ = 0; // of just 1 batch (map)


### PR DESCRIPTION
the location for the map background colour might be a bit messed up (since it's in pmaprenderer now but drawn in minimap.cpp) but it's where I would've expected it in the settings

suggestions welcome

as for the circular settings that's just preparation for until I figure out how to actually only draw the circle. it still looks neat now with the background though