### PR TITLE
Feature: Copy teambuild

### DIFF
--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -201,7 +201,6 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*) {
                 teambuilds.push_back(tb);
             }
             /* Code for copying a teambuild */
-            static int selectedTeambuild = -1;
             std::vector<const char*> names(teambuilds.size(), "\0");
             std::transform(
                 teambuilds.begin(),
@@ -209,29 +208,18 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*) {
                 names.begin(),
                 [](const TeamHeroBuild& tb) { return tb.name; }
            );
-            const auto width = ImGui::GetWindowContentRegionWidth();
-            ImGui::SetNextItemWidth(width);
-            const std::string copy_text = "Copy Teambuild";
-            // Get the index of the teambuild to be copied
-            const auto flags = ImGuiComboFlags_::ImGuiComboFlags_PopupAlignLeft;
             const int num_elements = static_cast<int>(names.size());
-            if (ImGui::BeginCombo("###copyTeambuild", copy_text.data(), flags)) {
-                for (int n = 0; n < num_elements; n++) {
-                    const bool is_selected = (selectedTeambuild == n);
-                    if (ImGui::Selectable(names[n], is_selected)) selectedTeambuild = n;
-
-                    if (is_selected) ImGui::SetItemDefaultFocus();
-                }
-                ImGui::EndCombo();
-            }
-            // If teambuild was selected, add a copy of it
-            if (selectedTeambuild >= 0) {
+            static int selectedTeambuild = 0;
+            ImGui::PushItemWidth(-60.0f - ImGui::GetStyle().ItemInnerSpacing.x);
+            ImGui::Combo("###teamBuildCombo", &selectedTeambuild, names.data(), num_elements);
+            ImGui::PopItemWidth();
+            ImGui::SameLine(0, ImGui::GetStyle().ItemInnerSpacing.x);
+            if (ImGui::Button("Copy##1", ImVec2(60.0f, 0))) {
                 TeamHeroBuild new_tb = teambuilds[selectedTeambuild];
                 std::string copy_name = std::string(new_tb.name) + " (Copy)";
                 GuiUtils::StrCopy(new_tb.name, copy_name.c_str(), sizeof(new_tb.name));
                 builds_changed = true;
                 teambuilds.push_back(new_tb);
-                selectedTeambuild = -1; // reset to stop adding the team build
             }
         }
         ImGui::End();

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -27,7 +27,7 @@
 #include <Modules/Resources.h>
 #include <Windows/HeroBuildsWindow.h>
 
-#define INI_FILENAME L"herobuilds.ini"
+constexpr const wchar_t* INI_FILENAME = L"herobuilds.ini";
 
 namespace {
 
@@ -198,7 +198,6 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*) {
                 }
 
                 builds_changed = true;
-
                 teambuilds.push_back(tb);
             }
         }
@@ -208,12 +207,14 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*) {
     for (size_t i = 0; i < teambuilds.size(); ++i) {
         if (!teambuilds[i].edit_open) continue;
         TeamHeroBuild& tbuild = teambuilds[i];
-        char winname[256];
-        snprintf(winname, 256, "%s###herobuild%d", tbuild.name, tbuild.ui_id);
+        constexpr size_t winname_buffer_size = 256; 
+        char winname[winname_buffer_size];
+        snprintf(winname, winname_buffer_size, "%s###herobuild%d", tbuild.name, tbuild.ui_id);
         ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
         ImGui::SetNextWindowSize(ImVec2(500, 0), ImGuiCond_FirstUseEver);
         if (ImGui::Begin(winname, &tbuild.edit_open)) {
-            builds_changed |= ImGui::InputText("Hero Build Name", tbuild.name, 128);
+            constexpr size_t name_buffer_size = 128;
+            builds_changed |= ImGui::InputText("Hero Build Name", tbuild.name, name_buffer_size);
             const float btn_width = 50.0f * ImGui::GetIO().FontGlobalScale;
             const float icon_btn_width = btn_width / 1.75f;
             const float panel_width = btn_width + 12.0f;
@@ -235,9 +236,9 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*) {
                 }
                 ImGui::SameLine(offset);
                 ImGui::PushItemWidth(text_item_width);
-                builds_changed |= ImGui::InputText("###name", build.name, 128);
+                builds_changed |= ImGui::InputText("###name", build.name, name_buffer_size);
                 ImGui::SameLine(offset += text_item_width + item_spacing);
-                builds_changed |= ImGui::InputText("###code", build.code, 128);
+                builds_changed |= ImGui::InputText("###code", build.code, name_buffer_size);
                 ImGui::SameLine(offset += text_item_width + item_spacing);
                 if (j == 0) {
                     ImGui::TextDisabled("Player");
@@ -368,7 +369,7 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*) {
         ImGui::End();
     }
 }
-void HeroBuildsWindow::View(const TeamHeroBuild& tbuild, unsigned int idx) {
+void HeroBuildsWindow::View(const TeamHeroBuild& tbuild, size_t idx) {
     if (idx >= tbuild.builds.size()) return;
     const HeroBuild& build = tbuild.builds[idx];
 
@@ -379,11 +380,12 @@ void HeroBuildsWindow::View(const TeamHeroBuild& tbuild, unsigned int idx) {
     }
 
     GW::UI::ChatTemplate* t = new GW::UI::ChatTemplate();
-    t->code.m_buffer = new wchar_t[128];
-    MultiByteToWideChar(CP_UTF8, 0, build.code, -1, t->code.m_buffer, 128);
+    constexpr size_t buffer_size = 128;
+    t->code.m_buffer = new wchar_t[buffer_size];
+    MultiByteToWideChar(CP_UTF8, 0, build.code, -1, t->code.m_buffer, buffer_size);
     t->code.m_size = t->code.m_capacity = wcslen(t->code.m_buffer);
-    t->name = new wchar_t[128];
-    MultiByteToWideChar(CP_UTF8, 0, build_name.c_str(), -1, t->name, 128);
+    t->name = new wchar_t[buffer_size];
+    MultiByteToWideChar(CP_UTF8, 0, build_name.c_str(), -1, t->name, buffer_size);
     GW::GameThread::Enqueue([t] {
         GW::UI::SendUIMessage(GW::UI::kOpenTemplate, t);
         delete[] t->code.m_buffer;
@@ -396,7 +398,7 @@ void HeroBuildsWindow::Send(const TeamHeroBuild& tbuild) {
     if (!std::string(tbuild.name).empty()) {
         send_queue.push(tbuild.name);
     }
-    for (unsigned int i = 0; i < tbuild.builds.size(); ++i) {
+    for (size_t i = 0; i < tbuild.builds.size(); ++i) {
         if (i == 0) {
             const HeroBuild& build = tbuild.builds[i];
             if (build.code[0] == 0 && build.name[0] == 0)
@@ -411,8 +413,8 @@ void HeroBuildsWindow::Send(const TeamHeroBuild& tbuild, size_t idx) {
     const std::string name(build.name);
     const std::string code(build.code);
 
-    const int buf_size = 139;
-    char buf[buf_size];
+    constexpr int buffer_size = 139;
+    char buffer[buffer_size];
     std::string build_name;
     HeroBuildName(tbuild, idx, &build_name);
     if (build_name.empty()) {
@@ -420,20 +422,21 @@ void HeroBuildsWindow::Send(const TeamHeroBuild& tbuild, size_t idx) {
     }
 
     if (code.empty()) {
-        snprintf(buf, buf_size, "%s", build_name.c_str());
+        snprintf(buffer, buffer_size, "%s", build_name.c_str());
     }
     else {
-        snprintf(buf, buf_size, "[%s;%s]", build_name.c_str(), build.code);
+        snprintf(buffer, buffer_size, "[%s;%s]", build_name.c_str(), build.code);
     }
-    if(buf[0])
-        send_queue.push(buf);
+    if(buffer[0])
+        send_queue.push(buffer);
 }
-void HeroBuildsWindow::HeroBuildName(const TeamHeroBuild& tbuild, unsigned int idx, std::string* out) {
+void HeroBuildsWindow::HeroBuildName(const TeamHeroBuild& tbuild, size_t idx, std::string* out) {
     if (idx >= tbuild.builds.size()) return;
     const HeroBuild& build = tbuild.builds[idx];
     const std::string name(build.name);
     const std::string code(build.code);
-    char buf[128];
+    constexpr int buffer_size = 128;
+    char buffer[buffer_size];
     auto id = idx > 0 && build.hero_index > 0 ? HeroIndexToID[build.hero_index] : 0;
     if (name.empty() && code.empty() && id == HeroID::NoHero) {
         return; // nothing to do here
@@ -457,23 +460,22 @@ void HeroBuildsWindow::HeroBuildName(const TeamHeroBuild& tbuild, unsigned int i
             c = HeroName[id];
     }
     if (name.empty()) {
-        if (idx > 0)
-            snprintf(buf, 128, "%s", c);
+        if (idx > 0) snprintf(buffer, buffer_size, "%s", c);
     }
     else {
-        snprintf(buf, 128, "%s (%s)", name.c_str(), idx == 0 ? "Player" : c);
+        snprintf(buffer, buffer_size, "%s (%s)", name.c_str(), idx == 0 ? "Player" : c);
     }
-    if (buf[0])
-        out->assign(buf);
+    if (buffer[0])
+        out->assign(buffer);
 }
-const char* HeroBuildsWindow::BuildName(unsigned int idx) const {
+const char* HeroBuildsWindow::BuildName(size_t idx) const {
     if (idx < teambuilds.size()) {
         return teambuilds[idx].name;
     } else {
         return nullptr;
     }
 }
-void HeroBuildsWindow::Load(unsigned int idx) {
+void HeroBuildsWindow::Load(size_t idx) {
     if (idx < teambuilds.size()) {
         Load(teambuilds[idx]);
     }
@@ -487,13 +489,13 @@ void HeroBuildsWindow::Load(const HeroBuildsWindow::TeamHeroBuild& tbuild) {
     if (tbuild.mode > 0) {
         GW::PartyMgr::SetHardMode(tbuild.mode == 2);
     }
-    for (unsigned int i = 0; i < tbuild.builds.size(); ++i) {
+    for (size_t i = 0; i < tbuild.builds.size(); ++i) {
         Load(tbuild, i);
     }
     send_timer = TIMER_INIT(); // give GW time to update the hero structs after adding them. 
 }
 
-void HeroBuildsWindow::Load(const TeamHeroBuild& tbuild, unsigned int idx ) {
+void HeroBuildsWindow::Load(const TeamHeroBuild& tbuild, size_t idx) {
     if (idx >= tbuild.builds.size()) return;
     if (GW::Map::GetInstanceType() != GW::Constants::InstanceType::Outpost) return;
     const HeroBuild& build = tbuild.builds[idx];
@@ -630,17 +632,18 @@ void HeroBuildsWindow::LoadFromFile() {
         tb.mode = inifile->GetLongValue(section, "mode", false);
         tb.builds.reserve(8);
 
+        constexpr size_t buffer_size = 16;
         for (int i = 0; i < 8; ++i) {
-            char namekey[16];
-            char templatekey[16];
-            char heroindexkey[16];
-            char showpanelkey[16];
-            char behaviorkey[16];
-            snprintf(namekey, 16, "name%d", i);
-            snprintf(templatekey, 16, "template%d", i);
-            snprintf(heroindexkey, 16, "heroindex%d", i);
-            snprintf(showpanelkey, 16, "panel%d", i);
-            snprintf(behaviorkey, 16, "behavior%d", i);
+            char namekey[buffer_size];
+            char templatekey[buffer_size];
+            char heroindexkey[buffer_size];
+            char showpanelkey[buffer_size];
+            char behaviorkey[buffer_size];
+            snprintf(namekey, buffer_size, "name%d", i);
+            snprintf(templatekey, buffer_size, "template%d", i);
+            snprintf(heroindexkey, buffer_size, "heroindex%d", i);
+            snprintf(showpanelkey, buffer_size, "panel%d", i);
+            snprintf(behaviorkey, buffer_size, "behavior%d", i);
             const char* nameval = inifile->GetValue(section, namekey, "");
             const char* templateval = inifile->GetValue(section, templatekey, "");
             int hero_index = inifile->GetLongValue(section, heroindexkey, -1);
@@ -663,6 +666,7 @@ void HeroBuildsWindow::LoadFromFile() {
 }
 
 void HeroBuildsWindow::SaveToFile() {
+    constexpr size_t buffer_size = 16;
     if (builds_changed) {
         if (inifile == nullptr) inifile = new CSimpleIni();
 
@@ -670,24 +674,25 @@ void HeroBuildsWindow::SaveToFile() {
         inifile->Reset();
 
         // then save
-        for (unsigned int i = 0; i < teambuilds.size(); ++i) {
+        for (size_t i = 0; i < teambuilds.size(); ++i) {
             const TeamHeroBuild& tbuild = teambuilds[i];
-            char section[16];
-            snprintf(section, 16, "builds%03d", i);
+            char section[buffer_size];
+            snprintf(section, buffer_size, "builds%03d", i);
             inifile->SetValue(section, "buildname", tbuild.name);
             inifile->SetLongValue(section, "mode", tbuild.mode);
-            for (unsigned int j = 0; j < tbuild.builds.size(); ++j) {
+            for (size_t j = 0; j < tbuild.builds.size(); ++j) {
                 const HeroBuild& build = tbuild.builds[j];
-                char namekey[16];
-                char templatekey[16];
-                char heroindexkey[16];
-                char showpanelkey[16];
-                char behaviorkey[16];
-                snprintf(namekey, 16, "name%d", j);
-                snprintf(templatekey, 16, "template%d", j);
-                snprintf(heroindexkey, 16, "heroindex%d", j);
-                snprintf(showpanelkey, 16, "panel%d", j);
-                snprintf(behaviorkey, 16, "behavior%d", j);
+                
+                char namekey[buffer_size];
+                char templatekey[buffer_size];
+                char heroindexkey[buffer_size];
+                char showpanelkey[buffer_size];
+                char behaviorkey[buffer_size];
+                snprintf(namekey, buffer_size, "name%d", j);
+                snprintf(templatekey, buffer_size, "template%d", j);
+                snprintf(heroindexkey, buffer_size, "heroindex%d", j);
+                snprintf(showpanelkey, buffer_size, "panel%d", j);
+                snprintf(behaviorkey, buffer_size, "behavior%d", j);
                 inifile->SetValue(section, namekey, build.name);
                 inifile->SetValue(section, templatekey, build.code);
                 inifile->SetLongValue(section, heroindexkey, build.hero_index);

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -200,6 +200,39 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*) {
                 builds_changed = true;
                 teambuilds.push_back(tb);
             }
+            /* Code for copying a teambuild */
+            static int selectedTeambuild = -1;
+            std::vector<const char*> names(teambuilds.size(), "\0");
+            std::transform(
+                teambuilds.begin(),
+                teambuilds.end(),
+                names.begin(),
+                [](const TeamHeroBuild& tb) { return tb.name; }
+           );
+            const auto width = ImGui::GetWindowContentRegionWidth();
+            ImGui::SetNextItemWidth(width);
+            const std::string copy_text = "Copy Teambuild";
+            // Get the index of the teambuild to be copied
+            const auto flags = ImGuiComboFlags_::ImGuiComboFlags_PopupAlignLeft;
+            const int num_elements = static_cast<int>(names.size());
+            if (ImGui::BeginCombo("###copyTeambuild", copy_text.data(), flags)) {
+                for (int n = 0; n < num_elements; n++) {
+                    const bool is_selected = (selectedTeambuild == n);
+                    if (ImGui::Selectable(names[n], is_selected)) selectedTeambuild = n;
+
+                    if (is_selected) ImGui::SetItemDefaultFocus();
+                }
+                ImGui::EndCombo();
+            }
+            // If teambuild was selected, add a copy of it
+            if (selectedTeambuild >= 0) {
+                TeamHeroBuild new_tb = teambuilds[selectedTeambuild];
+                std::string copy_name = std::string(new_tb.name) + " (Copy)";
+                GuiUtils::StrCopy(new_tb.name, copy_name.c_str(), sizeof(new_tb.name));
+                builds_changed = true;
+                teambuilds.push_back(new_tb);
+                selectedTeambuild = -1; // reset to stop adding the team build
+            }
         }
         ImGui::End();
     }

--- a/GWToolboxdll/Windows/HeroBuildsWindow.h
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.h
@@ -7,6 +7,8 @@
 #include <Timer.h>
 #include <ToolboxWindow.h>
 
+constexpr size_t BUFFER_SIZE = 128;
+
 class HeroBuildsWindow : public ToolboxWindow {
 private:
     // hero_index is:
@@ -15,12 +17,15 @@ private:
     // 0 for 'no hero', 
     // and 1+ for heroes, order is in HeroIndexToID array
     struct HeroBuild {
-        HeroBuild(const char* n, const char* c, int index = -1, int panel = 0, uint32_t _behavior = 1) : hero_index(index), show_panel(panel), behavior(_behavior) {
+        HeroBuild(const char* n, const char* c, int index = -1, int panel = 0, uint32_t _behavior = 1)
+            : hero_index(index)
+            , show_panel(panel)
+            , behavior(_behavior) {
             GuiUtils::StrCopy(name, n, sizeof(name));
             GuiUtils::StrCopy(code, c, sizeof(code));
         }
-        char name[128];
-        char code[128];
+        char name[BUFFER_SIZE];
+        char code[BUFFER_SIZE];
         int hero_index;
         uint32_t behavior = 1;
         int show_panel = 0;
@@ -34,7 +39,7 @@ private:
         }
         bool edit_open = false;
         int mode = 0; // 0=don't change, 1=normal mode, 2=hard mode
-        char name[128];
+        char name[BUFFER_SIZE];
         std::vector<HeroBuild> builds;
         unsigned int ui_id; // should be const but then assignment operator doesn't get created automatically, and I'm too lazy to redefine it, so just don't change this value, okay?
     };
@@ -101,7 +106,7 @@ private:
             Load,
             Finished
         } stage = Add;
-        char code[128];
+        char code[BUFFER_SIZE];
         size_t party_hero_index = 0xFFFFFFFF;
         GW::Constants::HeroID heroid = GW::Constants::HeroID::NoHero;
         int show_panel = 0;
@@ -112,7 +117,7 @@ private:
             , show_panel(_show_panel)
             , behavior(_behavior)
         {
-            snprintf(code, 128, "%s", c);
+            snprintf(code, BUFFER_SIZE, "%s", c);
             if (behavior < 0 || behavior > 2)
                 behavior = 1;
         }


### PR DESCRIPTION
Implemented the option to copy an existing teambuild as suggested in [Issue](https://github.com/HasKha/GWToolboxpp/issues/586#issue-855880129):

- Combobox to select an existing teambuild
- Copy button to copy the selected teambuild
- Note: Updated some const/constexpr qualifiers

How it looks like:

![image](https://user-images.githubusercontent.com/20141069/119979555-66d5a880-bfbb-11eb-9097-e82bb5e3263d.png)
