### PR TITLE
add command /hero <attack|guard|avoid> to adjust hero behaviour

### DIFF
--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -1243,11 +1243,9 @@ void ChatCommands::CmdReapplyTitle(const wchar_t* message, int argc, LPWSTR* arg
 }
 void ChatCommands::CmdHero(const wchar_t* message, int argc, LPWSTR* argv)
 {
-    GW::HookEntry hookentry;
     if (argc < 2)
         return Log::Error("Missing argument for /hero. It can be one of: avoid | guard | attack");
     std::wstring arg1 = GuiUtils::ToLower(argv[1]);
-
     const wchar_t* name = next_word(message);
 
     GW::PartyInfo* party_info = GW::PartyMgr::GetPartyInfo();
@@ -1258,8 +1256,8 @@ void ChatCommands::CmdHero(const wchar_t* message, int argc, LPWSTR* argv)
         return Log::Error("Party heroes validation failed");
 
     //detect the correct owner id for current player
-    auto me = GW::Agents::GetPlayer();
-    auto players = party_info->players;
+    GW::Agent* me = GW::Agents::GetPlayer();
+    GW::PlayerPartyMemberArray players = party_info->players;
     uint32_t ownerId;
     for (GW::PlayerPartyMember partyPlayer : players) {
         auto player = GW::PlayerMgr::GetPlayerByID(partyPlayer.login_number);

--- a/GWToolboxdll/Modules/ChatCommands.h
+++ b/GWToolboxdll/Modules/ChatCommands.h
@@ -77,6 +77,8 @@ private:
     static void CmdTransmoTarget(const wchar_t* message, int argc, LPWSTR* argv);
     static void CmdTransmoParty(const wchar_t* message, int argc, LPWSTR* argv);
     static void CmdTransmoAgent(const wchar_t* message, int argc, LPWSTR* argv);
+    static void CmdHero(const wchar_t* message, int argc, LPWSTR* argv);
+
     
     static void TransmoAgent(DWORD agent_id, PendingTransmo& transmo);
     static bool GetNPCInfoByName(const std::string name, PendingTransmo &transmo);


### PR DESCRIPTION
Hi,

I would like to add some extra functionality to easily adjust hero behaviour in a party. A simple command is fine I think but it could be extended to be used as a hotkey. Using the command

/hero <behaviour>

The heroes that belong to the current player will have their behaviour adjusted.

The command can take 1 argument with the values

    attack
    guard
    avoid

Thanks to the guys on discord who helped me out :)