### PR TITLE
Distance Widget - Added Display Options

### DIFF
--- a/GWToolboxdll/Widgets/DistanceWidget.cpp
+++ b/GWToolboxdll/Widgets/DistanceWidget.cpp
@@ -13,6 +13,8 @@
 
 void DistanceWidget::DrawSettingInternal() {
     ImGui::SameLine(); ImGui::Checkbox("Hide in outpost", &hide_in_outpost);
+    ImGui::SameLine(); ImGui::Checkbox("Show percentage value", &show_perc_value);
+    ImGui::SameLine(); ImGui::Checkbox("Show absolute value", &show_abs_value);
     Colors::DrawSettingHueWheel("Adjacent Range", &color_adjacent, 0);
     Colors::DrawSettingHueWheel("Nearby Range", &color_nearby, 0);
     Colors::DrawSettingHueWheel("Area Range", &color_area, 0);
@@ -24,6 +26,8 @@ void DistanceWidget::DrawSettingInternal() {
 void DistanceWidget::LoadSettings(CSimpleIni* ini) {
     ToolboxWidget::LoadSettings(ini);
     hide_in_outpost = ini->GetBoolValue(Name(), VAR_NAME(hide_in_outpost), hide_in_outpost);
+    show_perc_value = ini->GetBoolValue(Name(), VAR_NAME(show_perc_value), show_perc_value);
+    show_abs_value = ini->GetBoolValue(Name(), VAR_NAME(show_abs_value), show_abs_value);
     color_adjacent = Colors::Load(ini, Name(), VAR_NAME(color_adjacent), color_adjacent);
     color_nearby = Colors::Load(ini, Name(), VAR_NAME(color_nearby), color_nearby);
     color_area = Colors::Load(ini, Name(), VAR_NAME(color_area), color_area);
@@ -35,6 +39,8 @@ void DistanceWidget::LoadSettings(CSimpleIni* ini) {
 void DistanceWidget::SaveSettings(CSimpleIni* ini) {
     ToolboxWidget::SaveSettings(ini);
     ini->SetBoolValue(Name(), VAR_NAME(hide_in_outpost), hide_in_outpost);
+    ini->SetBoolValue(Name(), VAR_NAME(show_perc_value), show_perc_value);
+    ini->SetBoolValue(Name(), VAR_NAME(show_abs_value), show_abs_value);
     Colors::Save(ini, Name(), VAR_NAME(color_adjacent), color_adjacent);
     Colors::Save(ini, Name(), VAR_NAME(color_nearby), color_nearby);
     Colors::Save(ini, Name(), VAR_NAME(color_area), color_area);
@@ -48,17 +54,22 @@ void DistanceWidget::Draw(IDirect3DDevice9* pDevice) {
     if (!visible) return;
     if (hide_in_outpost && GW::Map::GetInstanceType() == GW::Constants::InstanceType::Outpost)
         return;
+    if (!show_perc_value && !show_abs_value)
+        return;
     ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0, 0, 0, 0));
     ImGui::SetNextWindowSize(ImVec2(150, 100), ImGuiCond_FirstUseEver);
     if (ImGui::Begin(Name(), nullptr, GetWinFlags(0, true))) {
-        static char dist_perc[32];
-        static char dist_abs[32];
         GW::Agent* me = GW::Agents::GetPlayer();
         GW::Agent* target = GW::Agents::GetTarget();
         if (me && target && me != target) {
+            constexpr size_t buffer_size = 32;
+            static char dist_perc[buffer_size];
+            static char dist_abs[buffer_size];
             float dist = GW::GetDistance(me->pos, target->pos);
-            snprintf(dist_perc, 32, "%2.0f %s", dist * 100 / GW::Constants::Range::Compass, "%%");
-            snprintf(dist_abs, 32, "%.0f", dist);
+            if (show_perc_value)
+                snprintf(dist_perc, buffer_size, "%2.0f %s", dist * 100 / GW::Constants::Range::Compass, "%%");
+            if (show_abs_value)
+                snprintf(dist_abs, buffer_size, "%.0f", dist);
 
             ImColor color = ImGui::GetStyleColorVec4(ImGuiCol_Text);
             if (dist <= GW::Constants::Range::Adjacent) {
@@ -88,22 +99,26 @@ void DistanceWidget::Draw(IDirect3DDevice9* pDevice) {
             ImGui::PopFont();
 
             // perc
-            ImGui::PushFont(GuiUtils::GetFont(GuiUtils::FontSize::widget_small));
-            cur = ImGui::GetCursorPos();
-            ImGui::SetCursorPos(ImVec2(cur.x + 2, cur.y + 2));
-            ImGui::TextColored(background, dist_perc);
-            ImGui::SetCursorPos(cur);
-            ImGui::TextColored(color, dist_perc);
-            ImGui::PopFont();
+            if (show_perc_value) {
+                ImGui::PushFont(GuiUtils::GetFont(GuiUtils::FontSize::widget_small));
+                cur = ImGui::GetCursorPos();
+                ImGui::SetCursorPos(ImVec2(cur.x + 2, cur.y + 2));
+                ImGui::TextColored(background, dist_perc);
+                ImGui::SetCursorPos(cur);
+                ImGui::TextColored(color, dist_perc);
+                ImGui::PopFont();
+            }
 
             // abs
-            ImGui::PushFont(GuiUtils::GetFont(GuiUtils::FontSize::widget_label));
-            cur = ImGui::GetCursorPos();
-            ImGui::SetCursorPos(ImVec2(cur.x + 2, cur.y + 2));
-            ImGui::TextColored(background, dist_abs);
-            ImGui::SetCursorPos(cur);
-            ImGui::Text(dist_abs);
-            ImGui::PopFont();
+            if (show_abs_value) {
+                ImGui::PushFont(GuiUtils::GetFont(GuiUtils::FontSize::widget_label));
+                cur = ImGui::GetCursorPos();
+                ImGui::SetCursorPos(ImVec2(cur.x + 2, cur.y + 2));
+                ImGui::TextColored(background, dist_abs);
+                ImGui::SetCursorPos(cur);
+                ImGui::Text(dist_abs);
+                ImGui::PopFont();
+            }
         }
     }
     ImGui::End();

--- a/GWToolboxdll/Widgets/DistanceWidget.h
+++ b/GWToolboxdll/Widgets/DistanceWidget.h
@@ -21,6 +21,8 @@ public:
     void LoadSettings(CSimpleIni* ini) override;
     void SaveSettings(CSimpleIni* ini) override;
     bool hide_in_outpost = false;
+    bool show_abs_value = true;
+    bool show_perc_value = true;
 
     Color color_adjacent = 0xFFFFFFFF;
     Color color_nearby = 0xFFFFFFFF;


### PR DESCRIPTION
Added two display options for the distance widget that were also suggested (partially) by the [Issue](https://github.com/HasKha/GWToolboxpp/issues/541#issue-718904959)

- Enable/Disable the percentage distance value
- Enable/Disable the absolute distance value