### PR TITLE
observer module: don't credit NPC kills

### DIFF
--- a/GWToolboxdll/Modules/ObserverModule.cpp
+++ b/GWToolboxdll/Modules/ObserverModule.cpp
@@ -345,17 +345,19 @@ void ObserverModule::HandleAgentState(const uint32_t agent_id, const uint32_t st
 
     // notify the party
     ObservableParty* party = GetObservablePartyById(observable_agent->party_id);
-    if (party)
-        party->stats.HandleDeath();
+
+    // only grant a kill if the victim belonged to a party
+    // (don't count footmen/archer/bodyguard/lord/ghostly kills)
+    if (!party) return;
+    party->stats.HandleDeath();
+
     // credit the kill to the last-hitter and their party,
-    // only if the dead guy belongs to a party
     ObservableAgent* killer = GetObservableAgentById(observable_agent->last_hit_by);
-    if (killer) {
-        killer->stats.HandleKill();
-        ObservableParty* killer_party = GetObservablePartyById(killer->party_id);
-        if (killer_party)
-            killer_party->stats.HandleKill();
-    }
+    if (!killer) return;
+    killer->stats.HandleKill();
+    ObservableParty* killer_party = GetObservablePartyById(killer->party_id);
+    if (killer_party)
+        killer_party->stats.HandleKill();
 }
 
 


### PR DESCRIPTION
Ensures the ObserverModule only credits kills on party members (players/henchmen), not NPC's (footmen, archers, etc...)

(p.s. thanks for cleaning up the code and fixing the memory leaks)