### PR TITLE
observer mode upgrades

### DIFF
--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -234,7 +234,6 @@ void ChatCommands::DrawHelp() {
         "'/damage <number>' sends the damage of a party member (e.g. '/damage 3').\n"
         "'/damage reset' resets the damage in party window.");
     ImGui::Bullet(); ImGui::Text("'/observer:reset' resets observer mode data.");
-    ImGui::Bullet(); ImGui::Text("'/observer:explorable' enables/disables the observer mode module to run in any explorable area.");
     ImGui::Bullet(); ImGui::Text("'/dialog <id>' sends a dialog.");
     ImGui::Bullet(); ImGui::Text("'/flag [all|clear|<number>]' to flag a hero in the minimap (same as using the buttons by the minimap).");
     ImGui::Bullet(); ImGui::Text("'/flag [all|<number>] [x] [y]' to flag a hero to coordinates [x],[y].");
@@ -343,7 +342,6 @@ void ChatCommands::Initialize() {
     GW::Chat::CreateCommand(L"damage", ChatCommands::CmdDamage);
     GW::Chat::CreateCommand(L"dmg", ChatCommands::CmdDamage);
     GW::Chat::CreateCommand(L"observer:reset", ChatCommands::CmdObserverReset);
-    GW::Chat::CreateCommand(L"observer:explorable", ChatCommands::CmdObserverToggleExplorable);
 
     GW::Chat::CreateCommand(L"chest", ChatCommands::CmdChest);
     GW::Chat::CreateCommand(L"xunlai", ChatCommands::CmdChest);
@@ -768,14 +766,6 @@ void ChatCommands::CmdObserverReset(const wchar_t* message, int argc, LPWSTR* ar
     UNREFERENCED_PARAMETER(argc);
     UNREFERENCED_PARAMETER(argv);
     ObserverModule::Instance().Reset();
-}
-
-
-void ChatCommands::CmdObserverToggleExplorable(const wchar_t* message, int argc, LPWSTR* argv) {
-    UNREFERENCED_PARAMETER(message);
-    UNREFERENCED_PARAMETER(argc);
-    UNREFERENCED_PARAMETER(argv);
-    ObserverModule::Instance().ToggleEnableExplorableAreas();
 }
 
 

--- a/GWToolboxdll/Modules/ChatCommands.h
+++ b/GWToolboxdll/Modules/ChatCommands.h
@@ -65,7 +65,6 @@ private:
     static void CmdTB(const wchar_t *message, int argc, LPWSTR *argv);
     static void CmdDamage(const wchar_t *message, int argc, LPWSTR *argv);
     static void CmdObserverReset(const wchar_t* message, int argc, LPWSTR* argv);
-    static void CmdObserverToggleExplorable(const wchar_t* message, int argc, LPWSTR* argv);
     static void CmdChest(const wchar_t *message, int argc, LPWSTR *argv);
     static void CmdAfk(const wchar_t *message, int argc, LPWSTR *argv);
     static void CmdTarget(const wchar_t *message, int argc, LPWSTR *argv);

--- a/GWToolboxdll/Modules/ObserverModule.cpp
+++ b/GWToolboxdll/Modules/ObserverModule.cpp
@@ -11,10 +11,13 @@
 #include <GWCA/Managers/StoCMgr.h>
 #include <GWCA/Managers/AgentMgr.h>
 #include <GWCA/Managers/PlayerMgr.h>
+#include <GWCA/Managers/GuildMgr.h>
 #include <GWCA/Managers/PartyMgr.h>
 #include <GWCA/Managers/RenderMgr.h>
 #include <GWCA/Managers/UIMgr.h>
 
+#include <GWCA/GameEntities/Map.h>
+#include <GWCA/GameEntities/Guild.h>
 #include <GWCA/GameEntities/Agent.h>
 #include <GWCA/GameEntities/Party.h>
 #include <GWCA/GameEntities/Player.h>
@@ -33,13 +36,13 @@
 #define INI_FILENAME L"observerlog.ini"
 #define IniSection "observer"
 
-#define NO_AGENT 0
-#define NO_PARTY 0
-#define NO_SKILL 0
-#define NO_TEAM 0
 
 namespace ObserverLabel {
+    const char* Profession = "Prf";
     const char* Name = "Name";
+    const char* PlayerGuildTag = "Tag";
+    const char* PlayerGuildRating = "Rtg";
+    const char* PlayerGuildRank = "Rnk";
     const char* Kills = "K";
     const char* Deaths = "D";
     const char* KDR = "KDR";
@@ -56,19 +59,10 @@ namespace ObserverLabel {
 }; // namespace ObserverLabels
 
 
-// TODO: replace with GWCA
-struct AgentProjectileLaunched : GW::Packet::StoC::Packet<AgentProjectileLaunched> {
-    uint32_t agent_id;
-    GW::Vec2f destination;
-    uint32_t unk1;          // word : 0 ?
-    uint32_t unk2;          // dword: changes with projectile animation model
-    uint32_t unk3;          // dword: value (143) for all martial weapons (?), n values for n skills (?)
-    uint32_t unk4;          // dword: 1 ?
-    uint32_t is_attack;     // byte
-};
-const uint32_t GW::Packet::StoC::Packet<AgentProjectileLaunched>::STATIC_HEADER = (0x00A3); // 163
-
-
+// Destructor
+ObserverModule::~ObserverModule() {
+    Reset();
+}
 
 void ObserverModule::Initialize()
 {
@@ -103,17 +97,16 @@ void ObserverModule::Initialize()
             HandleAgentAdd(packet->agent_id);
         });
 
-    GW::StoC::RegisterPacketCallback<AgentProjectileLaunched>(
-        &AgentProjectileLaunched_Entry, [this](GW::HookStatus* status, AgentProjectileLaunched* packet) -> void {
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::AgentProjectileLaunched>(
+        &AgentProjectileLaunched_Entry,
+        [this](GW::HookStatus* status, GW::Packet::StoC::AgentProjectileLaunched* packet) -> void {
             UNREFERENCED_PARAMETER(status);
             if (!IsActive()) return;
             if (!observer_session_initialized) {
                 if (!InitializeObserverSession()) return;
             }
-
             HandleAgentProjectileLaunched(packet->agent_id, (packet->is_attack == 0) ? false : true);
-        }
-    );
+        });
 
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericModifier>(
         &GenericModifier_Entry,
@@ -195,6 +188,13 @@ void ObserverModule::Terminate() {
 }
 
 
+// Is the Module actively tracking agents?
+const bool ObserverModule::IsActive() {
+    // an observer match is considered an explorable area
+    return is_enabled && is_explorable && (enable_in_explorable_areas || is_observer);
+}
+
+
 // Handle InstanceLoadInfo Packet
 void ObserverModule::HandleInstanceLoadInfo(GW::HookStatus* status, GW::Packet::StoC::InstanceLoadInfo *packet) {
     UNREFERENCED_PARAMETER(status);
@@ -223,19 +223,19 @@ void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t
     UNREFERENCED_PARAMETER(no_target);
 
     switch (value_id) {
-        case (uint32_t)ObserverModule::GenericValueId2::damage:
+        case GW::Packet::StoC::GenericValueID::damage:
             HandleDamageDone(caster_id, target_id, value, false);
             break;
 
-        case (uint32_t)ObserverModule::GenericValueId2::critical:
+        case GW::Packet::StoC::GenericValueID::critical:
             HandleDamageDone(caster_id, target_id, value, true);
             break;
 
-        case (uint32_t)ObserverModule::GenericValueId2::armorignoring:
+        case GW::Packet::StoC::GenericValueID::armorignoring:
             HandleDamageDone(caster_id, target_id, value, false);
             break;
 
-        case (uint32_t)ObserverModule::GenericValueId2::knocked_down:
+        case GW::Packet::StoC::GenericValueID::knocked_down:
             HandleKnockedDown(caster_id, value);
             break;
     };
@@ -246,15 +246,15 @@ void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t
     const uint32_t target_id, const uint32_t value, const bool no_target) {
 
     switch (value_id) {
-        case (uint32_t)ObserverModule::GenericValueId2::attack_finished:
+        case GW::Packet::StoC::GenericValueID::melee_attack_finished:
             HandleAttackFinished(caster_id);
             break;
 
-        case (uint32_t)ObserverModule::GenericValueId2::attack_stopped:
+        case GW::Packet::StoC::GenericValueID::attack_stopped:
             HandleAttackStopped(caster_id);
             break;
 
-        case (uint32_t)ObserverModule::GenericValueId2::attack_started: {
+        case GW::Packet::StoC::GenericValueID::attack_started: {
             // swap target and caster for skill_activated
             // log
             uint32_t _caster_id;
@@ -273,23 +273,23 @@ void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t
             break;
         }
 
-        case (uint32_t)ObserverModule::GenericValueId2::interrupted:
+        case GW::Packet::StoC::GenericValueID::interrupted:
             HandleInterrupted(caster_id);
             break;
 
-        case (uint32_t)ObserverModule::GenericValueId2::attack_skill_finsihed:
+        case GW::Packet::StoC::GenericValueID::attack_skill_finished:
             HandleAttackSkillFinished(caster_id);
             break;
 
-        case (uint32_t)ObserverModule::GenericValueId2::instant_skill_activated:
+        case GW::Packet::StoC::GenericValueID::instant_skill_activated:
             HandleInstantSkillActivated(caster_id, target_id, value);
             break;
 
-        case (uint32_t)ObserverModule::GenericValueId2::attack_skill_stopped:
+        case GW::Packet::StoC::GenericValueID::attack_skill_stopped:
             HandleAttackSkillStopped(caster_id);
             break;
 
-        case (uint32_t)ObserverModule::GenericValueId2::attack_skill_activated: {
+        case GW::Packet::StoC::GenericValueID::attack_skill_activated: {
             // swap target and caster for skill_activated
             // log
             uint32_t _caster_id;
@@ -308,15 +308,15 @@ void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t
             break;
         }
 
-        case (uint32_t)ObserverModule::GenericValueId2::skill_finished:
+        case GW::Packet::StoC::GenericValueID::skill_finished:
             HandleSkillFinished(caster_id);
             break;
 
-        case (uint32_t)ObserverModule::GenericValueId2::skill_stopped:
+        case GW::Packet::StoC::GenericValueID::skill_stopped:
             HandleSkillStopped(caster_id);
             break;
 
-        case (uint32_t)ObserverModule::GenericValueId2::skill_activated: {
+        case GW::Packet::StoC::GenericValueID::skill_activated: {
             // TODO: do location effecs cause entry here?
             // if so, Isle of the Dead, Burning Isle, Isle of Meditation,
             // Frozen Isle, Isle of Weeping Stone, etc... might slow down
@@ -617,18 +617,18 @@ void ObserverModule::ReduceAction(ObservableAgent* caster, const TargetAction& a
     if (action.is_attack) {
         // update the caster
         if (caster) {
-            caster->stats.total_attacks_done.Reduce(stage);
+            caster->stats.total_attacks_dealt.Reduce(stage);
             if (target) caster->stats.LazyGetAttacksDealedAgainst(target->agent_id).Reduce(stage);
             // if the target belonged to a party, the caster just attacked that other party
-            if (target_party) caster->stats.total_attacks_done_on_other_party.Reduce(stage);
+            if (target_party) caster->stats.total_attacks_dealt_to_other_party.Reduce(stage);
 
         }
 
         // update the casters party
         if (caster_party) {
-            caster_party->stats.total_attacks_done.Reduce(stage);
+            caster_party->stats.total_attacks_dealt.Reduce(stage);
             // if the target belonged to a party, the casters party just attacked that other party
-            if (target_party) caster_party->stats.total_attacks_done_on_other_party.Reduce(stage);
+            if (target_party) caster_party->stats.total_attacks_dealt_to_other_party.Reduce(stage);
         }
 
         // update the target
@@ -636,14 +636,14 @@ void ObserverModule::ReduceAction(ObservableAgent* caster, const TargetAction& a
             target->stats.total_attacks_received.Reduce(stage);
             if (caster) target->stats.LazyGetAttacksReceivedFrom(caster->agent_id).Reduce(stage);
             // if the caster belonged to a party, the target was just attacked by that other party
-            if (caster_party) target->stats.total_attacks_received_by_other_party.Reduce(stage);
+            if (caster_party) target->stats.total_attacks_received_from_other_party.Reduce(stage);
         }
 
         // update the targets party
         if (target_party) {
             target_party->stats.total_attacks_received.Reduce(stage);
             // if the caster belonged to a party, the target_party was just attacked by that other party
-            if (caster_party) target_party->stats.total_attacks_received_by_other_party.Reduce(stage);
+            if (caster_party) target_party->stats.total_attacks_received_from_other_party.Reduce(stage);
         }
     }
 
@@ -670,11 +670,10 @@ void ObserverModule::ReduceAction(ObservableAgent* caster, const TargetAction& a
         switch (target_type) {
             case (uint32_t) TargetType::no_target: {
                 // For stats purposes, consider as "used on self"
-                // but not "used on party"
                 // e.g. Sprint, Whirlwind
                 if (action.target_id == NO_AGENT) {
                     target = caster;
-                    target_party = nullptr;
+                    target_party = caster_party;
                 }
                 break;
             }
@@ -708,8 +707,22 @@ void ObserverModule::ReduceAction(ObservableAgent* caster, const TargetAction& a
         same_team = caster && target && (caster->team_id != NO_TEAM) && (caster->team_id == target->team_id);
         same_party = target_party && caster_party && (target_party->party_id == caster_party->party_id);
 
-        skill->total_usages.Reduce(stage);
-        if (target_party) skill->total_party_target_usages.Reduce(stage);
+        // notify the skill
+        skill->stats.total_usages.Reduce(stage);
+        if (target) {
+            // target usages
+            if (caster == target) skill->stats.total_self_usages.Reduce(stage);
+            else skill->stats.total_other_usages.Reduce(stage);
+
+            // team usages
+            if (same_team) skill->stats.total_own_team_usages.Reduce(stage);
+            else skill->stats.total_own_team_usages.Reduce(stage);
+        }
+        if (target_party) {
+            // party usages
+            if (caster_party == target_party) skill->stats.total_own_party_usages.Reduce(stage);
+            else skill->stats.total_other_party_usages.Reduce(stage);
+        }
 
         // notify the caster
         if (caster) {
@@ -719,13 +732,13 @@ void ObserverModule::ReduceAction(ObservableAgent* caster, const TargetAction& a
             // used against a target?
             if (target) {
                 // use against agent
-                caster->stats.LazyGetSkillUsedAgainst(target->agent_id, action.skill_id).Reduce(stage);
+                caster->stats.LazyGetSkillUsedOn(target->agent_id, action.skill_id).Reduce(stage);
 
                 // team:
                 // same team
                 if (same_team) caster->stats.total_skills_used_on_own_team.Reduce(stage);
                 // diff team
-                else caster->stats.total_skills_used_on_other_team.Reduce(stage);
+                else caster->stats.total_skills_used_on_other_teams.Reduce(stage);
             }
 
             // party:
@@ -733,7 +746,7 @@ void ObserverModule::ReduceAction(ObservableAgent* caster, const TargetAction& a
                 // same party
                 if (same_party) caster->stats.total_skills_used_on_own_party.Reduce(stage);
                 // diff party
-                else caster->stats.total_skills_used_on_other_party.Reduce(stage);
+                else caster->stats.total_skills_used_on_other_parties.Reduce(stage);
             }
         }
 
@@ -745,14 +758,14 @@ void ObserverModule::ReduceAction(ObservableAgent* caster, const TargetAction& a
             // same team
             if (same_team) caster_party->stats.total_skills_used_on_own_team.Reduce(stage);
             // diff team
-            else caster_party->stats.total_skills_used_on_other_team.Reduce(stage);
+            else caster_party->stats.total_skills_used_on_other_teams.Reduce(stage);
 
             // party:
             if (target_party) {
                 // same party
                 if (same_party) caster_party->stats.total_skills_used_on_own_party.Reduce(stage);
                 // diff party
-                else caster_party->stats.total_skills_used_on_other_party.Reduce(stage);
+                else caster_party->stats.total_skills_used_on_other_parties.Reduce(stage);
             }
         }
 
@@ -767,17 +780,17 @@ void ObserverModule::ReduceAction(ObservableAgent* caster, const TargetAction& a
 
                 // team
                 // same team
-                if (same_team) target->stats.total_skills_received_by_own_team.Reduce(stage);
+                if (same_team) target->stats.total_skills_received_from_own_team.Reduce(stage);
                 // diff team
-                else target->stats.total_skills_received_by_other_team.Reduce(stage);
+                else target->stats.total_skills_received_from_other_teams.Reduce(stage);
             }
 
             // party:
             if (caster_party) {
                 // same party
-                if (same_party) target->stats.total_skills_received_by_own_party.Reduce(stage);
+                if (same_party) target->stats.total_skills_received_from_own_party.Reduce(stage);
                 // diff party
-                else target->stats.total_skills_received_by_other_party.Reduce(stage);
+                else target->stats.total_skills_received_from_other_parties.Reduce(stage);
             }
         }
 
@@ -787,16 +800,16 @@ void ObserverModule::ReduceAction(ObservableAgent* caster, const TargetAction& a
 
             // team:
             // same team
-            if (same_team) target_party->stats.total_skills_received_by_own_team.Reduce(stage);
+            if (same_team) target_party->stats.total_skills_received_from_own_team.Reduce(stage);
             // diff team
-            else target_party->stats.total_skills_received_by_other_team.Reduce(stage);
+            else target_party->stats.total_skills_received_from_other_teams.Reduce(stage);
 
             // party:
             if (caster_party) {
                 // same party
-                if (same_party) target_party->stats.total_skills_received_by_own_party.Reduce(stage);
+                if (same_party) target_party->stats.total_skills_received_from_own_party.Reduce(stage);
                 // diff party
-                else target_party->stats.total_skills_received_by_other_party.Reduce(stage);
+                else target_party->stats.total_skills_received_from_other_parties.Reduce(stage);
             }
         }
     }
@@ -804,17 +817,28 @@ void ObserverModule::ReduceAction(ObservableAgent* caster, const TargetAction& a
 
 // Module: Reset the Modules state
 void ObserverModule::Reset() {
+    if (map) {
+        delete map;
+        map = nullptr;
+    }
+
+    // clear guild info
+    observable_guild_ids.clear();
+    for (const auto& [_, guild] : observable_guilds) if (guild) delete guild;
+    observable_guilds.clear();
+
     // clear skill info
+    observable_skill_ids.clear();
     for (const auto& [_, skill] : observable_skills) if (skill) delete skill;
     observable_skills.clear();
 
     // clear agent info
+    observable_agent_ids.clear();
     for (const auto& [_, agent] : observable_agents) if (agent) delete agent;
     observable_agents.clear();
 
     // clear party info
     observable_party_ids.clear();
-    observable_parties_array.clear();
     for (const auto& [_, party] : observable_parties) if (party) delete party;
     observable_parties.clear();
 }
@@ -823,6 +847,10 @@ void ObserverModule::Reset() {
 // Load all known ObservableAgent's on the current map
 // Returns false if failed to initialise. True if successful
 bool ObserverModule::InitializeObserverSession() {
+    // load area
+    GW::AreaInfo* map_info = GW::Map::GetCurrentMapInfo();
+    if (!map_info) return false;
+
     // load parties
     if (!SynchroniseParties()) return false;
 
@@ -837,9 +865,14 @@ bool ObserverModule::InitializeObserverSession() {
         GetObservableAgentById(agent->agent_id);
     }
 
+    // initialise the map
+    if (map) delete map;
+    map = new ObservableMap(*map_info);
+
     observer_session_initialized = true;
     return true;
 }
+
 
 // Synchronise known parties in the area
 bool ObserverModule::SynchroniseParties() {
@@ -852,9 +885,11 @@ bool ObserverModule::SynchroniseParties() {
     for (const GW::PartyInfo* party_info : parties) {
         if (!party_info) continue;
         // load and synchronize the party
-        ObserverModule::ObservableParty& observable_party = GetObservablePartyByPartyInfo(*party_info);
-        bool party_synchronised = observable_party.SynchroniseParty();
-        if (!party_synchronised) return false;
+        ObserverModule::ObservableParty* observable_party = GetObservablePartyByPartyInfo(*party_info);
+        if (observable_party) {
+            bool party_synchronised = observable_party->SynchroniseParty();
+            if (!party_synchronised) return false;
+        }
     }
 
     // success
@@ -865,7 +900,9 @@ bool ObserverModule::SynchroniseParties() {
 // Load settings
 void ObserverModule::LoadSettings(CSimpleIni* ini) {
     ToolboxModule::LoadSettings(ini);
-    is_enabled = ini->GetBoolValue(Name(), VAR_NAME(is_enabled), true);
+    is_enabled                  = ini->GetBoolValue(Name(), VAR_NAME(is_enabled), true);
+    trim_hench_names            = ini->GetBoolValue(Name(), VAR_NAME(trim_hench_names), false);
+    enable_in_explorable_areas  = ini->GetBoolValue(Name(), VAR_NAME(enable_in_explorable_areas), false);
 }
 
 
@@ -873,16 +910,20 @@ void ObserverModule::LoadSettings(CSimpleIni* ini) {
 void ObserverModule::SaveSettings(CSimpleIni* ini) {
     ToolboxModule::SaveSettings(ini);
     ini->SetBoolValue(Name(), VAR_NAME(is_enabled), is_enabled);
+    ini->SetBoolValue(Name(), VAR_NAME(trim_hench_names), trim_hench_names);
+    ini->SetBoolValue(Name(), VAR_NAME(enable_in_explorable_areas), enable_in_explorable_areas);
+    
 }
 
 
 // Draw internal settings
 void ObserverModule::DrawSettingInternal() {
     ImGui::Text("Enable data collection in Observer Mode.");
-    ImGui::Text("DISABLE if not using this feature to avoid using extra CPU and memory in Observer Mode.");
+    ImGui::Text("Disable if not using this feature to avoid using extra CPU and memory in Observer Mode.");
     ImGui::Checkbox("Enabled", &is_enabled);
+    ImGui::Checkbox("Trim henchman names", &trim_hench_names);
+    ImGui::Checkbox("Enable in all Explorable Areas", &enable_in_explorable_areas);
 }
-
 
 
 void ObserverModule::Update(float delta) {
@@ -898,6 +939,42 @@ void ObserverModule::Update(float delta) {
     }
 }
 
+// Lazy load an ObservableGuild using a guild_id
+ObserverModule::ObservableGuild* ObserverModule::GetObservableGuildById(const uint32_t guild_id) {
+    // shortcircuit for agent_id = 0
+    if (guild_id == NO_GUILD) return nullptr;
+
+    // lazy load
+    auto it = observable_guilds.find(guild_id);
+
+    // found
+    if (it != observable_guilds.end()) return it->second;
+
+    // create if active
+    if (!IsActive()) return nullptr;
+    const GW::GuildArray guilds = GW::GuildMgr::GetGuildArray();
+    if (!guilds.valid() && guild_id >= guilds.size()) return nullptr;
+    GW::Guild* guild = guilds[guild_id];
+    if (!guild) return nullptr;
+
+    ObserverModule::ObservableGuild* observable_guild = CreateObservableGuild(*guild);
+    return observable_guild;
+}
+
+
+// Create an ObservableGuild from a GW::Guild and cache it
+// Do NOT call this if the Agent already exists, it will cause a memory leak
+ObserverModule::ObservableGuild* ObserverModule::CreateObservableGuild(const GW::Guild& guild) {
+    // create
+    ObserverModule::ObservableGuild* observable_guild = new ObserverModule::ObservableGuild(*this, guild);
+    // cache
+    observable_guilds.insert({ observable_guild->guild_id, observable_guild });
+    observable_guild_ids.push_back(observable_guild->guild_id);
+    std::sort(observable_guild_ids.begin(), observable_guild_ids.end());
+    return observable_guild;
+}
+
+
 
 // Lazy load an ObservableAgent using an agent_id
 ObserverModule::ObservableAgent* ObserverModule::GetObservableAgentById(const uint32_t agent_id) {
@@ -910,34 +987,31 @@ ObserverModule::ObservableAgent* ObserverModule::GetObservableAgentById(const ui
     // found
     if (it != observable_agents.end()) return it->second;
 
-    // try create
+    // create if active
+    if (!IsActive()) return nullptr;
     const GW::Agent* agent = GW::Agents::GetAgentByID(agent_id);
     if (!agent) return nullptr;
 
     const GW::AgentLiving* agent_living = agent->GetAsAgentLiving();
     if (!agent_living) return nullptr;
 
-    ObserverModule::ObservableAgent& observable_agent = CreateObservableAgent(*agent_living);
-    return (&observable_agent);
+    ObserverModule::ObservableAgent* observable_agent = CreateObservableAgent(*agent_living);
+    return observable_agent;
 }
-
 
 
 // Create an ObservableAgent from a GW::AgentLiving and cache it
 // Do NOT call this if the Agent already exists, it will cause a memory leak
-ObserverModule::ObservableAgent& ObserverModule::CreateObservableAgent(const GW::AgentLiving& agent_living) {
+ObserverModule::ObservableAgent* ObserverModule::CreateObservableAgent(const GW::AgentLiving& agent_living) {
+    // create
+    // ensure the guild is loaded...
+    GetObservableGuildById(static_cast<uint32_t>(agent_living.tags->guild_id));
     ObserverModule::ObservableAgent* observable_agent = new ObserverModule::ObservableAgent(*this, agent_living);
+    // cache
     observable_agents.insert({ observable_agent->agent_id, observable_agent });
-    return *observable_agent;
-}
-
-
-// Create an ObservableSkill from a GW::Skill and cache it
-// Do NOT call this is if the Skill already exists, It will cause a memory leak
-ObserverModule::ObservableSkill& ObserverModule::CreateObservableSkill(const GW::Skill& gw_skill) {
-    ObservableSkill* observable_skill = new ObservableSkill(*this, gw_skill);
-    observable_skills.insert({ gw_skill.skill_id, observable_skill });
-    return *observable_skill;
+    observable_agent_ids.push_back(observable_agent->agent_id);
+    std::sort(observable_agent_ids.begin(), observable_agent_ids.end());
+    return observable_agent;
 }
 
 
@@ -952,23 +1026,40 @@ ObserverModule::ObservableSkill* ObserverModule::GetObservableSkillById(uint32_t
     // found
     if (it_existing != observable_skills.end()) return it_existing->second;
 
+    // create if active
+    if (!IsActive()) return nullptr;
     const GW::Skill& gw_skill = GW::SkillbarMgr::GetSkillConstantData(skill_id);
     if (gw_skill.skill_id == 0) return nullptr;
-    ObservableSkill& skill = CreateObservableSkill(gw_skill);
-    return &skill;
+    ObservableSkill* skill = CreateObservableSkill(gw_skill);
+    return skill;
 }
 
 
-// Create an ObservableParty and cache it
-// Do NOT call this if the party already exists, will cause memory leak
-ObserverModule::ObservableParty& ObserverModule::CreateObservableParty(const GW::PartyInfo& party_info) {
+
+// Create an ObservableSkill from a GW::Skill and cache it
+// Do NOT call this is if the Skill already exists, It will cause a memory leak
+ObserverModule::ObservableSkill* ObserverModule::CreateObservableSkill(const GW::Skill& gw_skill) {
     // create
-    ObservableParty* party = new ObservableParty(*this, party_info);
+    ObservableSkill* observable_skill = new ObservableSkill(*this, gw_skill);
     // cache
-    observable_parties.insert({ party->party_id, party });
-    observable_party_ids.push_back(party->party_id);
-    ReorderAndCacheParties();
-    return *party;
+    observable_skills.insert({ gw_skill.skill_id, observable_skill });
+    observable_skill_ids.push_back(observable_skill->skill_id);
+    std::sort(observable_skill_ids.begin(), observable_skill_ids.end());
+    return observable_skill;
+}
+
+
+// Lazy load an ObservableParty using a PartyInfo
+ObserverModule::ObservableParty* ObserverModule::GetObservablePartyByPartyInfo(const GW::PartyInfo& party_info) {
+    // lazy load
+    auto it_observable_party = observable_parties.find(party_info.party_id);
+    // found
+    if (it_observable_party != observable_parties.end()) return it_observable_party->second;
+
+    // create if active
+    if (!IsActive()) return nullptr;
+    ObserverModule::ObservableParty* observable_party = this->CreateObservableParty(party_info);
+    return observable_party;
 }
 
 
@@ -983,10 +1074,8 @@ ObserverModule::ObservableParty* ObserverModule::GetObservablePartyById(const ui
     // found
     if (it_party != observable_parties.end()) return it_party->second;
 
-    // not found
-    // try to create
-
-    // get party ctx
+    // create if active
+    if (!IsActive()) return nullptr;
     const GW::PartyContext* party_ctx = GW::GameContext::instance()->party;
     if (!party_ctx) return nullptr;
 
@@ -1000,25 +1089,268 @@ ObserverModule::ObservableParty* ObserverModule::GetObservablePartyById(const ui
     if (!party_info) return nullptr;
 
     // create
-    ObservableParty& observable_party = CreateObservableParty(*party_info);
+    ObservableParty* observable_party = CreateObservableParty(*party_info);
 
-    return &observable_party;
+    return observable_party;
 }
 
 
-// Lazy load an ObservableParty using a PartyInfo
-ObserverModule::ObservableParty& ObserverModule::GetObservablePartyByPartyInfo(const GW::PartyInfo& party_info) {
-    // lazy load
-    auto it_observed_party = observable_parties.find(party_info.party_id);
-    // found
-    if (it_observed_party != observable_parties.end()) return *it_observed_party->second;
-
+// Create an ObservableParty and cache it
+// Do NOT call this if the party already exists, will cause memory leak
+ObserverModule::ObservableParty* ObserverModule::CreateObservableParty(const GW::PartyInfo& party_info) {
     // create
-    ObservableParty* observed_party = new ObserverModule::ObservableParty(*this, party_info);
-    observable_parties.insert({ observed_party->party_id, observed_party });
-    observable_party_ids.push_back(observed_party->party_id);
-    ReorderAndCacheParties();
-    return *observed_party;
+    ObservableParty* observable_party = new ObservableParty(*this, party_info);
+    // cache
+    observable_parties.insert({ observable_party->party_id, observable_party });
+    observable_party_ids.push_back(observable_party->party_id);
+    std::sort(observable_party_ids.begin(), observable_party_ids.end());
+    return observable_party;
+}
+
+
+
+// change state based on an actions stage
+void ObserverModule::ObservedAction::Reduce(const ObserverModule::ActionStage stage) {
+	switch (stage) {
+		case ActionStage::Instant:
+			started += 1;
+			finished += 1;
+			break;
+		case ActionStage::Started:
+			started += 1;
+			break;
+		case ActionStage::Stopped:
+			stopped += 1;
+			break;
+		case ActionStage::Interrupted:
+			stopped -= 1;
+			interrupted += 1;
+			break;
+		case ActionStage::Finished:
+			finished += 1;
+			break;
+	}
+}
+
+
+// fired when the Agent dies
+void ObserverModule::SharedStats::HandleDeath() {
+	deaths += 1;
+	// recalculate kdr
+	kdr_pc = (float) kills / deaths;
+	// get kdr string
+	std::stringstream str;
+	str << std::fixed << std::setprecision(2) << kdr_pc;
+	kdr_str = str.str();
+}
+
+
+// fired when the agent scores a kill
+void ObserverModule::SharedStats::HandleKill() {
+	kills += 1;
+	// recalculate kdr
+	if (deaths < 1)
+		kdr_pc = static_cast<float>(kills);
+	else
+		kdr_pc = static_cast<float>(kills) / deaths;
+	// get kdr string
+	std::stringstream str;
+	str << std::fixed << std::setprecision(2) << kdr_pc;
+	kdr_str = str.str();
+}
+
+
+ObserverModule::ObservableAgentStats::~ObservableAgentStats() {
+	// attacks received (by agent)
+	for (const auto& [_, o_atk] : attacks_received_from_agent) if (o_atk) delete o_atk;
+	attacks_received_from_agent.clear();
+
+	// attacks dealed (by agent)
+	for (const auto& [_, o_atk] : attacks_dealt_to_agent) if (o_atk) delete o_atk;
+	attacks_dealt_to_agent.clear();
+
+	// skills used
+	skill_ids_used.clear();
+	for (const auto& [_, o_skill] : skills_used) if (o_skill) delete o_skill;
+	skills_used.clear();
+
+	// skills received
+	skill_ids_received.clear();
+	for (const auto& [_, o_skill] : skills_received) if (o_skill) delete o_skill;
+	skills_received.clear();
+
+	// skill received (by agent)
+	for (auto& [_, skill_ids] : skills_ids_received_by_agent) skill_ids.clear();
+	skills_ids_received_by_agent.clear();
+	for (auto& [_, agent_skills] : skills_received_from_agent) {
+		for (const auto [__, o_skill] : agent_skills) if (o_skill) delete o_skill;
+		agent_skills.clear();
+	}
+	skills_received_from_agent.clear();
+
+	// skill used (by agent)
+	for (auto& [_, skill_ids] : skills_ids_used_on_agent) skill_ids.clear();
+	for (auto& [_, agent_skills] : skills_used_on_agent) {
+		for (const auto [__, o_skill] : agent_skills) if (o_skill) delete o_skill;
+		agent_skills.clear();
+	}
+	skills_ids_used_on_agent.clear();
+}
+
+
+// Get attacks dealed against this agent, by a caster_agent_id
+// Lazy initialises the caster_agent_id
+ObserverModule::ObservedAction& ObserverModule::ObservableAgentStats::LazyGetAttacksDealedAgainst(const uint32_t target_agent_id) {
+    auto it = attacks_dealt_to_agent.find(target_agent_id);
+    if (it == attacks_dealt_to_agent.end()) {
+        // receiver not registered
+        ObservedAction* observed_action = new ObservedAction();
+        attacks_dealt_to_agent.insert({target_agent_id, observed_action});
+        return *observed_action;
+    } else {
+        // receiver is already reigstered
+        return *it->second;
+    }
+}
+
+
+// Get attacks dealed against this agent, by a caster_agent_id
+// Lazy initialises the caster_agent_id
+ObserverModule::ObservedAction& ObserverModule::ObservableAgentStats::LazyGetAttacksReceivedFrom(const uint32_t caster_agent_id) {
+	auto it = attacks_received_from_agent.find(caster_agent_id);
+	if (it == attacks_received_from_agent.end()) {
+		// attacker not registered
+		ObservedAction* observed_action = new ObservedAction();
+		attacks_received_from_agent.insert({caster_agent_id, observed_action});
+		return *observed_action;
+	} else {
+		// attacker is already reigstered
+		return *it->second;
+	}
+}
+
+
+// Get skills used by this agent
+// Lazy initialises the skill_id
+ObserverModule::ObservedAction& ObserverModule::ObservableAgentStats::LazyGetSkillUsed(const uint32_t skill_id) {
+	auto it_skill = skills_used.find(skill_id);
+	if (it_skill == skills_used.end()) {
+		// skill not registered
+		skill_ids_used.push_back(skill_id);
+		// re-sort skills
+		std::sort(skill_ids_used.begin(), skill_ids_used.end());
+		ObservedSkill* observed_skill = new ObservedSkill(skill_id);
+		skills_used.insert({skill_id, observed_skill});
+		return *observed_skill;
+	} else {
+		// skill already registered
+		return *it_skill->second;
+	}
+}
+
+
+// Get skills used received by this agent
+// Lazy initialises the skill_id
+ObserverModule::ObservedAction& ObserverModule::ObservableAgentStats::LazyGetSkillReceived(const uint32_t skill_id) {
+	auto it_skill = skills_received.find(skill_id);
+	if (it_skill == skills_received.end()) {
+		// skill not registered
+		skill_ids_received.push_back(skill_id);
+		// re-sort skills
+		std::sort(skill_ids_received.begin(), skill_ids_received.end());
+		ObservedSkill* observed_skill = new ObservedSkill(skill_id);
+		skills_received.insert({skill_id, observed_skill});
+		return *observed_skill;
+	} else {
+		// skill already registered
+		return *it_skill->second;
+	}
+}
+
+
+
+// Get a skill received by this agent, from another agent
+// Lazy initialises the skill_id and caster_agent_id
+ObserverModule::ObservedSkill& ObserverModule::ObservableAgentStats::LazyGetSkillReceivedFrom(const uint32_t caster_agent_id, const uint32_t skill_id) {
+	auto it_caster = skills_received_from_agent.find(caster_agent_id);
+	if (it_caster == skills_received_from_agent.end()) {
+		// receiver and his skills are not registered with this agent
+		std::vector<uint32_t> received_skill_ids = {skill_id};
+		skills_ids_received_by_agent.insert({ caster_agent_id, received_skill_ids });
+		ObservedSkill* observed_skill = new ObservedSkill(skill_id);
+		std::unordered_map<uint32_t, ObservedSkill*> received_skills = {{skill_id, observed_skill}};
+		skills_received_from_agent.insert({caster_agent_id, received_skills});
+		return *observed_skill;
+	} else {
+		// receiver is registered with this agent
+		std::unordered_map<uint32_t, ObservedSkill*>& used_by_caster = it_caster->second;
+		auto it_observed_skill = used_by_caster.find(skill_id);
+		// does receiver have the skill registered from/against us?
+		if (it_observed_skill == used_by_caster.end()) {
+			// caster hasn't registered this skill with this agent
+			// add & re-sort skill_ids by the caster
+			std::vector<uint32_t>& skills_ids_received_by_agent_vec = skills_ids_received_by_agent.find(caster_agent_id)->second;
+			skills_ids_received_by_agent_vec.push_back(skill_id);
+			// re-sort
+			std::sort(skills_ids_received_by_agent_vec.begin(), skills_ids_received_by_agent_vec.end());
+			// add the observed skill for the caster
+			ObservedSkill* observed_skill = new ObservedSkill(skill_id);
+			used_by_caster.insert({skill_id, observed_skill});
+			return *observed_skill;
+		} else {
+			// receivers already registered this skill
+			return *(it_observed_skill->second);
+		}
+	}
+}
+
+
+// Get a skill received by this agent, from another agent
+// Lazy initialises the skill_id and caster_agent_id
+ObserverModule::ObservedSkill& ObserverModule::ObservableAgentStats::LazyGetSkillUsedOn(const uint32_t target_agent_id, const uint32_t skill_id) {
+    auto it_target = skills_used_on_agent.find(target_agent_id);
+    if (it_target == skills_used_on_agent.end()) {
+        // receiver and his skills are not registered with this agent
+        std::vector<uint32_t> used_skill_ids = {skill_id};
+        skills_ids_used_on_agent.insert({ target_agent_id, used_skill_ids });
+        ObservedSkill* observed_skill = new ObservedSkill(skill_id);
+        std::unordered_map<uint32_t, ObservedSkill*> used_skills = {{skill_id, observed_skill}};
+        skills_used_on_agent.insert({target_agent_id, used_skills});
+        return *observed_skill;
+    } else {
+        std::unordered_map<uint32_t, ObservedSkill*>& used_on_target = it_target->second;
+        // receiver is registered with this agent
+        auto it_observed_skill = used_on_target.find(skill_id);
+        // does receiver have the skill registered from/against us?
+        if (it_observed_skill == used_on_target.end()) {
+            // target hasn't registered this skill with this agent
+            // add & re-sort skill_ids by the caster
+            std::vector<uint32_t>& skills_ids_used_on_agent_vec = skills_ids_used_on_agent.find(target_agent_id)->second;
+            skills_ids_used_on_agent_vec.push_back(skill_id);
+            // re-sort
+            std::sort(skills_ids_used_on_agent_vec.begin(), skills_ids_used_on_agent_vec.end());
+            // add the observed skill for the caster
+            ObservedSkill* observed_skill = new ObservedSkill(skill_id);
+            used_on_target.insert({skill_id, observed_skill});
+            return *observed_skill;
+        } else {
+            // receivers already registered this skill
+            return *(it_observed_skill->second);
+        }
+    }
+}
+
+
+// Constructor
+ObserverModule::ObservableParty::ObservableParty(ObserverModule& parent, const GW::PartyInfo& info)
+    : parent(parent)
+    , party_id(info.party_id) {}
+
+
+
+// Destructor
+ObserverModule::ObservableParty::~ObservableParty() {
+    agent_ids.clear();
 }
 
 
@@ -1042,43 +1374,78 @@ bool ObserverModule::ObservableParty::SynchroniseParty() {
     // 1. players
     //  1.1 player heroes
     // 2. henchmen
-    // destroy and re-initialise the agent_ids;
 
-    for (uint32_t agent_id : agent_ids) {
-        // disabuse old party members of their indexes and party_id
-        // to re-add them back on in a moment
-        ObservableAgent* observable_agent = parent.GetObservableAgentById(agent_id);
-        if (observable_agent) {
-            // clear observable_agents party info
-            observable_agent->party_id = NO_PARTY;
-            observable_agent->party_index = 0;
+    size_t party_index = 0;
+
+    // ensure agent_ids size
+    size_t party_size = party_info->players.size() + party_info->heroes.size() + party_info->henchmen.size();
+    if (party_size > agent_ids.size()) {
+        // agent_ids is too small
+        // add empty agent_ids
+        agent_ids.resize(party_size, NO_AGENT);
+    } else if (party_size < agent_ids.size()) {
+        // agent_ids is too large
+        // clear stale agent_ids
+        for (size_t i = party_size; i < agent_ids.size(); i += 1) {
+            // clear old party member
+            ObservableAgent* observable_agent_prev = parent.GetObservableAgentById(agent_ids[i]);
+            if (observable_agent_prev) {
+                observable_agent_prev->party_id = NO_PARTY;
+                observable_agent_prev->party_index = 0;
+            }
         }
+        agent_ids.resize(party_size, NO_AGENT);
     }
 
-    agent_ids.clear();
-    size_t party_index = 1;
+    // fill agent_ids and notify the agents
     for (const GW::PlayerPartyMember& party_player : party_info->players) {
         // notify the player of their party & position
         const GW::Player& player = players[party_player.login_number];
-        agent_ids.push_back(player.agent_id);
-
-        ObservableAgent* observable_player = parent.GetObservableAgentById(player.agent_id);
-        if (observable_player) {
-            // notify the player of their party & position
-            observable_player->party_id = party_id;
-            observable_player->party_index = party_index;
+        if (player.agent_id != 0) {
+            // if agent_id is 0, the agent either hasn't loaded or has disconnected
+            // if the agent has simply disconnected we keep them from agent_ids
+            // by avoiding this code block
+            if (agent_ids[party_index] != player.agent_id) {
+                // clear old party member
+                ObservableAgent* observable_player_prev = parent.GetObservableAgentById(agent_ids[party_index]);
+                if (observable_player_prev) {
+                    observable_player_prev->party_id = NO_PARTY;
+                    observable_player_prev->party_index = 0;
+                }
+            }
+            // add new party member
+            agent_ids[party_index] = player.agent_id;
+            ObservableAgent* observable_player = parent.GetObservableAgentById(player.agent_id);
+            if (observable_player) {
+                // notify the player of their party & position
+                observable_player->party_id = party_id;
+                observable_player->party_index = party_index;
+            }
         }
         party_index += 1;
 
         // No heroes in PvP but keeping this for consistency in all explorable areas...
         for (const GW::HeroPartyMember& hero : party_info->heroes) {
             if (hero.owner_player_id == party_player.login_number) {
-                agent_ids.push_back(hero.agent_id);
-                ObserverModule::ObservableAgent* observable_hero = parent.GetObservableAgentById(hero.agent_id);
-                if (observable_hero) {
-                    // notify the hero of their party & position
-                    observable_hero->party_id = party_id;
-                    observable_hero->party_index = party_index;
+                if (hero.agent_id != 0) {
+                    // out of scope/compass for some reason if agent_id = 0;
+                    // just leave the previous entry in our party
+                    if (agent_ids[party_index] != hero.agent_id) {
+                        // clear old party member
+                        ObserverModule::ObservableAgent* observable_hero_prev = parent.GetObservableAgentById(agent_ids[party_index]);
+                        if (observable_hero_prev) {
+                            observable_hero_prev->party_id = NO_PARTY;
+                            observable_hero_prev->party_index = 0;
+                        }
+                    }
+                    // add new party member
+                    agent_ids[party_index] = hero.agent_id;
+                    ObserverModule::ObservableAgent* observable_hero = parent.GetObservableAgentById(hero.agent_id);
+                    if (observable_hero) {
+                        // notify the hero of their party & position
+                        observable_hero->party_id = party_id;
+                        observable_hero->party_index = party_index;
+                    }
                 }
             }
             party_index += 1;
@@ -1086,14 +1453,55 @@ bool ObserverModule::ObservableParty::SynchroniseParty() {
     }
 
     for (const GW::HenchmanPartyMember& hench : party_info->henchmen) {
-        agent_ids.push_back(hench.agent_id);
-        ObserverModule::ObservableAgent* observable_hench = parent.GetObservableAgentById(hench.agent_id);
-        if (observable_hench) {
-            // notify the henchman of their party & position
-            observable_hench->party_id = party_id;
-            observable_hench->party_index = party_index;
+        if (hench.agent_id != 0) {
+            // out of scope/compass for some reason if agent_id = 0;
+            // just leave the previous entry in our party
+            if (agent_ids[party_index] != hench.agent_id) {
+                // clear old party member
+                ObserverModule::ObservableAgent* observable_hench_prev = parent.GetObservableAgentById(agent_ids[party_index]);
+                if (observable_hench_prev) {
+                    observable_hench_prev->party_id = NO_PARTY;
+                    observable_hench_prev->party_index = 0;
+                }
+            }
+            // add new party member
+            agent_ids[party_index] = hench.agent_id;
+            ObserverModule::ObservableAgent* observable_hench = parent.GetObservableAgentById(hench.agent_id);
+            if (observable_hench) {
+                // notify the henchman of their party & position
+                observable_hench->party_id = party_id;
+                observable_hench->party_index = party_index;
+            }
         }
         party_index += 1;
+    }
+
+    // infer teams name from first players guild
+    // TODO: retrieve this information from memory instead of inferring it
+    // note: this won't be accurate in HA where the teams name isn't simply
+    // player 0's guild
+    guild_id = NO_GUILD;
+    name = "";
+    display_name = "";
+    rank = NO_RANK;
+    rank_str = "";
+    rating = NO_RATING;
+    if (agent_ids.size() > 0) {
+        ObservableAgent* agent0 = parent.GetObservableAgentById(agent_ids[0]);
+        if (agent0) {
+            ObservableGuild* guild = parent.GetObservableGuildById(agent0->guild_id);
+            if (guild) {
+                guild_id = guild->guild_id;
+                name = guild->name;
+                rank = guild->rank;
+                rank_str = (guild->rank == NO_RANK) ? "N/A" : std::to_string(guild->rank);
+                rating = guild->rating;
+                display_name = guild->name + " [" + guild->tag + "]";
+            } else {
+                name = agent0->SanitizedName() + "'s team";
+                display_name = agent0->SanitizedName() + "'s team";
+            }
+        }
     }
 
     // success
@@ -1101,40 +1509,207 @@ bool ObserverModule::ObservableParty::SynchroniseParty() {
 }
 
 
-ObserverModule::ObservableSkill::ObservableSkill(ObserverModule& parent, const GW::Skill& _gw_skill) : parent(parent), gw_skill(_gw_skill) {
+// Constructor
+ObserverModule::ObservableSkill::ObservableSkill(ObserverModule& parent, const GW::Skill& _gw_skill)
+    : parent(parent)
+    , gw_skill(_gw_skill)
+{
     skill_id = _gw_skill.skill_id;
     // initialize the name asynchronously here
     if (!name_enc[0] && GW::UI::UInt32ToEncStr(gw_skill.name, name_enc, 16))
         GW::UI::AsyncDecodeStr(name_enc, name_dec, 256);
 }
 
-// Name of the Agent (modified a little)
-std::string ObserverModule::ObservableAgent::Name() {
-    // has been cached
-    if (trimmed_name.length() > 0) return trimmed_name;
-    // hasn't been cached yet
-    if (raw_name == L"") return "";
-    // can now be cached
-    std::string _trimmed_name = GuiUtils::WStringToString(raw_name);
 
-    if (profession.length() > 0) _trimmed_name = profession + " " + _trimmed_name;
+// Name of the skill
+const std::string ObserverModule::ObservableSkill::Name() {
+    // cached?
+    if (_name.length() > 0) return _name;
+    std::string name = GuiUtils::WStringToString(DecName());
+    // not ready to cache
+    if (name.length() == 0) return name;
+    // ready to cache
+    _name = name;
+    return _name;
+}
 
-    // TODO: add this as an optional setting
-    // strip ending [hench name] from henchmen
-    size_t begin = _trimmed_name.find(" [");
-    size_t end = _trimmed_name.find_first_of("]");
-    if (std::string::npos != begin && std::string::npos != end && begin <= end) {
-        _trimmed_name.erase(begin, end-begin + 1);
+
+// Name + skill_id of the Skill
+const std::string ObserverModule::ObservableSkill::DebugName() {
+    return std::string("(") + std::to_string(skill_id) + ") \"" + GuiUtils::WStringToString(DecName()) + "\"";
+}
+
+
+// Constructor
+ObserverModule::ObservableGuild::ObservableGuild(ObserverModule& parent, const GW::Guild& guild)
+    : parent(parent)
+    , guild_id(guild.index)
+    , key(guild.key)
+    , name(GuiUtils::WStringToString(guild.name))
+    , tag(GuiUtils::WStringToString(guild.tag))
+    , wrapped_tag("[" + tag + "]")
+    , rank(guild.rank)
+    , rating(guild.rating)
+    , faction(guild.faction)
+    , faction_point(guild.faction_point)
+    , qualifier_point(guild.qualifier_point)
+    , cape_trim(guild.cape_trim)
+{
+    //
+}
+
+
+// Constructor
+ObserverModule::ObservableAgent::ObservableAgent(ObserverModule& parent, const GW::AgentLiving& agent_living)
+    : parent(parent)
+    , state(agent_living.model_state)
+    , guild_id(static_cast<uint32_t>(agent_living.tags->guild_id))
+    , agent_id(agent_living.agent_id)
+    , team_id(agent_living.team_id)
+    , primary((GW::Constants::Profession) agent_living.primary)
+    , secondary((GW::Constants::Profession) agent_living.secondary)
+    , is_npc(agent_living.IsNPC())
+    , is_player(agent_living.IsPlayer())
+    , login_number(agent_living.login_number)
+{
+    // async initialise the agents name now because we probably want it later
+    GW::Agents::AsyncGetAgentName(&agent_living, _raw_name_w);
+
+    if (primary != GW::Constants::Profession::None) {
+        std::string prof = GW::Constants::GetProfessionAcronym(primary);
+        if (secondary != GW::Constants::Profession::None) {
+            std::string s_prof = GW::Constants::GetProfessionAcronym(secondary);
+            prof = prof + "/" + s_prof;
+        }
+        profession = prof;
+    }
+};
+
+
+// Destructor
+ObserverModule::ObservableAgent::~ObservableAgent() {
+    delete current_target_action;
+}
+
+
+// Name of the Agent to display on HUD
+std::string ObserverModule::ObservableAgent::DisplayName() {
+    bool is_initialised = _display_name.length() > 0;
+    // additional name modification settings can go here...
+    bool cache_busted = parent.trim_hench_names != trim_hench_name;
+    if (is_initialised && !cache_busted) {
+        return _display_name;
     }
 
-    // TODO: add this as a setting
-    // // strip ending (player number) from player
-    // begin = _trimmed_name.find(" (");
-    // end = _trimmed_name.find_first_of(")");
-    // if (std::string::npos != begin && std::string::npos != end && begin <= end) {
-    // _trimmed_name.erase(begin, end-begin + 1);
-    // }
+    // generate and cache display_name
+    std::string next_display_name = RawName();
 
-    trimmed_name = _trimmed_name;
-    return trimmed_name;
+    // remove hench name
+    if (parent.trim_hench_names) {
+        size_t begin = next_display_name.find("[");
+        size_t end = next_display_name.find_first_of("]");
+        if (std::string::npos != begin && std::string::npos != end && begin <= end) {
+            next_display_name.erase(begin, end-begin + 1);
+        }
+    }
+
+    // trim whitespace
+    size_t w_first = next_display_name.find_first_not_of(' ');
+    size_t w_last = next_display_name.find_last_not_of(' ');
+    if (w_first != std::string::npos) {
+        next_display_name = next_display_name.substr(w_first, w_last + 1);
+    }
+
+    trim_hench_name = parent.trim_hench_names;
+    _display_name = next_display_name;
+    return _display_name;
+}
+
+
+// Sanitized Name of the Agent (as std::string)
+std::string ObserverModule::ObservableAgent::SanitizedName() {
+    // has been cached
+    if (_sanitized_name.length() > 0) return _sanitized_name;
+    std::wstring sanitized_name_w = SanitizedNameW();
+    // can't be cached yet
+    if (sanitized_name_w.length() == 0) return "";
+    // can now be cached
+    _sanitized_name = GuiUtils::WStringToString(sanitized_name_w);
+    return _sanitized_name;
+}
+
+
+// Sanitized Name of the Agent (as std::wstring)
+std::wstring ObserverModule::ObservableAgent::SanitizedNameW() {
+    // has been cached
+    if (_sanitized_name_w.length() > 0) return _sanitized_name_w;
+    std::wstring raw_name_w = RawNameW();
+    // can't be cached yet
+    if (raw_name_w.length() == 0) return L"";
+    // can now be cached
+    _sanitized_name_w = GuiUtils::SanitizePlayerName(raw_name_w);
+    return _sanitized_name_w;
+}
+
+
+// Name of the Agent (as std::string)
+std::string ObserverModule::ObservableAgent::RawName() {
+    // has been cached
+    if (_raw_name.length() > 0) return _raw_name;
+    std::wstring raw_name_w = RawNameW();
+    // can't be cached yet
+    if (raw_name_w.length() == 0) return "";
+    // can now be cached
+    _raw_name = GuiUtils::WStringToString(raw_name_w);
+    return _raw_name;
+}
+
+
+// Name of the Agent (un-edited as wstring)
+std::wstring ObserverModule::ObservableAgent::RawNameW() {
+    // rely on the constructor initialising the name...
+    return _raw_name_w;
+}
+
+
+// Name + agent_id of the Agent
+std::string ObserverModule::ObservableAgent::DebugName() {
+    std::string debug_name = "(" + std::to_string(agent_id) + ") " + "\"" + RawName() + "\"";
+    return debug_name;
+}
+
+
+// Constructor
+ObserverModule::ObservableMap::ObservableMap(const GW::AreaInfo& area_info)
+    : campaign(area_info.campaign)
+    , continent(area_info.continent)
+    , region(area_info.region)
+    , type(area_info.type)
+    , flags(area_info.flags)
+    , name_id(area_info.name_id)
+    , description_id(area_info.description_id)
+{
+    // async initialise the name
+    if (GW::UI::UInt32ToEncStr(area_info.name_id, name_enc, 8)) {
+        GW::UI::AsyncDecodeStr(name_enc, &name_w);
+    }
+
+    // async initialise the description
+    if (GW::UI::UInt32ToEncStr(area_info.description_id, description_enc, 8)) {
+        GW::UI::AsyncDecodeStr(description_enc, &description_w);
+    }
+}
+
+// Cache & return name
+std::string ObserverModule::ObservableMap::Name() {
+    if (name.length() > 0) return name;
+    name = GuiUtils::WStringToString(name_w);
+    return name;
+}
+
+// Cache & return description
+std::string ObserverModule::ObservableMap::Description() {
+    if (description.length() > 0) return description;
+    description = GuiUtils::WStringToString(description_w);
+    return description;
 }

--- a/GWToolboxdll/Windows/ObserverExportWindow.cpp
+++ b/GWToolboxdll/Windows/ObserverExportWindow.cpp
@@ -24,107 +24,441 @@ void ObserverExportWindow::Initialize() {
     ToolboxWindow::Initialize();
 }
 
-// ObservableAgent to JSON
-nlohmann::json ObserverExportWindow::ObservableAgentToJSON(ObserverModule::ObservableAgent& agent) {
+// Convert to JSON (Version 0.1)
+nlohmann::json ObserverExportWindow::ToJSON_V_0_1() {
     nlohmann::json json;
-    json["name"] = agent.Name();
-    json["party_id"] = agent.party_id;
-    json["party_index"] = agent.party_index;
-    json["primary"] = agent.primary;
-    json["secondary"] = agent.secondary;
-    json["profession"] = agent.profession;
-    json["stats"] = ObservableAgentStatsToJSON(agent.stats);
-    for (uint32_t skill_id : agent.stats.skill_ids_used) {
-        ObserverModule::ObservableSkill* skill = ObserverModule::Instance().GetObservableSkillById(skill_id);
-        if (!skill) {
-            json["skills"].push_back(nlohmann::json::value_t::null);
-            continue;
-        }
-        json["skills"].push_back(ObservableSkillToJSON(*skill));
-    }
-    return json;
-}
+    ObserverModule& observer_module = ObserverModule::Instance();
+    const std::vector<uint32_t>& party_ids = observer_module.GetObservablePartyIds();
 
-// SharedStats to JSON
-nlohmann::json ObserverExportWindow::SharedStatsToJSON(ObserverModule::SharedStats& stats) {
-    nlohmann::json json;
-    json["total_crits_received"] = stats.total_crits_received;
-    json["total_crits_dealt"] = stats.total_crits_dealt;
-    json["total_party_crits_received"] = stats.total_party_crits_received;
-    json["total_party_crits_dealt"] = stats.total_party_crits_dealt;
-    json["knocked_down_count"] = stats.knocked_down_count;
-    json["interrupted_count"] = stats.interrupted_count;
-    json["interrupted_skills_count"] = stats.interrupted_skills_count;
-    json["cancelled_count"] = stats.cancelled_count;
-    json["cancelled_skills_count"] = stats.cancelled_skills_count;
-    json["knocked_down_duration"] = stats.knocked_down_duration;
-    json["deaths"] = stats.deaths;
-    json["kills"] = stats.kills;
-    json["kdr_str"] = stats.kdr_str;
-    return json;
-}
+    auto shared_stats_to_json = [](const ObserverModule::SharedStats& stats) -> nlohmann::json {
+        nlohmann::json shared_json;
+        shared_json["total_crits_received"]         = stats.total_crits_received;
+        shared_json["total_crits_dealt"]            = stats.total_crits_dealt;
+        shared_json["total_party_crits_received"]   = stats.total_party_crits_received;
+        shared_json["total_party_crits_dealt"]      = stats.total_party_crits_dealt;
+        shared_json["knocked_down_count"]           = stats.knocked_down_count;
+        shared_json["interrupted_count"]            = stats.interrupted_count;
+        shared_json["interrupted_skills_count"]     = stats.interrupted_skills_count;
+        shared_json["cancelled_count"]              = stats.cancelled_count;
+        shared_json["cancelled_skills_count"]       = stats.cancelled_skills_count;
+        shared_json["knocked_down_duration"]        = stats.knocked_down_duration;
+        shared_json["deaths"]                       = stats.deaths;
+        shared_json["kills"]                        = stats.kills;
+        shared_json["kdr_str"]                      = stats.kdr_str;
+        return shared_json;
+    };
 
-// ObservableAgentStats to JSON
-nlohmann::json ObserverExportWindow::ObservableAgentStatsToJSON(ObserverModule::ObservableAgentStats& stats) {
-    nlohmann::json json;
-    json.merge_patch(SharedStatsToJSON(stats));
-    return json;
-}
-
-// ObservablePartyStats to JSON
-nlohmann::json ObserverExportWindow::ObservablePartyStatsToJSON(ObserverModule::ObservablePartyStats& stats) {
-    nlohmann::json json;
-    json.merge_patch(SharedStatsToJSON(stats));
-    return json;
-}
-
-// ObservableParty to JSON
-nlohmann::json ObserverExportWindow::ObservablePartyToJSON(ObserverModule::ObservableParty& party) {
-    nlohmann::json json;
-    json["party_id"] = party.party_id;
-    json["stats"] = ObservablePartyStatsToJSON(party.stats);
-    for (uint32_t agent_id : party.agent_ids) {
-        ObserverModule::ObservableAgent* agent = ObserverModule::Instance().GetObservableAgentById(agent_id);
-        if (!agent) {
-            json["members"].push_back(nlohmann::json::value_t::null);
-            continue;
-        }
-        json["members"].push_back(ObservableAgentToJSON(*agent));
-    }
-    return json;
-}
-
-nlohmann::json ObserverExportWindow::ObservableSkillToJSON(ObserverModule::ObservableSkill& skill) {
-    nlohmann::json json;
-    json["name"] = skill.Name();
-    return json;
-}
-
-
-// Convert to JSON
-nlohmann::json ObserverExportWindow::ToJSON() {
-    nlohmann::json json;
-    const std::vector<ObserverModule::ObservableParty*>& parties = ObserverModule::Instance().GetObservablePartyArray();
-    json["version"] = "0.0";
-    for (ObserverModule::ObservableParty* party : parties) {
+    for (const uint32_t party_id : party_ids) {
+        // parties
+        const ObserverModule::ObservableParty* party = observer_module.GetObservablePartyById(party_id); 
         if (!party) {
             json["parties"].push_back(nlohmann::json::value_t::null);
             continue;
         }
-        json["parties"].push_back(ObservablePartyToJSON(*party));
+        json["parties"].push_back([&]() -> nlohmann::json {
+            // parties -> party
+            nlohmann::json json_party;
+            json_party["party_id"] = party->party_id;
+            json_party["stats"] = shared_stats_to_json(party->stats);
+            for (uint32_t agent_id : party->agent_ids) {
+                // parties -> party -> agents
+                ObserverModule::ObservableAgent* agent = observer_module.GetObservableAgentById(agent_id);
+                if (!agent) {
+                    json_party["members"].push_back(nlohmann::json::value_t::null);
+                    continue;
+                }
+                json_party["members"].push_back([&]() -> nlohmann::json {
+                    // parties -> party -> agents -> agent
+                    nlohmann::json json_agent;
+                    json_agent["display_name"]    = agent->DisplayName();
+                    json_agent["raw_name"]        = agent->RawName();
+                    json_agent["debug_name"]      = agent->DebugName();
+                    json_agent["sanitized_name"]  = agent->SanitizedName();
+                    json_agent["party_id"]        = agent->party_id;
+                    json_agent["party_index"]     = agent->party_index;
+                    json_agent["primary"]         = agent->primary;
+                    json_agent["secondary"]       = agent->secondary;
+                    json_agent["profession"]      = agent->profession;
+                    json_agent["stats"] = shared_stats_to_json(agent->stats);
+                    for (uint32_t skill_id : agent->stats.skill_ids_used) {
+                        // parties -> party -> agents -> agent -> skills
+                        ObserverModule::ObservableSkill* skill = ObserverModule::Instance().GetObservableSkillById(skill_id);
+                        if (!skill) {
+                            json["skills"].push_back(nlohmann::json::value_t::null);
+                            continue;
+                        }
+                        json["skills"].push_back([&]() -> nlohmann::json {
+                            // parties -> party -> agents -> agent -> skills -> skill
+                            nlohmann::json json_skill;
+                            json_skill["name"] = skill->Name();
+                            return json_skill;
+                        }());
+                    }
+                    return json_agent;
+                }());
+                return json;
+            }
+            return json_party;
+        }());
     }
 
     return json;
 }
 
+// Convert to JSON (Version 1.0)
+nlohmann::json ObserverExportWindow::ToJSON_V_1_0() {
+    nlohmann::json json;
+    ObserverModule& om = ObserverModule::Instance();
+
+    // name is built by iterating over the parties
+    bool name_prepend_vs = false;
+    std::string name = "";
+
+    json["map"] = nlohmann::json::value_t::null;
+    ObserverModule::ObservableMap* map = om.GetMap();
+    if (map) {
+        json["map"]                     = {};
+        json["map"]["name"]             = map->Name();
+        json["map"]["description"]      = map->Description();
+        json["map"]["is_pvp"]           = map->GetIsPvP();
+        json["map"]["is_guild_hall"]    = map->GetIsGuildHall();
+        json["map"]["campaign"]         = map->campaign;
+        json["map"]["continent"]        = map->continent;
+        json["map"]["region"]           = map->region;
+        json["map"]["type"]             = map->type;
+        json["map"]["flags"]            = map->flags;
+        json["map"]["name_id"]          = map->name_id;
+        json["map"]["description_id"]   = map->description_id;
+    }
+
+
+    auto action_to_json = [](const ObserverModule::ObservedAction& action) -> nlohmann::json {
+        nlohmann::json action_json;
+        action_json["started"] = action.started;
+        action_json["stopped"] = action.stopped;
+        action_json["interrupted"] = action.interrupted;
+        action_json["finished"] = action.finished;
+        return action_json;
+    };
+
+    auto shared_stats_to_json = [&action_to_json](const ObserverModule::SharedStats& stats) -> nlohmann::json {
+        nlohmann::json stats_json;
+        stats_json["total_crits_received"]          = stats.total_crits_received;
+        stats_json["total_crits_dealt"]             = stats.total_crits_dealt;
+        stats_json["total_party_crits_received"]    = stats.total_party_crits_received;
+        stats_json["total_party_crits_dealt"]       = stats.total_party_crits_dealt;
+        stats_json["knocked_down_count"]            = stats.knocked_down_count;
+        stats_json["interrupted_count"]             = stats.interrupted_count;
+        stats_json["interrupted_skills_count"]      = stats.interrupted_skills_count;
+        stats_json["cancelled_count"]               = stats.cancelled_count;
+        stats_json["cancelled_skills_count"]        = stats.cancelled_skills_count;
+        stats_json["knocked_down_duration"]         = stats.knocked_down_duration;
+        stats_json["deaths"]                        = stats.deaths;
+        stats_json["kills"]                         = stats.kills;
+        stats_json["kdr_str"]                       = stats.kdr_str;
+        stats_json["total_attacks_dealt"]                       = action_to_json(stats.total_attacks_dealt);
+        stats_json["total_attacks_received"]                    = action_to_json(stats.total_attacks_received);
+        stats_json["total_attacks_dealt_to_other_party"]        = action_to_json(stats.total_attacks_dealt_to_other_party);
+        stats_json["total_attacks_received_from_other_party"]   = action_to_json(stats.total_attacks_received_from_other_party);
+        stats_json["total_skills_used"]                         = action_to_json(stats.total_skills_used);
+        stats_json["total_skills_received"]                     = action_to_json(stats.total_skills_received);
+        stats_json["total_skills_used_on_own_party"]            = action_to_json(stats.total_skills_used_on_own_party);
+        stats_json["total_skills_used_on_other_parties"]        = action_to_json(stats.total_skills_used_on_other_parties);
+        stats_json["total_skills_received_from_own_party"]      = action_to_json(stats.total_skills_received_from_own_party);
+        stats_json["total_skills_received_from_other_parties"]  = action_to_json(stats.total_skills_received_from_other_parties);
+        stats_json["total_skills_used_on_own_team"]             = action_to_json(stats.total_skills_used_on_own_team);
+        stats_json["total_skills_used_on_other_teams"]          = action_to_json(stats.total_skills_used_on_other_teams);
+        stats_json["total_skills_received_from_own_team"]       = action_to_json(stats.total_skills_received_from_own_team);
+        stats_json["total_skills_received_from_other_teams"]    = action_to_json(stats.total_skills_received_from_other_teams);
+        return stats_json;
+    };
+
+    const std::vector<uint32_t>& guild_ids = om.GetObservableGuildIds();
+    const std::vector<uint32_t>& agent_ids = om.GetObservableAgentIds();
+    const std::vector<uint32_t>& party_ids = om.GetObservablePartyIds();
+    const std::vector<uint32_t>& skill_ids = om.GetObservableSkillIds();
+
+    // guilds
+    json["guilds"]["ids"] = guild_ids;
+    json["guilds"]["by_id"] = {};
+    for (uint32_t guild_id : guild_ids) {
+        std::string guild_id_s = std::to_string(guild_id);
+        ObserverModule::ObservableGuild* guild = om.GetObservableGuildById(guild_id);
+        if (!guild) {
+            json["guilds"]["by_id"][guild_id_s] = nlohmann::json::value_t::null;
+            continue;
+        }
+        json["guilds"]["by_id"][guild_id_s]["guild_id"]           = guild->guild_id;
+        json["guilds"]["by_id"][guild_id_s]["key"]                = guild->key.k;
+        json["guilds"]["by_id"][guild_id_s]["name"]               = guild->name;
+        json["guilds"]["by_id"][guild_id_s]["tag"]                = guild->tag;
+        json["guilds"]["by_id"][guild_id_s]["wrapped_tag"]        = guild->wrapped_tag;
+        json["guilds"]["by_id"][guild_id_s]["rank"]               = guild->rank;
+        json["guilds"]["by_id"][guild_id_s]["rating"]             = guild->rating;
+        json["guilds"]["by_id"][guild_id_s]["faction"]            = guild->faction;
+        json["guilds"]["by_id"][guild_id_s]["faction_point"]      = guild->faction_point;
+        json["guilds"]["by_id"][guild_id_s]["qualifier_point"]    = guild->qualifier_point;
+        json["guilds"]["by_id"][guild_id_s]["cape_trim"]          = guild->cape_trim;
+    }
+
+    // skills
+    json["skills"]["ids"] = skill_ids;
+    json["skills"]["by_id"] = {};
+    for (uint32_t skill_id : skill_ids) {
+        std::string skill_id_s = std::to_string(skill_id);
+        ObserverModule::ObservableSkill* skill = om.GetObservableSkillById(skill_id);
+        if (!skill) {
+            json["skills"]["by_id"][skill_id_s] = nlohmann::json::value_t::null;
+            continue;
+        }
+        json["skills"]["by_id"][skill_id_s]["name"]             = skill->Name();
+        json["skills"]["by_id"][skill_id_s]["stats"]["total_usages"]                = action_to_json(skill->stats.total_usages);
+        json["skills"]["by_id"][skill_id_s]["stats"]["total_self_usages"]           = action_to_json(skill->stats.total_self_usages);
+        json["skills"]["by_id"][skill_id_s]["stats"]["total_other_usages"]          = action_to_json(skill->stats.total_other_usages);
+        json["skills"]["by_id"][skill_id_s]["stats"]["total_own_party_usages"]      = action_to_json(skill->stats.total_own_party_usages);
+        json["skills"]["by_id"][skill_id_s]["stats"]["total_other_party_usages"]    = action_to_json(skill->stats.total_other_party_usages);
+        json["skills"]["by_id"][skill_id_s]["stats"]["total_own_team_usages"]       = action_to_json(skill->stats.total_own_team_usages);
+        json["skills"]["by_id"][skill_id_s]["stats"]["total_other_team_usages"]     = action_to_json(skill->stats.total_other_team_usages);
+        json["skills"]["by_id"][skill_id_s]["skill_id"]         = skill->gw_skill.skill_id;
+        json["skills"]["by_id"][skill_id_s]["campaign"]         = skill->gw_skill.campaign;
+        json["skills"]["by_id"][skill_id_s]["type"]             = skill->gw_skill.type;
+        json["skills"]["by_id"][skill_id_s]["sepcial"]          = skill->gw_skill.special;
+        json["skills"]["by_id"][skill_id_s]["activation"]       = skill->gw_skill.activation;
+        json["skills"]["by_id"][skill_id_s]["combo_req"]        = skill->gw_skill.combo_req;
+        json["skills"]["by_id"][skill_id_s]["effect1"]          = skill->gw_skill.effect1;
+        json["skills"]["by_id"][skill_id_s]["condition"]        = skill->gw_skill.condition;
+        json["skills"]["by_id"][skill_id_s]["effect2"]          = skill->gw_skill.effect2;
+        json["skills"]["by_id"][skill_id_s]["weapon_req"]       = skill->gw_skill.weapon_req;
+        json["skills"]["by_id"][skill_id_s]["profession"]       = skill->gw_skill.profession;
+        json["skills"]["by_id"][skill_id_s]["attribute"]        = skill->gw_skill.attribute;
+        json["skills"]["by_id"][skill_id_s]["skill_id_pvp"]     = skill->gw_skill.skill_id_pvp;
+        json["skills"]["by_id"][skill_id_s]["combo"]            = skill->gw_skill.combo;
+        json["skills"]["by_id"][skill_id_s]["target"]           = skill->gw_skill.target;
+        json["skills"]["by_id"][skill_id_s]["skill_equip_type"] = skill->gw_skill.skill_equip_type;
+        json["skills"]["by_id"][skill_id_s]["energy_cost"]      = skill->gw_skill.energy_cost;
+        json["skills"]["by_id"][skill_id_s]["health_cost"]      = skill->gw_skill.health_cost;
+        json["skills"]["by_id"][skill_id_s]["adrenaline"]       = skill->gw_skill.adrenaline;
+        json["skills"]["by_id"][skill_id_s]["activation"]       = skill->gw_skill.activation;
+        json["skills"]["by_id"][skill_id_s]["aftercast"]        = skill->gw_skill.aftercast;
+        json["skills"]["by_id"][skill_id_s]["duration0"]        = skill->gw_skill.duration0;
+        json["skills"]["by_id"][skill_id_s]["duration15"]       = skill->gw_skill.duration15;
+        json["skills"]["by_id"][skill_id_s]["recharge"]         = skill->gw_skill.recharge;
+        json["skills"]["by_id"][skill_id_s]["scale0"]           = skill->gw_skill.scale0;
+        json["skills"]["by_id"][skill_id_s]["scale15"]          = skill->gw_skill.scale15;
+        json["skills"]["by_id"][skill_id_s]["bonusScale0"]      = skill->gw_skill.bonusScale0;
+        json["skills"]["by_id"][skill_id_s]["bonusScale15"]     = skill->gw_skill.bonusScale15;
+        json["skills"]["by_id"][skill_id_s]["aoe_range"]        = skill->gw_skill.aoe_range;
+        json["skills"]["by_id"][skill_id_s]["const_effect"]     = skill->gw_skill.const_effect;
+        json["skills"]["by_id"][skill_id_s]["icon_file_id"]     = skill->gw_skill.icon_file_id;
+    }
+
+    // parties
+    json["parties"]["ids"] = party_ids;
+    json["parties"]["by_id"] = {};
+    for (uint32_t party_id : party_ids) {
+        std::string party_id_s = std::to_string(party_id);
+        ObserverModule::ObservableParty* party = om.GetObservablePartyById(party_id);
+        if (!party) {
+            json["parties"]["by_id"][party_id_s] = nlohmann::json::value_t::null;
+            continue;
+        }
+        if (name_prepend_vs) name.append(" vs ");
+        name.append(party->display_name);
+        name_prepend_vs = true;
+        json["parties"]["by_id"][party_id_s]["party_id"] = party->party_id;
+        json["parties"]["by_id"][party_id_s]["name"] = party->name;
+        json["parties"]["by_id"][party_id_s]["display_name"] = party->display_name;
+        json["parties"]["by_id"][party_id_s]["guild_id"] = party->guild_id;
+        json["parties"]["by_id"][party_id_s]["agent_ids"] = party->agent_ids;
+        json["parties"]["by_id"][party_id_s]["rank"] = party->rank;
+        json["parties"]["by_id"][party_id_s]["rank_str"] = party->rank_str;
+        json["parties"]["by_id"][party_id_s]["rating"] = party->rating;
+        json["parties"]["by_id"][party_id_s]["stats"] = shared_stats_to_json(party->stats);
+    }
+
+    // agents
+    json["agents"]["ids"] = agent_ids;
+    json["agents"]["by_id"] = {};
+    for (uint32_t agent_id : agent_ids) {
+        std::string agent_id_s = std::to_string(agent_id);
+        ObserverModule::ObservableAgent* agent = om.GetObservableAgentById(agent_id);
+        if (!agent) {
+            json["agents"]["by_id"][agent_id_s] = nlohmann::json::value_t::null;
+            continue;
+        }
+        json["agents"]["by_id"][agent_id_s]["display_name"]   = agent->DisplayName();
+        json["agents"]["by_id"][agent_id_s]["raw_name"]       = agent->RawName();
+        json["agents"]["by_id"][agent_id_s]["debug_name"]     = agent->DebugName();
+        json["agents"]["by_id"][agent_id_s]["sanitized_name"] = agent->SanitizedName();
+        json["agents"]["by_id"][agent_id_s]["party_id"]       = agent->party_id;
+        json["agents"]["by_id"][agent_id_s]["party_index"]    = agent->party_index;
+        json["agents"]["by_id"][agent_id_s]["primary"]        = agent->primary;
+        json["agents"]["by_id"][agent_id_s]["secondary"]      = agent->secondary;
+        json["agents"]["by_id"][agent_id_s]["profession"]     = agent->profession;
+        json["agents"]["by_id"][agent_id_s]["guild_id"]       = agent->guild_id;
+        json["agents"]["by_id"][agent_id_s]["stats"]          = shared_stats_to_json(agent->stats);
+
+        // attacks
+
+        // attacks dealt (by agent)
+        for (auto& [target_id, action] : agent->stats.attacks_dealt_to_agent) {
+            std::string target_id_s = std::to_string(target_id);
+            if (!action) {
+                json["agents"]["by_id"][agent_id_s]["attacks_dealt_to_agent"][target_id_s] = nlohmann::json::value_t::null;
+                continue;
+            }
+            json["agents"]["by_id"][agent_id_s]["attacks_dealt_to_agent"][target_id_s] = action_to_json(*action);
+        }
+
+        // attacks received (by agent)
+        for (auto& [caster_id, action] : agent->stats.attacks_received_from_agent) {
+            std::string caster_id_s = std::to_string(caster_id);
+            if (!action) {
+                json["agents"]["by_id"][agent_id_s]["attacks_received_from_agent"][caster_id_s] = nlohmann::json::value_t::null;
+                continue;
+            }
+            json["agents"]["by_id"][agent_id_s]["attacks_received_from_agent"][caster_id_s] = action_to_json(*action);
+        }
+
+        // skills
+
+        // skills used
+        json["agents"]["by_id"][agent_id_s]["stats"]["skill_ids_used"] = agent->stats.skill_ids_used;
+        for (uint32_t skill_id : agent->stats.skill_ids_used) {
+            std::string skill_id_s = std::to_string(skill_id);
+            const auto it_skill = agent->stats.skills_used.find(skill_id);
+            if (it_skill == agent->stats.skills_used.end()) {
+                json["agents"]["by_id"][agent_id_s]["stats"]["skills_used"][skill_id_s] = nlohmann::json::value_t::null;
+                continue;
+            }
+            json["agents"]["by_id"][agent_id_s]["stats"]["skills_used"][skill_id_s] = action_to_json(*it_skill->second);
+            json["agents"]["by_id"][agent_id_s]["stats"]["skills_used"][skill_id_s]["skill_id"] = it_skill->second->skill_id;
+        }
+
+        // skills received
+        json["agents"]["by_id"][agent_id_s]["stats"]["skill_ids_received"] = agent->stats.skill_ids_received;
+        for (uint32_t skill_id : agent->stats.skill_ids_received) {
+            std::string skill_id_s = std::to_string(skill_id);
+            const auto it_skill = agent->stats.skills_received.find(skill_id);
+            if (it_skill == agent->stats.skills_received.end()) {
+                json["agents"]["by_id"][agent_id_s]["stats"]["skills_received"][skill_id_s] = nlohmann::json::value_t::null;
+                continue;
+            }
+            json["agents"]["by_id"][agent_id_s]["stats"]["skills_received"][skill_id_s]             = action_to_json(*it_skill->second);
+            json["agents"]["by_id"][agent_id_s]["stats"]["skills_received"][skill_id_s]["skill_id"] = it_skill->second->skill_id;
+        }
+
+        // skills used (by agent)
+        for (auto& [target_id, agent_skill_ids] : agent->stats.skills_ids_used_on_agent) {
+            std::string target_id_s = std::to_string(target_id);
+            auto it_target = agent->stats.skills_used_on_agent.find(target_id);
+            if (it_target == agent->stats.skills_used_on_agent.end()) {
+                json["agents"]["by_id"][agent_id_s]["stats"]["skills_used_on_agent"][target_id_s] = nlohmann::json::value_t::null;
+                continue;
+            }
+            for (uint32_t skill_id : agent_skill_ids) {
+                std::string skill_id_s = std::to_string(skill_id);
+                auto it_skill = it_target->second.find(skill_id);
+                if (it_skill == it_target->second.end()) {
+                    json["agents"]["by_id"][agent_id_s]["stats"]["skills_used_on_agent"][target_id_s][skill_id_s] = nlohmann::json::value_t::null;
+                    continue;
+                }
+                json["agents"]["by_id"][agent_id_s]["stats"]["skills_used_on_agent"][target_id_s][skill_id_s] = action_to_json(*it_skill->second);
+            }
+        }
+
+        // skills received (by agent)
+        for (auto& [caster_id, agent_skill_ids] : agent->stats.skills_ids_received_by_agent) {
+            std::string caster_id_s = std::to_string(caster_id);
+            auto it_target = agent->stats.skills_received_from_agent.find(caster_id);
+            if (it_target == agent->stats.skills_received_from_agent.end()) {
+                json["agents"]["by_id"][agent_id_s]["stats"]["skills_received_from_agent"][caster_id_s] = nlohmann::json::value_t::null;
+                continue;
+            }
+            for (uint32_t skill_id : agent_skill_ids) {
+                std::string skill_id_s = std::to_string(skill_id);
+                auto it_skill = it_target->second.find(skill_id);
+                if (it_skill == it_target->second.end()) {
+                    json["agents"]["by_id"][agent_id_s]["stats"]["skills_received_from_agent"][caster_id_s][skill_id_s] = nlohmann::json::value_t::null;
+                    continue;
+                }
+                json["agents"]["by_id"][agent_id_s]["stats"]["skills_received_from_agent"][caster_id_s][skill_id_s] = action_to_json(*it_skill->second);
+            }
+        }
+    }
+
+    json["name"] = name;
+
+    return json;
+}
+
+std::string ObserverExportWindow::PadLeft(std::string input, uint8_t count, char c) {
+    input.insert(input.begin(), count - input.size(), c);
+    return input;
+}
+
+
 // Export as JSON
-void ObserverExportWindow::ExportToJSON() {
-    std::wstring file_location = Resources::GetPath(L"observer.json");
+void ObserverExportWindow::ExportToJSON(Version version) {
+    nlohmann::json json;
+    std::string filename;
+    SYSTEMTIME time;
+    GetLocalTime(&time);
+    std::string year = std::to_string(time.wYear);
+    std::string month = std::to_string(time.wMonth);
+    std::string day = std::to_string(time.wDay);
+    std::string hour = std::to_string(time.wHour);
+    std::string minute = std::to_string(time.wMinute);
+    std::string second = std::to_string(time.wSecond);
+    std::string export_time = PadLeft(year, 4, '0')
+        + "-"
+        + PadLeft(month, 2, '0')
+        + "-"
+        + PadLeft(day, 2, '0')
+        + "T"
+        + PadLeft(hour, 2, '0')
+        + "-"
+        + PadLeft(minute, 2, '0')
+        + "-"
+        + PadLeft(second, 2, '0');
+
+    switch (version) {
+        case Version::V_0_1: {
+            json = ToJSON_V_0_1();
+            json["verson"] = "0.1";
+            json["exported_at_local"] = export_time;
+            filename = export_time + "_observer.json";
+            json["filename"] = filename;
+            break;
+        }
+        case Version::V_1_0: {
+            json = ToJSON_V_1_0();
+            json["verson"] = "1.0";
+            json["exported_at_local"] = export_time;
+            std::string name = json["name"].dump();
+            // remove quotation marks (come in from json.dump())
+            name.erase(std::remove(name.begin(), name.end(), '"'), name.end());
+            // replace spaces with _
+            std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c){
+                return static_cast<unsigned char>(c == ' ' ? '_' : c);
+            });
+            // replace non-alphanumeric with "x" to make simply FS safe, but also show something is missing
+            name = std::regex_replace(name, std::regex("[^A-Za-z0-9.-_]/g"), "x");
+            filename = export_time + "_" + name + ".json";
+            json["filename"] = filename;
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+
+    Resources::EnsureFolderExists(Resources::GetPath(L"observer"));
+    std::wstring file_location = Resources::GetPath(L"observer\\" + GuiUtils::StringToWString(filename));
     if (PathFileExistsW(file_location.c_str())) {
         DeleteFileW(file_location.c_str());
     }
 
-    nlohmann::json json = ToJSON();
     std::ofstream out(file_location);
     out << json.dump();
     out.close();
@@ -163,8 +497,11 @@ void ObserverExportWindow::Draw(IDirect3DDevice9* pDevice) {
 
     ImGui::Text("Export Observer matches to JSON");
 
-    if (ImGui::Button("Export to JSON"))
-        ExportToJSON();
+    if (ImGui::Button("Export to JSON (Version 0.1)"))
+        ExportToJSON(Version::V_0_1);
+
+    if (ImGui::Button("Export to JSON (Version 1.0)"))
+        ExportToJSON(Version::V_1_0);
 
     ImGui::End();
 }
@@ -184,3 +521,4 @@ void ObserverExportWindow::SaveSettings(CSimpleIni* ini) {
 void ObserverExportWindow::DrawSettingInternal() {
     // No internal settings yet
 }
+

--- a/GWToolboxdll/Windows/ObserverExportWindow.h
+++ b/GWToolboxdll/Windows/ObserverExportWindow.h
@@ -27,15 +27,15 @@ public:
         return instance;
     }
 
-    nlohmann::json ToJSON();
-    void ExportToJSON();
+    enum class Version {
+        V_0_1,
+        V_1_0
+    };
 
-    nlohmann::json ObservableAgentToJSON(ObserverModule::ObservableAgent& agent);
-    nlohmann::json SharedStatsToJSON(ObserverModule::SharedStats& stats);
-    nlohmann::json ObservableAgentStatsToJSON(ObserverModule::ObservableAgentStats& stats);
-    nlohmann::json ObservablePartyStatsToJSON(ObserverModule::ObservablePartyStats& stats);
-    nlohmann::json ObservablePartyToJSON(ObserverModule::ObservableParty& party);
-    nlohmann::json ObservableSkillToJSON(ObserverModule::ObservableSkill& skill);
+    std::string PadLeft(std::string input, uint8_t count, char c);
+    nlohmann::json ToJSON_V_0_1();
+    nlohmann::json ToJSON_V_1_0();
+    void ExportToJSON(Version version);
 
     const char* Name() const override { return "Observer Export"; };
     const char* Icon() const override { return ICON_FA_EYE; }

--- a/GWToolboxdll/Windows/ObserverPartyWindow.cpp
+++ b/GWToolboxdll/Windows/ObserverPartyWindow.cpp
@@ -20,27 +20,6 @@
 
 #define NO_AGENT 0
 
-// row: [#] [name        ] [kills] [deaths] [kdr] [skill_rupts] [skill_cancels] [skills_finished]
-
-// row:
-
-// [#:tiny]
-// [name:long]
-// [kills:tiny]
-// [deaths:tiny]
-// [kdr:tiny]
-// [cancels:tiny]
-// [rupts:tiny]
-// [kds:tiny]
-// [-atk:tiny]
-// [+atk:tiny]
-// [-crt:tiny]
-// [+crt:tiny]
-// [-skl:tiny]
-// [+skl:tiny]
-
-
-
 void ObserverPartyWindow::Initialize() {
     ToolboxWindow::Initialize();
 }
@@ -56,10 +35,33 @@ void ObserverPartyWindow::DrawHeaders(const size_t party_count) {
     }
 
     for (size_t i = 0; i < party_count; i += 1) {
-        // don't flip it
+		// [profession:short]
+		if (show_profession) {
+			ImGui::Text(ObserverLabel::Profession);
+			ImGui::SameLine(offset += text_short);
+        }
+
         // [name:long]
         ImGui::Text(ObserverLabel::Name);
         ImGui::SameLine(offset += text_long);
+
+		// [guild-tag:short]
+		if (show_player_guild_tag) {
+			ImGui::Text(ObserverLabel::PlayerGuildTag);
+			ImGui::SameLine(offset += text_short);
+        }
+
+		// [guild-rating:tiny]
+		if (show_player_guild_rating) {
+			ImGui::Text(ObserverLabel::PlayerGuildRating);
+			ImGui::SameLine(offset += text_tiny);
+        }
+
+		// [guild-rank]
+		if (show_player_guild_rank) {
+			ImGui::Text(ObserverLabel::PlayerGuildRank);
+			ImGui::SameLine(offset += text_tiny);
+        }
 
 		// [kills:tiny]
 		if (show_kills) {
@@ -132,7 +134,6 @@ void ObserverPartyWindow::DrawHeaders(const size_t party_count) {
             ImGui::Text(ObserverLabel::SkillsUsedOnOtherParties);
             ImGui::SameLine(offset += text_tiny);
         }
-
     }
 }
 
@@ -140,35 +141,67 @@ void ObserverPartyWindow::DrawHeaders(const size_t party_count) {
 // Draw a blank
 void ObserverPartyWindow::DrawBlankPartyMember(float& offset) {
 	uint16_t tinys = 0;
-    if (!show_kills) tinys += 1;
-    if (!show_deaths) tinys += 1;
-    if (!show_kdr) tinys += 1;
-    if (!show_cancels) tinys += 1;
-	if (!show_interrupts) tinys += 1;
-	if (!show_knockdowns) tinys += 1;
-	if (!show_received_party_attacks) tinys += 1;
-	if (!show_dealt_party_attacks) tinys += 1;
-	if (!show_received_party_crits) tinys += 1;
-	if (!show_dealt_party_crits) tinys += 1;
-	if (!show_received_party_skills) tinys += 1;
-	if (!show_dealt_party_skills) tinys += 1;
+    uint16_t shorts = 0;
+    if (show_profession) shorts += 1;
+    if (show_player_guild_tag) shorts += 1;
+    if (show_player_guild_rating) tinys += 1;
+    if (show_player_guild_rank) tinys += 1;
+    if (show_kills) tinys += 1;
+    if (show_deaths) tinys += 1;
+    if (show_kdr) tinys += 1;
+    if (show_cancels) tinys += 1;
+	if (show_interrupts) tinys += 1;
+	if (show_knockdowns) tinys += 1;
+	if (show_received_party_attacks) tinys += 1;
+	if (show_dealt_party_attacks) tinys += 1;
+	if (show_received_party_crits) tinys += 1;
+	if (show_dealt_party_crits) tinys += 1;
+	if (show_received_party_skills) tinys += 1;
+	if (show_dealt_party_skills) tinys += 1;
 
     ImGui::Text("");
-    ImGui::SameLine(offset += (text_long + tinys * text_tiny));
+    ImGui::SameLine(offset += (text_long + shorts * text_short + tinys * text_tiny));
 }
 
 
 // Draw a Party Member
-void ObserverPartyWindow::DrawPartyMember(float& offset, ObserverModule::ObservableAgent& agent, const bool odd,
-    const bool is_player, const bool is_target) {
+void ObserverPartyWindow::DrawPartyMember(float& offset, ObserverModule::ObservableAgent& agent, const ObserverModule::ObservableGuild* guild,
+    const bool odd, const bool is_player, const bool is_target) {
     UNREFERENCED_PARAMETER(is_player);
     UNREFERENCED_PARAMETER(is_target);
 
     auto& Text = odd ? ImGui::TextDisabled : ImGui::Text;
 
+    // [profession:short]
+    if (show_profession) {
+		Text(agent.profession.c_str());
+		ImGui::SameLine(offset += text_short);
+    }
+
 	// [name:long]
-	Text(agent.Name().c_str());
+	Text(agent.DisplayName().c_str());
 	ImGui::SameLine(offset += text_long);
+
+    // [guild-tag:short]
+    if (show_player_guild_tag) {
+        if (guild) ImGui::Text(guild->wrapped_tag.c_str());
+		else ImGui::Text("");
+        ImGui::SameLine(offset += text_short);
+    }
+
+    // [guild-rating:tiny]
+    if (show_player_guild_rating) {
+        if (guild) ImGui::Text(std::to_string(guild->rating).c_str());
+		else ImGui::Text("");
+        ImGui::SameLine(offset += text_tiny);
+    }
+
+    // [guild-rank]
+    if (show_player_guild_rank) {
+        if (guild) ImGui::Text(std::to_string(guild->rank).c_str());
+		else ImGui::Text("");
+        ImGui::SameLine(offset += text_tiny);
+    }
 
 	// [kills:tiny]
     if (show_kills) {
@@ -208,13 +241,13 @@ void ObserverPartyWindow::DrawPartyMember(float& offset, ObserverModule::Observa
 
 	// [-atk:tiny]
     if (show_received_party_attacks) {
-		Text(std::to_string(agent.stats.total_attacks_received_by_other_party.finished).c_str());
+		Text(std::to_string(agent.stats.total_attacks_received_from_other_party.finished).c_str());
 		ImGui::SameLine(offset += text_tiny);
     }
 
 	// [+atk:tiny]
     if (show_dealt_party_attacks) {
-		Text(std::to_string(agent.stats.total_attacks_done_on_other_party.finished).c_str());
+		Text(std::to_string(agent.stats.total_attacks_dealt_to_other_party.finished).c_str());
 		ImGui::SameLine(offset += text_tiny);
     }
 
@@ -232,13 +265,13 @@ void ObserverPartyWindow::DrawPartyMember(float& offset, ObserverModule::Observa
 
 	// [-skl:tiny]
     if (show_received_party_skills) {
-		Text(std::to_string(agent.stats.total_skills_received_by_other_party.finished).c_str());
+		Text(std::to_string(agent.stats.total_skills_received_from_other_parties.finished).c_str());
 		ImGui::SameLine(offset += text_tiny);
     }
 
 	// [+skl:tiny]
     if (show_dealt_party_skills) {
-		Text(std::to_string(agent.stats.total_skills_used_on_other_party.finished).c_str());
+		Text(std::to_string(agent.stats.total_skills_used_on_other_parties.finished).c_str());
 		ImGui::SameLine(offset += text_tiny);
     }
 }
@@ -247,9 +280,33 @@ void ObserverPartyWindow::DrawPartyMember(float& offset, ObserverModule::Observa
 // Draw a Party row
 void ObserverPartyWindow::DrawParty(float& offset, const ObserverModule::ObservableParty& party) {
     // [name:long]
-    // TODO: get guild name & put it here
-    ImGui::Text("");
+    ImGui::Text(party.display_name.c_str());
     ImGui::SameLine(offset += text_long);
+
+    // [profession:tiny]
+    if (show_profession) {
+		ImGui::Text("");
+		ImGui::SameLine(offset += text_short);
+    }
+
+    // [guild-tag:short]
+    if (show_player_guild_tag) {
+        // tag is in display_name
+        // this makes it not hideable
+        ImGui::SameLine(offset += text_short);
+    }
+
+    // [guild-rating:tiny]
+    if (show_player_guild_rating) {
+        ImGui::Text(std::to_string(party.rating).c_str());
+        ImGui::SameLine(offset += text_tiny);
+    }
+
+    // [guild-rank]
+    if (show_player_guild_rank) {
+        ImGui::Text(std::to_string(party.rank).c_str());
+        ImGui::SameLine(offset += text_tiny);
+    }
 
     // [kills:tiny]
     if (show_kills) {
@@ -289,13 +346,13 @@ void ObserverPartyWindow::DrawParty(float& offset, const ObserverModule::Observa
 
     // [-atk:tiny]
     if (show_received_party_attacks) {
-		ImGui::Text(std::to_string(party.stats.total_attacks_received_by_other_party.finished).c_str());
+		ImGui::Text(std::to_string(party.stats.total_attacks_received_from_other_party.finished).c_str());
 		ImGui::SameLine(offset += text_tiny);
     }
 
     // [+atk:tiny]
     if (show_dealt_party_attacks) {
-		ImGui::Text(std::to_string(party.stats.total_attacks_done_on_other_party.finished).c_str());
+		ImGui::Text(std::to_string(party.stats.total_attacks_dealt_to_other_party.finished).c_str());
 		ImGui::SameLine(offset += text_tiny);
     }
 
@@ -313,13 +370,13 @@ void ObserverPartyWindow::DrawParty(float& offset, const ObserverModule::Observa
 
     // [-skl:tiny]
     if (show_received_party_skills) {
-		ImGui::Text(std::to_string(party.stats.total_skills_received_by_other_party.finished).c_str());
+		ImGui::Text(std::to_string(party.stats.total_skills_received_from_other_parties.finished).c_str());
 		ImGui::SameLine(offset += text_tiny);
     }
 
     // [+skl:tiny]
     if (show_dealt_party_skills) {
-		ImGui::Text(std::to_string(party.stats.total_skills_used_on_other_party.finished).c_str());
+		ImGui::Text(std::to_string(party.stats.total_skills_used_on_other_parties.finished).c_str());
 		ImGui::SameLine(offset += text_tiny);
     }
 
@@ -344,11 +401,14 @@ void ObserverPartyWindow::Draw(IDirect3DDevice9* pDevice) {
     // this should work with both 2/3(+?) parties, with preference on 2
 
     int max_party_size = 0;
-    const std::vector<ObserverModule::ObservableParty*> parties = observer_module.GetObservablePartyArray();
-    size_t party_count = parties.size();
+    const std::vector<uint32_t>& party_ids = observer_module.GetObservablePartyIds();
+    size_t party_count = party_ids.size();
+    std::vector<const ObserverModule::ObservableParty*> parties;
     size_t actual_party_count = 0;
-    for (const ObserverModule::ObservableParty* party : parties) {
-        if (party == nullptr) continue;
+    for (const uint32_t party_id : party_ids) {
+        const ObserverModule::ObservableParty* party = observer_module.GetObservablePartyById(party_id);
+        if (!party) continue;
+        parties.push_back(party);
         actual_party_count += 1;
         int size = static_cast<int>(party->agent_ids.size());
         if (size > max_party_size) max_party_size = size;
@@ -356,15 +416,14 @@ void ObserverPartyWindow::Draw(IDirect3DDevice9* pDevice) {
 
 
 	float global = ImGui::GetIO().FontGlobalScale;
-	text_long   = 220.0f * global;
+	text_long   = 200.0f * global;
 	text_medium = 150.0f * global;
-	text_short  = 80.0f  * global;
+	text_short  = 55.0f  * global;
 	text_tiny	= 40.0f  * global;
 
-    DrawHeaders(actual_party_count);
-    ImGui::Text(""); // new line
-
-    ImGui::Separator();
+    // DrawHeaders(actual_party_count);
+    // ImGui::Text(""); // new line
+    // ImGui::Separator();
 
     // iterate through each party member
     for (int party_member_index = -1; party_member_index < max_party_size; party_member_index += 1) {
@@ -374,8 +433,11 @@ void ObserverPartyWindow::Draw(IDirect3DDevice9* pDevice) {
         if (party_member_index == 0) {
             ImGui::Text("");
             ImGui::Separator();
+            DrawHeaders(actual_party_count);
+            ImGui::Text("");
+            ImGui::Separator();
         }
-        // force new line
+        // force new line for each player
         else if (party_member_index > 0) ImGui::Text("");
         // else if (party_member_index > 0) ImGui::Separator();
 
@@ -395,16 +457,13 @@ void ObserverPartyWindow::Draw(IDirect3DDevice9* pDevice) {
 				ImGui::SameLine(offset += text_tiny);
 			}
 
-		    ObserverModule::ObservableParty* party = parties[party_index];
-			if (party == nullptr) {
-				// nothing to print...
-			    continue;
-			}
+		    const ObserverModule::ObservableParty* party = parties[party_index];
+            if (!party) return;
 
 			// draw party total
 			if (party_member_index == -1) {
-			    DrawParty(offset, *party);
-		       continue;
+				DrawParty(offset, *party);
+				continue;
 		    }
 
 
@@ -426,13 +485,14 @@ void ObserverPartyWindow::Draw(IDirect3DDevice9* pDevice) {
 			// party_member not found
 	        ObserverModule::ObservableAgent* party_member =
 				observer_module.GetObservableAgentById(party_member_id);
-	        if (party_member == nullptr) {
+	        if (!party_member) {
 			    DrawBlankPartyMember(offset);
 			    continue;
 	        }
 
 	        // party member found!
-	        DrawPartyMember(offset, *party_member, party_member_index % 2, false, false);
+            const ObserverModule::ObservableGuild* guild = observer_module.GetObservableGuildById(party_member->guild_id);
+	        DrawPartyMember(offset, *party_member, guild, party_member_index % 2, false, false);
 		}
     }
 
@@ -445,6 +505,10 @@ void ObserverPartyWindow::LoadSettings(CSimpleIni* ini) {
 	ToolboxWindow::LoadSettings(ini);
 
 	show_player_number = ini->GetBoolValue(Name(), VAR_NAME(show_player_number), true);
+	show_profession = ini->GetBoolValue(Name(), VAR_NAME(show_profession), true);
+    show_player_guild_tag = ini->GetBoolValue(Name(), VAR_NAME(show_player_guild_tag), true);
+    show_player_guild_rating = ini->GetBoolValue(Name(), VAR_NAME(show_player_guild_rating), false);
+    show_player_guild_rank = ini->GetBoolValue(Name(), VAR_NAME(show_player_guild_rank), false);
     show_kills = ini->GetBoolValue(Name(), VAR_NAME(show_kills), true);
     show_deaths = ini->GetBoolValue(Name(), VAR_NAME(show_deaths), true);
     show_kdr = ini->GetBoolValue(Name(), VAR_NAME(show_kdr), true);
@@ -465,6 +529,10 @@ void ObserverPartyWindow::SaveSettings(CSimpleIni* ini) {
 	ToolboxWindow::SaveSettings(ini);
 
 	ini->SetBoolValue(Name(), VAR_NAME(show_player_number), show_player_number);
+    ini->SetBoolValue(Name(), VAR_NAME(show_profession), show_profession);
+    ini->SetBoolValue(Name(), VAR_NAME(show_player_guild_tag), show_player_guild_tag);
+    ini->SetBoolValue(Name(), VAR_NAME(show_player_guild_rank), show_player_guild_rank);
+    ini->SetBoolValue(Name(), VAR_NAME(show_player_guild_rating), show_player_guild_rating);
     ini->SetBoolValue(Name(), VAR_NAME(show_kills), show_kills);
     ini->SetBoolValue(Name(), VAR_NAME(show_deaths), show_deaths);
     ini->SetBoolValue(Name(), VAR_NAME(show_kdr), show_kdr);
@@ -483,6 +551,22 @@ void ObserverPartyWindow::SaveSettings(CSimpleIni* ini) {
 void ObserverPartyWindow::DrawSettingInternal() {
     ImGui::Text("Make sure the Observer Module is enabled.");
     ImGui::Checkbox("Show player number (#)", &show_player_number);
+    ImGui::Checkbox((std::string("Show professions (")
+		+ ObserverLabel::Profession
+		+ ")").c_str(), &show_profession);
+
+    ImGui::Checkbox((std::string("Show Player Guild Tags (")
+		+ ObserverLabel::PlayerGuildTag
+		+ ")").c_str(), &show_player_guild_tag);
+
+    ImGui::Checkbox((std::string("Show Player Guild Rating (")
+		+ ObserverLabel::PlayerGuildRating
+		+ ")").c_str(), &show_player_guild_rating);
+
+    ImGui::Checkbox((std::string("Show Player Guild Rank (")
+		+ ObserverLabel::PlayerGuildRank
+		+ ")").c_str(), &show_player_guild_rank);
+
     ImGui::Checkbox((std::string("Show kills (")
 		+ ObserverLabel::Kills
 		+ ")").c_str(), &show_kills);

--- a/GWToolboxdll/Windows/ObserverPartyWindow.h
+++ b/GWToolboxdll/Windows/ObserverPartyWindow.h
@@ -36,8 +36,8 @@ public:
     void Initialize() override;
 
     void DrawBlankPartyMember(float& offset);
-    void DrawPartyMember(float& offset, ObserverModule::ObservableAgent& agent, const bool odd,
-        const bool is_player, const bool is_target);
+    void DrawPartyMember(float& offset, ObserverModule::ObservableAgent& agent, const ObserverModule::ObservableGuild* guild,
+        const bool odd, const bool is_player, const bool is_target);
     void DrawParty(float& offset, const ObserverModule::ObservableParty& party);
     void DrawHeaders(const size_t party_count);
 
@@ -54,6 +54,10 @@ protected:
 
 
     bool show_player_number = true;
+    bool show_profession = true;
+    bool show_player_guild_tag = true;
+    bool show_player_guild_rating = false;
+    bool show_player_guild_rank = false;
     bool show_kills = true;
     bool show_deaths = true;
     bool show_kdr = true;

--- a/GWToolboxdll/Windows/ObserverPlayerWindow.cpp
+++ b/GWToolboxdll/Windows/ObserverPlayerWindow.cpp
@@ -130,7 +130,7 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9* pDevice) {
     } else if (!tracking) {
         ImGui::Text("No selection");
     } else {
-        ImGui::Text(tracking->Name().c_str());
+        ImGui::Text(tracking->DisplayName().c_str());
 
         float global = ImGui::GetIO().FontGlobalScale;
         text_long   = 220.0f * global;
@@ -149,9 +149,9 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9* pDevice) {
     }
 
 
-    if (show_comparison && compared) {
+    if (show_comparison && compared && !(!show_skills_used_on_self && tracking && compared->agent_id == tracking->agent_id)) {
         // skills
-        ImGui::Text((std::string("Skills used on: ") + compared->Name()).c_str());
+        ImGui::Text((std::string("Skills used on: ") + compared->DisplayName()).c_str());
         DrawSkillHeaders();
         ImGui::Separator();
             auto it_used_on_agent_skills = tracking->stats.skills_used_on_agent.find(compared->agent_id);
@@ -171,6 +171,7 @@ void ObserverPlayerWindow::LoadSettings(CSimpleIni* ini) {
 
     show_tracking = ini->GetBoolValue(Name(), VAR_NAME(show_tracking), true);
     show_comparison = ini->GetBoolValue(Name(), VAR_NAME(show_comparison), true);
+    show_comparison = ini->GetBoolValue(Name(), VAR_NAME(show_skills_used_on_self), true);
 }
 
 
@@ -180,6 +181,7 @@ void ObserverPlayerWindow::SaveSettings(CSimpleIni* ini) {
 
     ini->SetBoolValue(Name(), VAR_NAME(show_tracking), show_tracking);
     ini->SetBoolValue(Name(), VAR_NAME(show_comparison), show_comparison);
+    ini->SetBoolValue(Name(), VAR_NAME(show_skills_used_on_self), show_skills_used_on_self);
 }
 
 // Draw settings
@@ -187,4 +189,5 @@ void ObserverPlayerWindow::DrawSettingInternal() {
     ImGui::Text("Make sure the Observer Module is enabled.");
     ImGui::Checkbox("Show tracking player", &show_tracking);
     ImGui::Checkbox("Show player comparison", &show_comparison);
+    ImGui::Checkbox("Show skills used on self", &show_skills_used_on_self);
 }

--- a/GWToolboxdll/Windows/ObserverPlayerWindow.h
+++ b/GWToolboxdll/Windows/ObserverPlayerWindow.h
@@ -59,4 +59,5 @@ protected:
 
     bool show_tracking = true;
     bool show_comparison = true;
+    bool show_skills_used_on_self = true;
 };

--- a/GWToolboxdll/Windows/PacketLoggerWindow.h
+++ b/GWToolboxdll/Windows/PacketLoggerWindow.h
@@ -4,6 +4,9 @@
 
 #include <ToolboxWindow.h>
 
+#include <chrono>
+
+
 class PacketLoggerWindow : public ToolboxWindow {
     PacketLoggerWindow() {};
     ~PacketLoggerWindow() { ClearMessageLog(); };
@@ -15,6 +18,7 @@ public:
 
     const char* Name() const override { return "Packet Logger"; }
     void Draw(IDirect3DDevice9* pDevice) override;
+    void DrawSettingInternal() override;
 
     void Initialize() override;
     void SaveSettings(CSimpleIni* ini) override;
@@ -26,8 +30,18 @@ public:
     void AddMessageLog(const wchar_t* encoded);
     void SaveMessageLog();
     void ClearMessageLog();
+    void PacketHandler(GW::HookStatus* status, GW::Packet::StoC::PacketBase* packet);
+    void CtoSHandler(GW::HookStatus* status, void* packet);
+    std::string PadLeft(std::string input, uint8_t count, char c);
+    std::string PrefixTimestamp(std::string message);
     
 private:
+    enum TimestampType : int {
+        TimestampType_None,
+        TimestampType_Local,
+        TimestampType_Instance,
+    };
+
     std::unordered_map<std::wstring, std::wstring*> message_log;
     std::wstring* last_message_decoded = nullptr;
     uint32_t identifiers[512] = { 0 }; // Presume 512 is big enough for header size...
@@ -44,4 +58,10 @@ private:
     GW::HookEntry MessageCore_Entry;
     GW::HookEntry MessageLocal_Entry;
     GW::HookEntry NpcGeneralStats_Entry;
+
+    int timestamp_type = TimestampType::TimestampType_None;
+    bool timestamp_show_hours = true;
+    bool timestamp_show_minutes = true;
+    bool timestamp_show_seconds = true;
+    bool timestamp_show_milliseconds = true;
 };


### PR DESCRIPTION
- Add Map info to ObserverModule
- Add Guilds info to ObserverModule
- Replaced some packets with their GWCA versions
- Move lots of functions from .h files to .cpp files
- Fix bug causing a parties received skills stats to not be tracked properly
- Fixed a bug causing a player to be removed from the ObserverPartyWindow if they disconnect
- Added additional stats for Skills usage
- Big upgrade to ObserverModeExportWindow - can now export all ObserverMode data as normalised JSON
- Added optional timestamp to PacketLoggerWindow