### PR TITLE
added targeting by aget id

### DIFF
--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -283,7 +283,7 @@ void ChatCommands::DrawHelp() {
     ImGui::Bullet(); ImGui::Text("'/target closest' to target the closest agent to you.\n"
         "'/target ee' to target best ebon escape agent.\n"
         "'/target hos' to target best vipers/hos agent.\n"
-        "'/target [name|model_id] [index]' target nearest NPC by name or model_id. \n\tIf index is specified, it will index-th by ID.\n"
+        "'/target [name|model_id] [index]' target nearest NPC by name or model_id. \n\tIf index is specified, it will target index-th by ID.\n"
         "'/target player [name|player_number]' target nearest player by name or player number.\n"
         "'/target gadget [name|gadget_id]' target nearest interactive object by name or gadget_id.\n"
         "'/target priority [partymember]' to target priority target of party member.");

--- a/GWToolboxdll/Modules/ChatCommands.h
+++ b/GWToolboxdll/Modules/ChatCommands.h
@@ -95,6 +95,7 @@ private:
     static bool ParseScale(int scale,PendingTransmo& transmo);
     static bool GetTargetTransmoInfo(PendingTransmo& transmo);
     static void TargetNearest(const wchar_t* model_id_or_name, TargetType type);
+    static const wchar_t* GetRemainingArgsWstr(const wchar_t* message, int argc_start);
 
     static std::vector<ToolboxUIElement*> MatchingWindows(const wchar_t *message, int argc, LPWSTR *argv);
 


### PR DESCRIPTION
added an optional 2nd argument to /target id index, to target based on index-th agent id

this is useful when different party member need to target different enemies with the same model ids