### PR TITLE
Travel to a specific disctrict

### DIFF
--- a/GWToolboxdll/Windows/TravelWindow.cpp
+++ b/GWToolboxdll/Windows/TravelWindow.cpp
@@ -1432,11 +1432,10 @@ bool TravelWindow::ParseDistrict(const std::wstring &s, GW::Constants::District 
 {
     std::string compare = GuiUtils::ToLower(GuiUtils::RemovePunctuation(GuiUtils::WStringToString(s)));
     std::string first_word = compare.substr(0, compare.find(' '));
+    char alias[3];
 
-    // Parse the district number
-    if (isdigit(first_word[first_word.length() - 1])) {
-        number = first_word[first_word.length() - 1] - 48;
-        first_word = first_word.substr(0, first_word.size() - 1);
+    if (sscanf(first_word.c_str(), "%2s%u", alias, &number) == 2) {
+        first_word = first_word.substr(0, strlen(alias));
     }
 
     // Shortcut words e.g "/tp ae" for american english

--- a/GWToolboxdll/Windows/TravelWindow.cpp
+++ b/GWToolboxdll/Windows/TravelWindow.cpp
@@ -1431,16 +1431,25 @@ bool TravelWindow::ParseOutpost(const std::wstring &s, GW::Constants::MapID &out
 bool TravelWindow::ParseDistrict(const std::wstring &s, GW::Constants::District &district, uint32_t &number)
 {
     std::string compare = GuiUtils::ToLower(GuiUtils::RemovePunctuation(GuiUtils::WStringToString(s)));
-    // Shortcut words e.g "/tp ae" for american english
     std::string first_word = compare.substr(0, compare.find(' '));
 
-    TravelWindow &instance = Instance();
-    const auto &shorthand_outpost = instance.shorthand_district_names.find(first_word);
-    if (shorthand_outpost != instance.shorthand_district_names.end()) {
-        const DistrictAlias &outpost_info = shorthand_outpost->second;
-        district = outpost_info.district;
-        number = outpost_info.district_number;
-        return true;
+    // Parse the district number
+    if (isdigit(first_word[first_word.length() - 1])) {
+        number = first_word[first_word.length() - 1] - 48;
+        first_word = first_word.substr(0, first_word.size() - 1);
     }
-    return false;
+
+    // Shortcut words e.g "/tp ae" for american english
+    TravelWindow& instance = Instance();
+    const auto& shorthand_outpost = instance.shorthand_district_names.find(first_word);
+
+    if (shorthand_outpost == instance.shorthand_district_names.end()) {
+        return false;
+    }
+
+    const DistrictAlias& outpost_info = shorthand_outpost->second;
+    district = outpost_info.district;
+    number = outpost_info.district_number ? outpost_info.district_number : number;
+
+    return true;
 }

--- a/GWToolboxdll/Windows/TravelWindow.h
+++ b/GWToolboxdll/Windows/TravelWindow.h
@@ -153,7 +153,6 @@ private:
     const std::map<const std::string, const DistrictAlias> shorthand_district_names = 
     {
         {"ae", {GW::Constants::District::American}},
-        {"ae1", {GW::Constants::District::American,1}},
         {"int", {GW::Constants::District::International}},
         {"ee", {GW::Constants::District::EuropeEnglish}},
         {"eg", {GW::Constants::District::EuropeGerman}},


### PR DESCRIPTION
Allows the /tp command to handle specifying a district number
i.e: `/tp kama ae2` will travel to Kamadan American District 2

Note that I am not that experienced with C++ and my way to parse the district number is probably very wrong. The way I did, it  wont work for districts >9 (this should only happen during events like wintersday/boardwalk, so shouldn't be much of a problem).    
If you have a better way of parsing the district number I'd be glad to update this PR.

Side question, I noticed the code to travel to a specific Guild Hall was removed, is there a reason ?