### PR TITLE
Update Hotkeys.cpp

### DIFF
--- a/GWToolboxdll/Windows/Hotkeys.cpp
+++ b/GWToolboxdll/Windows/Hotkeys.cpp
@@ -1170,6 +1170,12 @@ void HotkeyDialog::Execute()
         return;
     if (id == 0)
         return;
+    if (isExplorable()) {
+        GW::Agent *target = GW::Agents::GetTarget();
+        if (target && target->type == 0xDB) {
+            GW::Agents::GoNPC(target);
+        }
+    }
     GW::Agents::SendDialog(id);
     if (show_message_in_emote_channel)
         Log::Info("Sent dialog %s (%d)", name, id);


### PR DESCRIPTION
Added gonpc if in explorable. Use case: Putting 8578561,8578567,8581889,8581895, all on 1 key allows you to accept the quest and take the reward for both, Breaching the Stygian Veil, and Brood Wars. (If the quest's are completed) . Without gonpc you'd have to hit the same hotkey 4 times to achieve the same results.