### PR TITLE
add command /hero <attack|guard|avoid> to adjust hero behaviour

### DIFF
--- a/GWToolboxdll/Modules/ChatCommands.h
+++ b/GWToolboxdll/Modules/ChatCommands.h
@@ -77,6 +77,8 @@ private:
     static void CmdTransmoTarget(const wchar_t* message, int argc, LPWSTR* argv);
     static void CmdTransmoParty(const wchar_t* message, int argc, LPWSTR* argv);
     static void CmdTransmoAgent(const wchar_t* message, int argc, LPWSTR* argv);
+    static void CmdHero(const wchar_t* message, int argc, LPWSTR* argv);
+
     
     static void TransmoAgent(DWORD agent_id, PendingTransmo& transmo);
     static bool GetNPCInfoByName(const std::string name, PendingTransmo &transmo);


### PR DESCRIPTION
Hi,

I would like to add some extra functionality to easily adjust hero behaviour in a party. A simple command is fine I think but it could be extended to be used as a hotkey. Using the command 

`/hero <behaviour>` 

The heroes that belong to the current player will have their behaviour adjusted. 

The command can take 1 argument with the values 

- attack
- guard
- avoid 

Thanks to the guys on discord who helped me out :)
