### PR TITLE
Feat: Party Skill Statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ GWToolbox.aps
 *.sublime-workspace*
 .vs/
 build/
+
+# VSCode stuff
+.vscode/

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -1745,7 +1745,7 @@ void ChatCommands::CmdSkillStatistics(const wchar_t* message, int argc, LPWSTR* 
     if (argc == 2) {
         /* command: /skillstats reset */
         if (arg1 == L"reset") {
-            PartyStatisticsWindow::Instance().ResetPlayerStatistics();
+            PartyStatisticsWindow::Instance().UnsetPlayerStatistics();
         }
         /* command: /skllstats playerNum */
         else {

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -278,7 +278,7 @@ void ChatCommands::DrawHelp() {
     ImGui::Bullet(); ImGui::Text("'/flag [all|clear|<number>]' to flag a hero in the minimap (same as using the buttons by the minimap).");
     ImGui::Bullet(); ImGui::Text("'/flag [all|<number>] [x] [y]' to flag a hero to coordinates [x],[y].");
     ImGui::Bullet(); ImGui::Text("'/flag <number> clear' to clear flag for a hero.");
-
+    
     ImGui::Bullet(); ImGui::Text("'/load [build template|build name] [Hero index]' loads a build. The build name must be between quotes if it contains spaces. First Hero index is 1, last is 7. Leave out for player");
     ImGui::Bullet(); ImGui::Text("'/pcons [on|off]' toggles, enables or disables pcons.");
     const char* toggle_hint = "<name> options: helm, costume, costume_head, cape, <window_or_widget_name>";
@@ -350,30 +350,30 @@ void ChatCommands::Initialize() {
     const DWORD def_scale = 0x64000000;
     // Available Transmo NPCs
     // @Enhancement: Ability to target an NPC in-game and add it to this list via a GUI
-    npc_transmos = {
-        {"charr", {163, def_scale, 0x0004c409, 0, 98820}},
-        {"reindeer", {5, def_scale, 277573, 277576, 32780}},
-        {"gwenpre", {244, def_scale, 116377, 116759, 98820}},
-        {"gwenchan", {245, def_scale, 116377, 283392, 98820}},
+    npc_transmos = { 
+        {"charr", {163, def_scale, 0x0004c409, 0, 98820}}, 
+        {"reindeer", {5, def_scale, 277573, 277576, 32780}}, 
+        {"gwenpre", {244, def_scale, 116377, 116759, 98820}}, 
+        {"gwenchan", {245, def_scale, 116377, 283392, 98820}}, 
         {"eye", {0x1f4, def_scale, 0x9d07, 0, 0}},
-        {"zhu", {298, def_scale, 170283, 170481, 98820}},
-        {"kuunavang", {309, def_scale, 157438, 157527, 98820}},
-        {"beetle", {329, def_scale, 207331, 279211, 98820}},
-        {"polar", {313, def_scale, 277551, 277556, 98820}},
-        {"celepig", {331, def_scale, 279205, 0, 0}},
-        {"mallyx", {315, def_scale, 243812, 0, 98820}},
-        {"bonedragon", {231, def_scale, 16768, 0, 0}},
-        {"destroyer", {312, def_scale, 285891, 285900, 98820}},
-        {"destroyer2", {146, def_scale, 285886, 285890, 32780}},
-        {"koss", {250, def_scale, 243282, 245053, 98820}},
-        {"smite", {346, def_scale, 129664, 0, 98820}},
-        {"dorian", {8299, def_scale, 86510, 0, 98820}},
-        {"kanaxai", {317, def_scale, 184176, 185319, 98820}},
-        {"skeletonic", {359, def_scale, 52356, 0, 98820}},
+        {"zhu", {298, def_scale, 170283, 170481, 98820}}, 
+        {"kuunavang", {309, def_scale, 157438, 157527, 98820}}, 
+        {"beetle", {329, def_scale, 207331, 279211, 98820}},     
+        {"polar", {313, def_scale, 277551, 277556, 98820}},    
+        {"celepig", {331, def_scale, 279205, 0, 0}},  
+        {"mallyx", {315, def_scale, 243812, 0, 98820}},     
+        {"bonedragon", {231, def_scale, 16768, 0, 0}},     
+        {"destroyer", {312, def_scale, 285891, 285900, 98820}},   
+        {"destroyer2", {146, def_scale, 285886, 285890, 32780}},    
+        {"koss", {250, def_scale, 243282, 245053, 98820}},     
+        {"smite", {346, def_scale, 129664, 0, 98820}}, 
+        {"dorian", {8299, def_scale, 86510, 0, 98820}},         
+        {"kanaxai", {317, def_scale, 184176, 185319, 98820}},         
+        {"skeletonic", {359, def_scale, 52356, 0, 98820}},          
         {"moa", {504, def_scale, 16689, 0, 98820}}
     };
 
-    // you can create commands here in-line with a lambda, but only if they are only
+    // you can create commands here in-line with a lambda, but only if they are only 
     // a couple of lines and not used multiple times
     GW::Chat::CreateCommand(L"ff", [](const wchar_t*, int, LPWSTR*) {
         GW::Chat::SendChat('/', "resign");
@@ -443,7 +443,7 @@ bool ChatCommands::WndProc(UINT Message, WPARAM wParam, LPARAM lParam) {
                 case VK_W:
                 case VK_X:
                 case VK_Z:
-
+                
                 case VK_ESCAPE:
                 case VK_UP:
                 case VK_DOWN:
@@ -460,8 +460,8 @@ void ChatCommands::Update(float delta) {
 
     if (delta == 0.f) return;
 
-    if (GW::CameraMgr::GetCameraUnlock()
-        && !GW::Chat::GetIsTyping()
+    if (GW::CameraMgr::GetCameraUnlock() 
+        && !GW::Chat::GetIsTyping() 
         && !ImGui::GetIO().WantTextInput) {
 
         float forward = 0;
@@ -675,8 +675,8 @@ void ChatCommands::CmdEnterMission(const wchar_t*, int argc, LPWSTR* argv) {
     const char* const error_fow_uw_syntax = "Use '/enter fow' or '/enter uw' to trigger entry";
     const char* const error_no_scrolls = "Unable to enter elite area; no scroll found";
     const char* const error_not_leading = "Unable to enter mission; you're not party leader";
-
-    if (GW::Map::GetInstanceType() != GW::Constants::InstanceType::Outpost)
+    
+    if (GW::Map::GetInstanceType() != GW::Constants::InstanceType::Outpost) 
         return Log::Error(error_use_from_outpost);
 
     switch (GW::Map::GetMapID()) {
@@ -741,7 +741,7 @@ void ChatCommands::CmdDialog(const wchar_t *, int argc, LPWSTR *argv) {
 void ChatCommands::CmdChest(const wchar_t *, int, LPWSTR * argv) {
     if (!IsMapReady())
         return;
-    if (wcscmp(argv[0], L"chest") == 0
+    if (wcscmp(argv[0], L"chest") == 0 
         && GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable) {
         const GW::Agent* const target = GW::Agents::GetTarget();
         if (target && target->type == 0x200) {
@@ -760,7 +760,7 @@ void ChatCommands::CmdTB(const wchar_t *message, int argc, LPWSTR *argv) {
         MainWindow::Instance().visible ^= 1;
         return;
     }
-
+    
     if (argc < 3) {
         const std::wstring arg = GuiUtils::ToLower(argv[1]);
         if (arg == L"hide") { // e.g. /tb hide
@@ -1099,7 +1099,7 @@ void ChatCommands::CmdTarget(const wchar_t *message, int argc, LPWSTR *argv) {
             Log::Info("Target model id (PlayerNumber) is %d", target->player_number);
         }
         return;
-    }
+    } 
     if (arg1 == L"getpos") {
         const GW::AgentLiving* const target = GW::Agents::GetTargetAsAgentLiving();
         if (target == nullptr) {
@@ -1316,15 +1316,15 @@ void ChatCommands::CmdPingEquipment(const wchar_t* message, int argc, LPWSTR* ar
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 1), 3);
     else if (arg1 == L"offhand" || arg1 == L"shield")
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 2), 3);
-    else if (arg1 == L"chest")
+    else if (arg1 == L"chest")      
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 3), 2);
-    else if (arg1 == L"legs")
+    else if (arg1 == L"legs")       
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 4), 2);
     else if (arg1 == L"head")
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 5), 2);
-    else if (arg1 == L"boots" || arg1 == L"feet")
+    else if (arg1 == L"boots" || arg1 == L"feet")       
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 6), 2);
-    else if (arg1 == L"gloves" || arg1 == L"hands")
+    else if (arg1 == L"gloves" || arg1 == L"hands")     
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 7), 2);
     else if (arg1 == L"weapons") {
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 1),3);
@@ -1397,7 +1397,7 @@ bool ChatCommands::ParseScale(int scale, PendingTransmo& transmo) {
 }
 
 void ChatCommands::CmdTransmoTarget(const wchar_t*, int argc, LPWSTR* argv) {
-
+    
     const GW::AgentLiving* const target = GW::Agents::GetTargetAsAgentLiving();
     if (argc < 2) {
         Log::Error("Missing /transmotarget argument");
@@ -1428,7 +1428,7 @@ void ChatCommands::CmdTransmoTarget(const wchar_t*, int argc, LPWSTR* argv) {
 
 void ChatCommands::CmdTransmo(const wchar_t *, int argc, LPWSTR *argv) {
     PendingTransmo transmo;
-
+    
     if (argc > 1) {
         int iscale;
         if (wcsncmp(argv[1], L"reset", 5) == 0) {

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -277,7 +277,7 @@ void ChatCommands::DrawHelp() {
     ImGui::Bullet(); ImGui::Text("'/flag [all|clear|<number>]' to flag a hero in the minimap (same as using the buttons by the minimap).");
     ImGui::Bullet(); ImGui::Text("'/flag [all|<number>] [x] [y]' to flag a hero to coordinates [x],[y].");
     ImGui::Bullet(); ImGui::Text("'/flag <number> clear' to clear flag for a hero.");
-    
+
     ImGui::Bullet(); ImGui::Text("'/load [build template|build name] [Hero index]' loads a build. The build name must be between quotes if it contains spaces. First Hero index is 1, last is 7. Leave out for player");
     ImGui::Bullet(); ImGui::Text("'/pcons [on|off]' toggles, enables or disables pcons.");
     const char* toggle_hint = "<name> options: helm, costume, costume_head, cape, <window_or_widget_name>";
@@ -349,30 +349,30 @@ void ChatCommands::Initialize() {
     const DWORD def_scale = 0x64000000;
     // Available Transmo NPCs
     // @Enhancement: Ability to target an NPC in-game and add it to this list via a GUI
-    npc_transmos = { 
-        {"charr", {163, def_scale, 0x0004c409, 0, 98820}}, 
-        {"reindeer", {5, def_scale, 277573, 277576, 32780}}, 
-        {"gwenpre", {244, def_scale, 116377, 116759, 98820}}, 
-        {"gwenchan", {245, def_scale, 116377, 283392, 98820}}, 
+    npc_transmos = {
+        {"charr", {163, def_scale, 0x0004c409, 0, 98820}},
+        {"reindeer", {5, def_scale, 277573, 277576, 32780}},
+        {"gwenpre", {244, def_scale, 116377, 116759, 98820}},
+        {"gwenchan", {245, def_scale, 116377, 283392, 98820}},
         {"eye", {0x1f4, def_scale, 0x9d07, 0, 0}},
-        {"zhu", {298, def_scale, 170283, 170481, 98820}}, 
-        {"kuunavang", {309, def_scale, 157438, 157527, 98820}}, 
-        {"beetle", {329, def_scale, 207331, 279211, 98820}},     
-        {"polar", {313, def_scale, 277551, 277556, 98820}},    
-        {"celepig", {331, def_scale, 279205, 0, 0}},  
-        {"mallyx", {315, def_scale, 243812, 0, 98820}},     
-        {"bonedragon", {231, def_scale, 16768, 0, 0}},     
-        {"destroyer", {312, def_scale, 285891, 285900, 98820}},   
-        {"destroyer2", {146, def_scale, 285886, 285890, 32780}},    
-        {"koss", {250, def_scale, 243282, 245053, 98820}},     
-        {"smite", {346, def_scale, 129664, 0, 98820}}, 
-        {"dorian", {8299, def_scale, 86510, 0, 98820}},         
-        {"kanaxai", {317, def_scale, 184176, 185319, 98820}},         
-        {"skeletonic", {359, def_scale, 52356, 0, 98820}},          
+        {"zhu", {298, def_scale, 170283, 170481, 98820}},
+        {"kuunavang", {309, def_scale, 157438, 157527, 98820}},
+        {"beetle", {329, def_scale, 207331, 279211, 98820}},
+        {"polar", {313, def_scale, 277551, 277556, 98820}},
+        {"celepig", {331, def_scale, 279205, 0, 0}},
+        {"mallyx", {315, def_scale, 243812, 0, 98820}},
+        {"bonedragon", {231, def_scale, 16768, 0, 0}},
+        {"destroyer", {312, def_scale, 285891, 285900, 98820}},
+        {"destroyer2", {146, def_scale, 285886, 285890, 32780}},
+        {"koss", {250, def_scale, 243282, 245053, 98820}},
+        {"smite", {346, def_scale, 129664, 0, 98820}},
+        {"dorian", {8299, def_scale, 86510, 0, 98820}},
+        {"kanaxai", {317, def_scale, 184176, 185319, 98820}},
+        {"skeletonic", {359, def_scale, 52356, 0, 98820}},
         {"moa", {504, def_scale, 16689, 0, 98820}}
     };
 
-    // you can create commands here in-line with a lambda, but only if they are only 
+    // you can create commands here in-line with a lambda, but only if they are only
     // a couple of lines and not used multiple times
     GW::Chat::CreateCommand(L"ff", [](const wchar_t*, int, LPWSTR*) {
         GW::Chat::SendChat('/', "resign");
@@ -441,7 +441,7 @@ bool ChatCommands::WndProc(UINT Message, WPARAM wParam, LPARAM lParam) {
                 case VK_W:
                 case VK_X:
                 case VK_Z:
-                
+
                 case VK_ESCAPE:
                 case VK_UP:
                 case VK_DOWN:
@@ -458,8 +458,8 @@ void ChatCommands::Update(float delta) {
 
     if (delta == 0.f) return;
 
-    if (GW::CameraMgr::GetCameraUnlock() 
-        && !GW::Chat::GetIsTyping() 
+    if (GW::CameraMgr::GetCameraUnlock()
+        && !GW::Chat::GetIsTyping()
         && !ImGui::GetIO().WantTextInput) {
 
         float forward = 0;
@@ -673,8 +673,8 @@ void ChatCommands::CmdEnterMission(const wchar_t*, int argc, LPWSTR* argv) {
     const char* const error_fow_uw_syntax = "Use '/enter fow' or '/enter uw' to trigger entry";
     const char* const error_no_scrolls = "Unable to enter elite area; no scroll found";
     const char* const error_not_leading = "Unable to enter mission; you're not party leader";
-    
-    if (GW::Map::GetInstanceType() != GW::Constants::InstanceType::Outpost) 
+
+    if (GW::Map::GetInstanceType() != GW::Constants::InstanceType::Outpost)
         return Log::Error(error_use_from_outpost);
 
     switch (GW::Map::GetMapID()) {
@@ -739,7 +739,7 @@ void ChatCommands::CmdDialog(const wchar_t *, int argc, LPWSTR *argv) {
 void ChatCommands::CmdChest(const wchar_t *, int, LPWSTR * argv) {
     if (!IsMapReady())
         return;
-    if (wcscmp(argv[0], L"chest") == 0 
+    if (wcscmp(argv[0], L"chest") == 0
         && GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable) {
         const GW::Agent* const target = GW::Agents::GetTarget();
         if (target && target->type == 0x200) {
@@ -758,7 +758,7 @@ void ChatCommands::CmdTB(const wchar_t *message, int argc, LPWSTR *argv) {
         MainWindow::Instance().visible ^= 1;
         return;
     }
-    
+
     if (argc < 3) {
         const std::wstring arg = GuiUtils::ToLower(argv[1]);
         if (arg == L"hide") { // e.g. /tb hide
@@ -1097,7 +1097,7 @@ void ChatCommands::CmdTarget(const wchar_t *message, int argc, LPWSTR *argv) {
             Log::Info("Target model id (PlayerNumber) is %d", target->player_number);
         }
         return;
-    } 
+    }
     if (arg1 == L"getpos") {
         const GW::AgentLiving* const target = GW::Agents::GetTargetAsAgentLiving();
         if (target == nullptr) {
@@ -1314,15 +1314,15 @@ void ChatCommands::CmdPingEquipment(const wchar_t* message, int argc, LPWSTR* ar
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 1), 3);
     else if (arg1 == L"offhand" || arg1 == L"shield")
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 2), 3);
-    else if (arg1 == L"chest")      
+    else if (arg1 == L"chest")
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 3), 2);
-    else if (arg1 == L"legs")       
+    else if (arg1 == L"legs")
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 4), 2);
     else if (arg1 == L"head")
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 5), 2);
-    else if (arg1 == L"boots" || arg1 == L"feet")       
+    else if (arg1 == L"boots" || arg1 == L"feet")
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 6), 2);
-    else if (arg1 == L"gloves" || arg1 == L"hands")     
+    else if (arg1 == L"gloves" || arg1 == L"hands")
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 7), 2);
     else if (arg1 == L"weapons") {
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 1),3);
@@ -1395,7 +1395,7 @@ bool ChatCommands::ParseScale(int scale, PendingTransmo& transmo) {
 }
 
 void ChatCommands::CmdTransmoTarget(const wchar_t*, int argc, LPWSTR* argv) {
-    
+
     const GW::AgentLiving* const target = GW::Agents::GetTargetAsAgentLiving();
     if (argc < 2) {
         Log::Error("Missing /transmotarget argument");
@@ -1426,7 +1426,7 @@ void ChatCommands::CmdTransmoTarget(const wchar_t*, int argc, LPWSTR* argv) {
 
 void ChatCommands::CmdTransmo(const wchar_t *, int argc, LPWSTR *argv) {
     PendingTransmo transmo;
-    
+
     if (argc > 1) {
         int iscale;
         if (wcsncmp(argv[1], L"reset", 5) == 0) {

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -421,7 +421,7 @@ void ChatCommands::Initialize() {
     });
     GW::Chat::CreateCommand(L"hero", ChatCommands::CmdHeroBehaviour);
     GW::Chat::CreateCommand(L"morale", ChatCommands::CmdMorale);
-    GW::Chat::CreateCommand(L"morale", ChatCommands::CmdSkillStatistics);
+    GW::Chat::CreateCommand(L"skillstats", ChatCommands::CmdSkillStatistics);
 }
 
 bool ChatCommands::WndProc(UINT Message, WPARAM wParam, LPARAM lParam) {

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -49,7 +49,6 @@
 #include <Windows/MainWindow.h>
 #include <Windows/SettingsWindow.h>
 #include <Widgets/TimerWidget.h>
-#include <Windows/PartyStatistics.h>
 
 
 #define F_PI 3.14159265358979323846f
@@ -278,7 +277,7 @@ void ChatCommands::DrawHelp() {
     ImGui::Bullet(); ImGui::Text("'/flag [all|clear|<number>]' to flag a hero in the minimap (same as using the buttons by the minimap).");
     ImGui::Bullet(); ImGui::Text("'/flag [all|<number>] [x] [y]' to flag a hero to coordinates [x],[y].");
     ImGui::Bullet(); ImGui::Text("'/flag <number> clear' to clear flag for a hero.");
-    
+
     ImGui::Bullet(); ImGui::Text("'/load [build template|build name] [Hero index]' loads a build. The build name must be between quotes if it contains spaces. First Hero index is 1, last is 7. Leave out for player");
     ImGui::Bullet(); ImGui::Text("'/pcons [on|off]' toggles, enables or disables pcons.");
     const char* toggle_hint = "<name> options: helm, costume, costume_head, cape, <window_or_widget_name>";
@@ -350,30 +349,30 @@ void ChatCommands::Initialize() {
     const DWORD def_scale = 0x64000000;
     // Available Transmo NPCs
     // @Enhancement: Ability to target an NPC in-game and add it to this list via a GUI
-    npc_transmos = { 
-        {"charr", {163, def_scale, 0x0004c409, 0, 98820}}, 
-        {"reindeer", {5, def_scale, 277573, 277576, 32780}}, 
-        {"gwenpre", {244, def_scale, 116377, 116759, 98820}}, 
-        {"gwenchan", {245, def_scale, 116377, 283392, 98820}}, 
+    npc_transmos = {
+        {"charr", {163, def_scale, 0x0004c409, 0, 98820}},
+        {"reindeer", {5, def_scale, 277573, 277576, 32780}},
+        {"gwenpre", {244, def_scale, 116377, 116759, 98820}},
+        {"gwenchan", {245, def_scale, 116377, 283392, 98820}},
         {"eye", {0x1f4, def_scale, 0x9d07, 0, 0}},
-        {"zhu", {298, def_scale, 170283, 170481, 98820}}, 
-        {"kuunavang", {309, def_scale, 157438, 157527, 98820}}, 
-        {"beetle", {329, def_scale, 207331, 279211, 98820}},     
-        {"polar", {313, def_scale, 277551, 277556, 98820}},    
-        {"celepig", {331, def_scale, 279205, 0, 0}},  
-        {"mallyx", {315, def_scale, 243812, 0, 98820}},     
-        {"bonedragon", {231, def_scale, 16768, 0, 0}},     
-        {"destroyer", {312, def_scale, 285891, 285900, 98820}},   
-        {"destroyer2", {146, def_scale, 285886, 285890, 32780}},    
-        {"koss", {250, def_scale, 243282, 245053, 98820}},     
-        {"smite", {346, def_scale, 129664, 0, 98820}}, 
-        {"dorian", {8299, def_scale, 86510, 0, 98820}},         
-        {"kanaxai", {317, def_scale, 184176, 185319, 98820}},         
-        {"skeletonic", {359, def_scale, 52356, 0, 98820}},          
+        {"zhu", {298, def_scale, 170283, 170481, 98820}},
+        {"kuunavang", {309, def_scale, 157438, 157527, 98820}},
+        {"beetle", {329, def_scale, 207331, 279211, 98820}},
+        {"polar", {313, def_scale, 277551, 277556, 98820}},
+        {"celepig", {331, def_scale, 279205, 0, 0}},
+        {"mallyx", {315, def_scale, 243812, 0, 98820}},
+        {"bonedragon", {231, def_scale, 16768, 0, 0}},
+        {"destroyer", {312, def_scale, 285891, 285900, 98820}},
+        {"destroyer2", {146, def_scale, 285886, 285890, 32780}},
+        {"koss", {250, def_scale, 243282, 245053, 98820}},
+        {"smite", {346, def_scale, 129664, 0, 98820}},
+        {"dorian", {8299, def_scale, 86510, 0, 98820}},
+        {"kanaxai", {317, def_scale, 184176, 185319, 98820}},
+        {"skeletonic", {359, def_scale, 52356, 0, 98820}},
         {"moa", {504, def_scale, 16689, 0, 98820}}
     };
 
-    // you can create commands here in-line with a lambda, but only if they are only 
+    // you can create commands here in-line with a lambda, but only if they are only
     // a couple of lines and not used multiple times
     GW::Chat::CreateCommand(L"ff", [](const wchar_t*, int, LPWSTR*) {
         GW::Chat::SendChat('/', "resign");
@@ -421,7 +420,6 @@ void ChatCommands::Initialize() {
     });
     GW::Chat::CreateCommand(L"hero", ChatCommands::CmdHeroBehaviour);
     GW::Chat::CreateCommand(L"morale", ChatCommands::CmdMorale);
-    GW::Chat::CreateCommand(L"skillstats", ChatCommands::CmdSkillStatistics);
 }
 
 bool ChatCommands::WndProc(UINT Message, WPARAM wParam, LPARAM lParam) {
@@ -443,7 +441,7 @@ bool ChatCommands::WndProc(UINT Message, WPARAM wParam, LPARAM lParam) {
                 case VK_W:
                 case VK_X:
                 case VK_Z:
-                
+
                 case VK_ESCAPE:
                 case VK_UP:
                 case VK_DOWN:
@@ -460,8 +458,8 @@ void ChatCommands::Update(float delta) {
 
     if (delta == 0.f) return;
 
-    if (GW::CameraMgr::GetCameraUnlock() 
-        && !GW::Chat::GetIsTyping() 
+    if (GW::CameraMgr::GetCameraUnlock()
+        && !GW::Chat::GetIsTyping()
         && !ImGui::GetIO().WantTextInput) {
 
         float forward = 0;
@@ -675,8 +673,8 @@ void ChatCommands::CmdEnterMission(const wchar_t*, int argc, LPWSTR* argv) {
     const char* const error_fow_uw_syntax = "Use '/enter fow' or '/enter uw' to trigger entry";
     const char* const error_no_scrolls = "Unable to enter elite area; no scroll found";
     const char* const error_not_leading = "Unable to enter mission; you're not party leader";
-    
-    if (GW::Map::GetInstanceType() != GW::Constants::InstanceType::Outpost) 
+
+    if (GW::Map::GetInstanceType() != GW::Constants::InstanceType::Outpost)
         return Log::Error(error_use_from_outpost);
 
     switch (GW::Map::GetMapID()) {
@@ -741,7 +739,7 @@ void ChatCommands::CmdDialog(const wchar_t *, int argc, LPWSTR *argv) {
 void ChatCommands::CmdChest(const wchar_t *, int, LPWSTR * argv) {
     if (!IsMapReady())
         return;
-    if (wcscmp(argv[0], L"chest") == 0 
+    if (wcscmp(argv[0], L"chest") == 0
         && GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable) {
         const GW::Agent* const target = GW::Agents::GetTarget();
         if (target && target->type == 0x200) {
@@ -760,7 +758,7 @@ void ChatCommands::CmdTB(const wchar_t *message, int argc, LPWSTR *argv) {
         MainWindow::Instance().visible ^= 1;
         return;
     }
-    
+
     if (argc < 3) {
         const std::wstring arg = GuiUtils::ToLower(argv[1]);
         if (arg == L"hide") { // e.g. /tb hide
@@ -1099,7 +1097,7 @@ void ChatCommands::CmdTarget(const wchar_t *message, int argc, LPWSTR *argv) {
             Log::Info("Target model id (PlayerNumber) is %d", target->player_number);
         }
         return;
-    } 
+    }
     if (arg1 == L"getpos") {
         const GW::AgentLiving* const target = GW::Agents::GetTargetAsAgentLiving();
         if (target == nullptr) {
@@ -1316,15 +1314,15 @@ void ChatCommands::CmdPingEquipment(const wchar_t* message, int argc, LPWSTR* ar
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 1), 3);
     else if (arg1 == L"offhand" || arg1 == L"shield")
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 2), 3);
-    else if (arg1 == L"chest")      
+    else if (arg1 == L"chest")
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 3), 2);
-    else if (arg1 == L"legs")       
+    else if (arg1 == L"legs")
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 4), 2);
     else if (arg1 == L"head")
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 5), 2);
-    else if (arg1 == L"boots" || arg1 == L"feet")       
+    else if (arg1 == L"boots" || arg1 == L"feet")
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 6), 2);
-    else if (arg1 == L"gloves" || arg1 == L"hands")     
+    else if (arg1 == L"gloves" || arg1 == L"hands")
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 7), 2);
     else if (arg1 == L"weapons") {
         GameSettings::PingItem(GW::Items::GetItemBySlot(GW::Constants::Bag::Equipped_Items, 1),3);
@@ -1397,7 +1395,7 @@ bool ChatCommands::ParseScale(int scale, PendingTransmo& transmo) {
 }
 
 void ChatCommands::CmdTransmoTarget(const wchar_t*, int argc, LPWSTR* argv) {
-    
+
     const GW::AgentLiving* const target = GW::Agents::GetTargetAsAgentLiving();
     if (argc < 2) {
         Log::Error("Missing /transmotarget argument");
@@ -1428,7 +1426,7 @@ void ChatCommands::CmdTransmoTarget(const wchar_t*, int argc, LPWSTR* argv) {
 
 void ChatCommands::CmdTransmo(const wchar_t *, int argc, LPWSTR *argv) {
     PendingTransmo transmo;
-    
+
     if (argc > 1) {
         int iscale;
         if (wcsncmp(argv[1], L"reset", 5) == 0) {
@@ -1728,50 +1726,5 @@ void ChatCommands::CmdHeroBehaviour(const wchar_t*, int argc, LPWSTR* argv)
         if (hero.owner_player_id == me->login_number) {
             GW::CtoS::SendPacket(0xC, GAME_CMSG_HERO_BEHAVIOR, hero.agent_id, behaviour);
         }
-    }
-}
-
-void ChatCommands::CmdSkillStatistics(const wchar_t* message, int argc, LPWSTR* argv) {
-    UNREFERENCED_PARAMETER(message);
-
-    /* command: /skillstats */
-    /* will write the stats of the self player */
-    if (argc < 2) {
-        PartyStatisticsWindow::Instance().WritePlayerStatistics();
-        return;
-    }
-
-    const auto arg1 = GuiUtils::ToLower(argv[1]);
-
-    if (argc == 2) {
-        /* command: /skillstats reset */
-        if (arg1 == L"reset") {
-            PartyStatisticsWindow::Instance().UnsetPlayerStatistics();
-        }
-        /* command: /skllstats playerNum */
-        else {
-            auto player_number = uint32_t{0};
-            GuiUtils::ParseUInt(argv[1], &player_number);
-            --player_number; // List will start at index zero
-
-            PartyStatisticsWindow::Instance().WritePlayerStatistics(player_number);
-        }
-
-        return;
-    }
-
-    /* command: /skillstats playerNum skillNum */
-    if (argc >= 3) {
-        const auto player_number_arg = argv[1];
-        auto player_number = uint32_t{0};
-
-        GuiUtils::ParseUInt(player_number_arg, &player_number);
-        --player_number; // List will start at index zero
-
-        auto skill_number = uint32_t{0};
-        GuiUtils::ParseUInt(argv[2], &skill_number);
-        --skill_number; // List will start at index zero
-
-        PartyStatisticsWindow::Instance().WritePlayerStatistics(player_number, skill_number);
     }
 }

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -1734,33 +1734,49 @@ void ChatCommands::CmdHeroBehaviour(const wchar_t*, int argc, LPWSTR* argv)
 void ChatCommands::CmdSkillStatistics(const wchar_t* message, int argc, LPWSTR* argv) {
     UNREFERENCED_PARAMETER(message);
 
+    /* command: /skillstats */
     if (argc < 2) {
         PartyStatisticsWindow::Instance().WritePartyStatistics();
         return;
     }
 
-    std::wstring arg1 = GuiUtils::ToLower(argv[1]);
+    const auto arg1 = GuiUtils::ToLower(argv[1]);
 
     if (argc == 2) {
+        /* command: /skillstats reset */
         if (arg1 == L"reset") {
             PartyStatisticsWindow::Instance().ResetPlayerStatistics();
-        } else {
+        }
+        /* command: /skllstats playerNum */
+        else {
             auto player_number = uint32_t{0};
             GuiUtils::ParseUInt(argv[1], &player_number);
             --player_number; // List will start at index zero
 
             PartyStatisticsWindow::Instance().WritePlayerStatistics(player_number);
         }
-    } else if (argc == 3) {
-        if (arg1 == L"full") {
-            auto player_number = uint32_t{0};
-            GuiUtils::ParseUInt(argv[2], &player_number);
-            --player_number; // List will start at 5index zero
 
-            PartyStatisticsWindow::Instance().WritePlayerStatistics(player_number, static_cast<uint32_t>(-1), true);
-        }
+        return;
+    }
+
+    const auto arg2 = GuiUtils::ToLower(argv[2]);
+
+    if (argc >= 3) {
+        const auto full_team_idxs = static_cast<uint32_t>(-1);
+        const auto player_number_arg = argv[1];
         auto player_number = uint32_t{0};
-        GuiUtils::ParseUInt(argv[1], &player_number);
+
+        /* command: /skillstats playerNum full */
+        if (arg2 == L"full") {
+            GuiUtils::ParseUInt(player_number_arg, &player_number);
+            --player_number; // List will start at index zero
+
+            PartyStatisticsWindow::Instance().WritePlayerStatistics(player_number, full_team_idxs, true);
+            return;
+        }
+
+        /* command: /skillstats playerNum skillNum */
+        GuiUtils::ParseUInt(player_number_arg, &player_number);
         --player_number; // List will start at index zero
 
         auto skill_number = uint32_t{0};

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -1735,8 +1735,9 @@ void ChatCommands::CmdSkillStatistics(const wchar_t* message, int argc, LPWSTR* 
     UNREFERENCED_PARAMETER(message);
 
     /* command: /skillstats */
+    /* will write the stats of the self player */
     if (argc < 2) {
-        PartyStatisticsWindow::Instance().WritePartyStatistics();
+        PartyStatisticsWindow::Instance().WritePlayerStatistics();
         return;
     }
 
@@ -1759,23 +1760,11 @@ void ChatCommands::CmdSkillStatistics(const wchar_t* message, int argc, LPWSTR* 
         return;
     }
 
-    const auto arg2 = GuiUtils::ToLower(argv[2]);
-
+    /* command: /skillstats playerNum skillNum */
     if (argc >= 3) {
-        const auto full_team_idxs = static_cast<uint32_t>(-1);
         const auto player_number_arg = argv[1];
         auto player_number = uint32_t{0};
 
-        /* command: /skillstats playerNum full */
-        if (arg2 == L"full") {
-            GuiUtils::ParseUInt(player_number_arg, &player_number);
-            --player_number; // List will start at index zero
-
-            PartyStatisticsWindow::Instance().WritePlayerStatistics(player_number, full_team_idxs, true);
-            return;
-        }
-
-        /* command: /skillstats playerNum skillNum */
         GuiUtils::ParseUInt(player_number_arg, &player_number);
         --player_number; // List will start at index zero
 

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -49,6 +49,7 @@
 #include <Windows/MainWindow.h>
 #include <Windows/SettingsWindow.h>
 #include <Widgets/TimerWidget.h>
+#include <Windows/PartyStatistics.h>
 
 
 #define F_PI 3.14159265358979323846f
@@ -420,6 +421,7 @@ void ChatCommands::Initialize() {
     });
     GW::Chat::CreateCommand(L"hero", ChatCommands::CmdHeroBehaviour);
     GW::Chat::CreateCommand(L"morale", ChatCommands::CmdMorale);
+    GW::Chat::CreateCommand(L"morale", ChatCommands::CmdSkillStatistics);
 }
 
 bool ChatCommands::WndProc(UINT Message, WPARAM wParam, LPARAM lParam) {
@@ -1726,5 +1728,45 @@ void ChatCommands::CmdHeroBehaviour(const wchar_t*, int argc, LPWSTR* argv)
         if (hero.owner_player_id == me->login_number) {
             GW::CtoS::SendPacket(0xC, GAME_CMSG_HERO_BEHAVIOR, hero.agent_id, behaviour);
         }
+    }
+}
+
+void ChatCommands::CmdSkillStatistics(const wchar_t* message, int argc, LPWSTR* argv) {
+    UNREFERENCED_PARAMETER(message);
+
+    if (argc < 2) {
+        PartyStatisticsWindow::Instance().WritePartyStatistics();
+        return;
+    }
+
+    std::wstring arg1 = GuiUtils::ToLower(argv[1]);
+
+    if (argc == 2) {
+        if (arg1 == L"reset") {
+            PartyStatisticsWindow::Instance().ResetPlayerStatistics();
+        } else {
+            auto player_number = uint32_t{0};
+            GuiUtils::ParseUInt(argv[1], &player_number);
+            --player_number; // List will start at index zero
+
+            PartyStatisticsWindow::Instance().WritePlayerStatistics(player_number);
+        }
+    } else if (argc == 3) {
+        if (arg1 == L"full") {
+            auto player_number = uint32_t{0};
+            GuiUtils::ParseUInt(argv[2], &player_number);
+            --player_number; // List will start at 5index zero
+
+            PartyStatisticsWindow::Instance().WritePlayerStatistics(player_number, static_cast<uint32_t>(-1), true);
+        }
+        auto player_number = uint32_t{0};
+        GuiUtils::ParseUInt(argv[1], &player_number);
+        --player_number; // List will start at index zero
+
+        auto skill_number = uint32_t{0};
+        GuiUtils::ParseUInt(argv[2], &skill_number);
+        --skill_number; // List will start at index zero
+
+        PartyStatisticsWindow::Instance().WritePlayerStatistics(player_number, skill_number);
     }
 }

--- a/GWToolboxdll/Modules/ChatCommands.h
+++ b/GWToolboxdll/Modules/ChatCommands.h
@@ -95,8 +95,7 @@ private:
     static void CmdHeroBehaviour(const wchar_t *message, int argc, LPWSTR *argv);
     static void CmdPingQuest(const wchar_t* message, int argc, LPWSTR* argv);
     static void CmdMorale(const wchar_t*, int argc, LPWSTR* argv);
-    static void CmdSkillStatistics(const wchar_t *message, int argc, LPWSTR *argv);
-
+    
     static void TransmoAgent(DWORD agent_id, PendingTransmo& transmo);
     static bool GetNPCInfoByName(const std::string name, PendingTransmo &transmo);
     static bool GetNPCInfoByName(const std::wstring name, PendingTransmo &transmo);

--- a/GWToolboxdll/Modules/ChatCommands.h
+++ b/GWToolboxdll/Modules/ChatCommands.h
@@ -95,7 +95,8 @@ private:
     static void CmdHeroBehaviour(const wchar_t *message, int argc, LPWSTR *argv);
     static void CmdPingQuest(const wchar_t* message, int argc, LPWSTR* argv);
     static void CmdMorale(const wchar_t*, int argc, LPWSTR* argv);
-    
+    static void CmdSkillStatistics(const wchar_t *message, int argc, LPWSTR *argv);
+
     static void TransmoAgent(DWORD agent_id, PendingTransmo& transmo);
     static bool GetNPCInfoByName(const std::string name, PendingTransmo &transmo);
     static bool GetNPCInfoByName(const std::wstring name, PendingTransmo &transmo);

--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -138,7 +138,7 @@ void ToolboxSettings::LoadModules(CSimpleIni* ini) {
     optional_modules.push_back(&StringDecoderWindow::Instance());
     optional_modules.push_back(&DoorMonitorWindow::Instance());
     optional_modules.push_back(&SkillListingWindow::Instance());
-
+    
 
 #endif
     std::sort(
@@ -162,7 +162,7 @@ void ToolboxSettings::LoadModules(CSimpleIni* ini) {
     if (use_world_map) optional_modules.push_back(&WorldMapWidget::Instance());
     if (use_effect_monitor) optional_modules.push_back(&EffectsMonitorWidget::Instance());
 #if _DEBUG
-
+    
 #endif
 
     std::sort(
@@ -188,7 +188,7 @@ void ToolboxSettings::DrawSettingInternal() {
     DrawFreezeSetting();
     ImGui::Checkbox("Save Location Data", &save_location_data);
     ImGui::ShowHelp("Toolbox will save your location every second in a file in Settings Folder.");
-
+    
     const size_t cols = (size_t)floor(ImGui::GetWindowWidth() / (170.0f * ImGui::GetIO().FontGlobalScale));
 
     ImGui::Separator();
@@ -247,7 +247,7 @@ void ToolboxSettings::DrawSettingInternal() {
     }
     ImGui::Columns(1);
     ImGui::PopID();
-
+    
     ImGui::Separator();
     if (ImGui::TreeNodeEx("Show the following in the main window:", ImGuiTreeNodeFlags_FramePadding | ImGuiTreeNodeFlags_SpanAvailWidth)) {
 
@@ -389,7 +389,7 @@ void ToolboxSettings::Draw(IDirect3DDevice9*) {
 
 void ToolboxSettings::Update(float delta) {
     UNREFERENCED_PARAMETER(delta);
-
+    
 
     // save location data
     if (save_location_data && TIMER_DIFF(location_timer) > 1000) {
@@ -463,3 +463,4 @@ void ToolboxSettings::Update(float delta) {
         }
     }
 }
+

--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -136,7 +136,7 @@ void ToolboxSettings::LoadModules(CSimpleIni* ini) {
     optional_modules.push_back(&StringDecoderWindow::Instance());
     optional_modules.push_back(&DoorMonitorWindow::Instance());
     optional_modules.push_back(&SkillListingWindow::Instance());
-    
+
 
 #endif
     std::sort(
@@ -160,7 +160,7 @@ void ToolboxSettings::LoadModules(CSimpleIni* ini) {
     if (use_world_map) optional_modules.push_back(&WorldMapWidget::Instance());
     if (use_effect_monitor) optional_modules.push_back(&EffectsMonitorWidget::Instance());
 #if _DEBUG
-    
+
 #endif
 
     std::sort(
@@ -186,7 +186,7 @@ void ToolboxSettings::DrawSettingInternal() {
     DrawFreezeSetting();
     ImGui::Checkbox("Save Location Data", &save_location_data);
     ImGui::ShowHelp("Toolbox will save your location every second in a file in Settings Folder.");
-    
+
     const size_t cols = (size_t)floor(ImGui::GetWindowWidth() / (170.0f * ImGui::GetIO().FontGlobalScale));
 
     ImGui::Separator();
@@ -244,7 +244,7 @@ void ToolboxSettings::DrawSettingInternal() {
     }
     ImGui::Columns(1);
     ImGui::PopID();
-    
+
     ImGui::Separator();
     if (ImGui::TreeNodeEx("Show the following in the main window:", ImGuiTreeNodeFlags_FramePadding | ImGuiTreeNodeFlags_SpanAvailWidth)) {
 
@@ -384,7 +384,7 @@ void ToolboxSettings::Draw(IDirect3DDevice9*) {
 
 void ToolboxSettings::Update(float delta) {
     UNREFERENCED_PARAMETER(delta);
-    
+
 
     // save location data
     if (save_location_data && TIMER_DIFF(location_timer) > 1000) {
@@ -458,4 +458,3 @@ void ToolboxSettings::Update(float delta) {
         }
     }
 }
-

--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -44,6 +44,7 @@
 #include <Windows/MaterialsWindow.h>
 #include <Windows/SettingsWindow.h>
 #include <Windows/NotePadWindow.h>
+#include <Windows/PartyStatistics.h>
 #include <Windows/TradeWindow.h>
 #include <Windows/ObjectiveTimerWindow.h>
 #include <Windows/FactionLeaderboardWindow.h>
@@ -127,6 +128,7 @@ void ToolboxSettings::LoadModules(CSimpleIni* ini) {
     if (use_obfuscator) optional_modules.push_back(&Obfuscator::Instance());
     if (use_completion_window) optional_modules.push_back(&CompletionWindow::Instance());
     if (use_reroll_window) optional_modules.push_back(&RerollWindow::Instance());
+    if (use_team_statistics) optional_modules.push_back(&PartyStatisticsWindow::Instance());
 
 #ifdef _DEBUG
 #if 0
@@ -229,7 +231,8 @@ void ToolboxSettings::DrawSettingInternal() {
         {"Observer Party Window",&use_observer_party_window},
         {"Observer Export Window",&use_observer_export_window},
         {"Vanquish counter",&use_vanquish},
-        {"World Map",&use_world_map}
+        {"World Map",&use_world_map},
+        {"Team Statistics",&use_team_statistics}
     };
     ImGui::Columns(static_cast<int>(cols), "global_enable_cols", false);
     size_t items_per_col = (size_t)ceil(features.size() / static_cast<float>(cols));
@@ -328,6 +331,7 @@ void ToolboxSettings::LoadSettings(CSimpleIni* ini) {
     use_world_map = ini->GetBoolValue(Name(), VAR_NAME(use_world_map), use_world_map);
     use_effect_monitor = ini->GetBoolValue(Name(), VAR_NAME(use_effect_monitor), use_effect_monitor);
     use_reroll_window = ini->GetBoolValue(Name(), VAR_NAME(use_reroll_window), use_reroll_window);
+    use_team_statistics = ini->GetBoolValue(Name(), VAR_NAME(use_team_statistics), use_team_statistics);
 }
 
 void ToolboxSettings::SaveSettings(CSimpleIni* ini) {
@@ -376,6 +380,7 @@ void ToolboxSettings::SaveSettings(CSimpleIni* ini) {
     ini->SetBoolValue(Name(), VAR_NAME(use_world_map), use_world_map);
     ini->SetBoolValue(Name(), VAR_NAME(use_effect_monitor), use_effect_monitor);
     ini->SetBoolValue(Name(), VAR_NAME(use_reroll_window), use_reroll_window);
+    ini->SetBoolValue(Name(), VAR_NAME(use_team_statistics), use_team_statistics);
 }
 
 void ToolboxSettings::Draw(IDirect3DDevice9*) {

--- a/GWToolboxdll/Modules/ToolboxSettings.h
+++ b/GWToolboxdll/Modules/ToolboxSettings.h
@@ -87,4 +87,5 @@ private:
     bool use_obfuscator = true;
     bool use_completion_window = true;
     bool use_reroll_window = true;
+    bool use_team_statistics = true;
 };

--- a/GWToolboxdll/Modules/ToolboxSettings.h
+++ b/GWToolboxdll/Modules/ToolboxSettings.h
@@ -19,7 +19,7 @@ public:
     const char* Icon() const override { return ICON_FA_TOOLBOX;  }
 
     void LoadModules(CSimpleIni* ini);
-
+    
     void Update(float delta) override;
 
     void LoadSettings(CSimpleIni* ini) override;

--- a/GWToolboxdll/Modules/ToolboxSettings.h
+++ b/GWToolboxdll/Modules/ToolboxSettings.h
@@ -19,7 +19,7 @@ public:
     const char* Icon() const override { return ICON_FA_TOOLBOX;  }
 
     void LoadModules(CSimpleIni* ini);
-    
+
     void Update(float delta) override;
 
     void LoadSettings(CSimpleIni* ini) override;

--- a/GWToolboxdll/Windows/NotePadWindow.cpp
+++ b/GWToolboxdll/Windows/NotePadWindow.cpp
@@ -14,8 +14,8 @@ void NotePadWindow::Draw(IDirect3DDevice9* pDevice) {
     if (ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
         ImVec2 cmax = ImGui::GetWindowContentRegionMax();
         ImVec2 cmin = ImGui::GetWindowContentRegionMin();
-        if (ImGui::InputTextMultiline("##source", text, TEXT_SIZE, ImVec2(cmax.x - cmin.x, cmax.y - cmin.y),
-                ImGuiInputTextFlags_AllowTabInput)) {
+        if (ImGui::InputTextMultiline("##source", text, TEXT_SIZE,
+            ImVec2(cmax.x - cmin.x, cmax.y - cmin.y), ImGuiInputTextFlags_AllowTabInput)) {
             filedirty = true;
         }
     }

--- a/GWToolboxdll/Windows/NotePadWindow.cpp
+++ b/GWToolboxdll/Windows/NotePadWindow.cpp
@@ -14,8 +14,8 @@ void NotePadWindow::Draw(IDirect3DDevice9* pDevice) {
     if (ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
         ImVec2 cmax = ImGui::GetWindowContentRegionMax();
         ImVec2 cmin = ImGui::GetWindowContentRegionMin();
-        if (ImGui::InputTextMultiline("##source", text, TEXT_SIZE,
-            ImVec2(cmax.x - cmin.x, cmax.y - cmin.y), ImGuiInputTextFlags_AllowTabInput)) {
+        if (ImGui::InputTextMultiline("##source", text, TEXT_SIZE, ImVec2(cmax.x - cmin.x, cmax.y - cmin.y),
+                ImGuiInputTextFlags_AllowTabInput)) {
             filedirty = true;
         }
     }

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -324,6 +324,8 @@ void PartyStatisticsWindow::SkillCallback(const uint32_t value_id, const uint32_
         }
     }
 
+    if (NONE_SKILL == value) return;
+
     if (party_indicies.empty() || party_stats.empty()) return;
 
     if (party_ids.find(agent_id) == party_ids.end()) return;
@@ -381,6 +383,13 @@ bool PartyStatisticsWindow::PartySizeChanged() {
 /********************/
 
 void PartyStatisticsWindow::UnsetPlayerStatistics() {
+    for (auto& [_, skill_to_encode] : skills_to_encode) {
+        if (nullptr != skill_to_encode.encoder) {
+            delete skill_to_encode.encoder;
+        }
+    }
+    skills_to_encode.clear();
+
     party_ids.clear();
     party_indicies.clear();
     party_names.clear();

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -136,7 +136,7 @@ void PartyStatisticsWindow::SkillCallback(const uint32_t value_id, const uint32_
 
 void PartyStatisticsWindow::Update(float delta) {
     UNREFERENCED_PARAMETER(delta);
-    if (!chat_queue.empty() && TIMER_DIFF(send_timer) > 600.0F) {
+    if (!chat_queue.empty() && TIMER_DIFF(send_timer) > TIME_DIFF_THRESH) {
         send_timer = TIMER_INIT();
         if (GW::Constants::InstanceType::Loading == GW::Map::GetInstanceType()) return;
         if (!GW::Agents::GetPlayer()) return;

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -365,11 +365,12 @@ void PartyStatisticsWindow::Initialize() {
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValueTarget>(&GenericValueTarget_Entry,
         [this](GW::HookStatus* status, GW::Packet::StoC::GenericValueTarget* packet) -> void {
             UNREFERENCED_PARAMETER(status);
-            const uint32_t value_id = packet->Value_id;
-            const uint32_t caster_id = packet->caster;
-            const uint32_t target_id = packet->target;
-            const uint32_t value = packet->value;
-            const bool no_target = false;
+
+            const auto value_id = packet->Value_id;
+            const auto caster_id = packet->caster;
+            const auto target_id = packet->target;
+            const auto value = packet->value;
+            const auto no_target = false;
             HandleGenericPacket(value_id, caster_id, target_id, value, no_target);
         });
 
@@ -423,7 +424,7 @@ void PartyStatisticsWindow::DrawPartyMember(const PlayerSkillCounts& party_membe
     snprintf(header_label, buffer_length, "%s", agent_name);
 
     static auto is_open = true;
-    if (ImGui::CollapsingHeader(header_label, &is_open, ImGuiTreeNodeFlags_DefaultOpen)) {
+    if (ImGui::CollapsingHeader(header_label, &is_open)) {
         auto total_num_skills = uint32_t{0};
         std::for_each(party_member_stats.skill_counts.begin(), party_member_stats.skill_counts.end(),
             [&total_num_skills](const SkillCount& p) { total_num_skills += p.skill_count; });

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -343,7 +343,11 @@ void PartyStatisticsWindow::SkillCallback(const uint32_t value_id, const uint32_
     if (!skill_found) {
         size_t skill_idx{0};
         for (auto& [id, count, name] : player_skills) {
-            if (NONE_SKILL != id) continue;
+            if (NONE_SKILL != id) {
+                ++skill_idx;
+
+                continue;
+            }
 
             id = activated_skill_id;
             count = 1;

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -1,0 +1,467 @@
+#include "stdafx.h"
+
+#include <algorithm>
+
+#include <GWCA/Constants/Constants.h>
+#include <GWCA/GameEntities/Agent.h>
+#include <GWCA/GameEntities/Map.h>
+#include <GWCA/GameEntities/Party.h>
+#include <GWCA/GameEntities/Player.h>
+#include <GWCA/GameEntities/Skill.h>
+#include <GWCA/Managers/AgentMgr.h>
+#include <GWCA/Managers/ChatMgr.h>
+#include <GWCA/Managers/MapMgr.h>
+#include <GWCA/Managers/PartyMgr.h>
+#include <GWCA/Managers/SkillbarMgr.h>
+#include <GWCA/Managers/StoCMgr.h>
+#include <GWCA/Managers/UIMgr.h>
+#include <GWCA/Packets/StoC.h>
+
+#include <GuiUtils.h>
+#include <Modules/Resources.h>
+#include <Windows/PartyStatistics.h>
+
+void PartyStatisticsWindow::GetSkillName(const uint32_t skill_id, char* skill_name) {
+    const auto& skill_data = GW::SkillbarMgr::GetSkillConstantData(skill_id);
+
+    const auto length = size_t{32};
+    wchar_t buffer[length] = {L'\0'};
+
+    if (GW::UI::UInt32ToEncStr(skill_data.name, buffer, length)) {
+        GW::UI::AsyncDecodeStr(buffer, skill_name, length);
+    }
+}
+
+void PartyStatisticsWindow::GetPlayerName(const GW::Agent* const agent, char* agent_name) {
+    if (nullptr == agent_name || nullptr == agent) return;
+
+    auto buffer = GW::Agents::GetAgentEncName(agent);
+    if (nullptr == buffer) return;
+
+    const auto length = size_t{32};
+    GW::UI::AsyncDecodeStr(buffer, agent_name, length);
+}
+
+void PartyStatisticsWindow::ClearOnPartySizeChange() {
+    if (GW::Constants::InstanceType::Outpost != GW::Map::GetInstanceType()) return;
+
+    static auto last_party_size = static_cast<size_t>(-1);
+    if (static_cast<size_t>(-1) == last_party_size) {
+        last_party_size = GW::PartyMgr::GetPartySize();
+    }
+
+    const auto current_party_size = GW::PartyMgr::GetPartySize();
+    const auto party_size_change = current_party_size != last_party_size;
+    if (party_size_change) {
+        ClearPartyIndicies();
+        ClearPartyMember();
+        SetPartyMember();
+        last_party_size = current_party_size;
+    }
+}
+
+void PartyStatisticsWindow::ClearPartyIndicies() { party_indicies.clear(); }
+
+void PartyStatisticsWindow::ClearPartyMember() { party_stats.clear(); }
+
+void PartyStatisticsWindow::MapLoadedCallback(GW::HookStatus*, GW::Packet::StoC::MapLoaded* packet) {
+    UNREFERENCED_PARAMETER(packet);
+    switch (GW::Map::GetInstanceType()) {
+        case GW::Constants::InstanceType::Explorable: {
+            Instance().ClearPartyIndicies();
+            Instance().ClearPartyMember();
+            Instance().SetPartyMember();
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}
+
+void PartyStatisticsWindow::HandleGenericPacket(const uint32_t value_id, const uint32_t caster_id,
+    const uint32_t target_id, const uint32_t value, const bool no_target) {
+    auto agent_id = caster_id;
+    const auto activated_skill_id = value;
+
+    switch (value_id) {
+        case GW::Packet::StoC::GenericValueID::instant_skill_activated:
+        case GW::Packet::StoC::GenericValueID::skill_activated:
+        case GW::Packet::StoC::GenericValueID::skill_finished:
+        case GW::Packet::StoC::GenericValueID::attack_skill_activated:
+        case GW::Packet::StoC::GenericValueID::attack_skill_finished: {
+            if (!no_target) {
+                agent_id = target_id;
+            }
+            break;
+        }
+        default: {
+            return;
+        }
+    }
+
+    const auto agent_it = std::find_if(Instance().party_stats.begin(), Instance().party_stats.end(),
+        [&agent_id](const auto val) { return val.agent_id == agent_id; });
+    const auto party_member_found = agent_it != Instance().party_stats.end();
+
+    if (!party_member_found) return;
+
+    const auto agent_idx = std::distance(Instance().party_stats.begin(), agent_it);
+
+    auto& member_stats = Instance().party_stats[agent_idx];
+    auto& member_skill_counts = member_stats.skill_counts;
+
+    const auto skill_it = std::find_if(member_skill_counts.begin(), member_skill_counts.end(),
+        [&activated_skill_id](const auto val) { return val.skill_id == activated_skill_id; });
+    const auto skill_found = skill_it != member_skill_counts.end();
+
+    if (!skill_found) {
+        for (auto& [skill_id, count] : member_skill_counts) {
+            if (skill_id != 0) continue;
+
+            skill_id = activated_skill_id;
+            count = 1;
+            break;
+        }
+        return;
+    }
+
+    for (auto& [skill_id, count] : member_skill_counts) {
+        if (activated_skill_id == skill_id) {
+            ++count;
+            break;
+        };
+    }
+}
+
+void PartyStatisticsWindow::Update(float delta) {
+    UNREFERENCED_PARAMETER(delta);
+    if (!chat_queue.empty() && TIMER_DIFF(send_timer) > 600.0F) {
+        send_timer = TIMER_INIT();
+        if (GW::Constants::InstanceType::Loading == GW::Map::GetInstanceType()) return;
+        if (!GW::Agents::GetPlayer()) return;
+
+        GW::Chat::SendChat('#', chat_queue.front().c_str());
+        chat_queue.pop();
+    }
+}
+
+std::string GetSkillFullInfoString(
+    const char* const agent_name, const char* const skill_name, const uint32_t skill_count) {
+    return std::string(agent_name) + std::string{" Used Skill "} + std::string{skill_name} + std::string{" "} +
+           std::to_string(skill_count) + std::string{" times."};
+}
+
+void PartyStatisticsWindow::WritePlayerStatistics(
+    const uint32_t player_idx, const uint32_t skill_idx, const bool full_info) {
+    if (GW::Constants::InstanceType::Loading == GW::Map::GetInstanceType()) return;
+
+    if (player_idx >= party_stats.size()) return;
+
+    const auto buffer_length = size_t{64};
+
+    const auto& party_member_stats = party_stats[player_idx];
+    const auto& party_member_skill_counts = party_member_stats.skill_counts;
+    const auto agent = GW::Agents::GetAgentByID(party_member_stats.agent_id);
+
+    char agent_name[buffer_length] = {'\0'};
+
+    // hero id is "unknown" in outpost
+    if (nullptr == agent) {
+        snprintf(agent_name, buffer_length, "Unknown Hero");
+    }
+    // player
+    else {
+        GetPlayerName(agent, agent_name);
+    }
+
+    /* Single skill output with full info  */
+    if (static_cast<uint32_t>(-1) != skill_idx) {
+        if (skill_idx > (MAX_NUM_SKILLS - 1)) return;
+
+        const auto skill_id = party_member_skill_counts[skill_idx].skill_id;
+        const auto skill_count = party_member_skill_counts[skill_idx].skill_count;
+
+        char skill_name[buffer_length] = {'\0'};
+        GetSkillName(skill_id, skill_name);
+        const auto member_stats_str = GetSkillFullInfoString(agent_name, skill_name, skill_count);
+
+        chat_queue.push(std::wstring(member_stats_str.begin(), member_stats_str.end()));
+
+        return;
+    }
+
+    /* All skills output with full info */
+    if (full_info) {
+        const auto num_skills = party_member_skill_counts.size();
+
+        for (size_t i = 0; i < num_skills; ++i) {
+            const auto skill_id = party_member_skill_counts[i].skill_id;
+            const auto skill_count = party_member_skill_counts[i].skill_count;
+
+            char skill_name[buffer_length] = {'\0'};
+            GetSkillName(skill_id, skill_name);
+
+            const auto member_stats_str = GetSkillFullInfoString(agent_name, skill_name, skill_count);
+
+            chat_queue.push(std::wstring(member_stats_str.begin(), member_stats_str.end()));
+        }
+
+        return;
+    }
+
+    /* All skills output without full info */
+    auto member_stats_str = std::string(agent_name) + std::string{" ["};
+    const auto num_skills = party_member_skill_counts.size();
+    for (size_t i = 0; i < num_skills; ++i) {
+        const auto skill_count = party_member_skill_counts[i].skill_count;
+
+        if (i == (num_skills - 1)) {
+            member_stats_str += std::to_string(skill_count);
+
+        } else {
+            member_stats_str += std::to_string(skill_count) + " - ";
+        }
+    }
+    member_stats_str += "]";
+
+    chat_queue.push(std::wstring(member_stats_str.begin(), member_stats_str.end()));
+}
+
+void PartyStatisticsWindow::WritePartyStatistics() {
+    for (size_t i = 0; i < party_stats.size(); ++i) {
+        WritePlayerStatistics(i);
+    }
+}
+
+void PartyStatisticsWindow::ResetPlayerStatistics() {
+    ClearPartyIndicies();
+    ClearPartyMember();
+    SetPartyMember();
+}
+
+const GW::Skillbar* PartyStatisticsWindow::GetPlayerSkillbar(const uint32_t player_id) {
+    const auto skillbar_array = GW::SkillbarMgr::GetSkillbarArray();
+    if (!skillbar_array.valid()) return nullptr;
+
+    for (const auto& skillbar : skillbar_array) {
+        if (skillbar.agent_id == player_id) return &skillbar;
+    }
+
+    return nullptr;
+}
+
+void PartyStatisticsWindow::SetPartyIndicies() {
+    if (!GW::PartyMgr::GetIsPartyLoaded()) return;
+
+    GW::PartyInfo* info = GW::PartyMgr::GetPartyInfo();
+    if (info == nullptr) return;
+
+    GW::PlayerArray players = GW::Agents::GetPlayerArray();
+    if (!players.valid()) return;
+
+    size_t index = 0;
+    for (GW::PlayerPartyMember& player : info->players) {
+        uint32_t id = players[player.login_number].agent_id;
+        party_indicies[id] = index++;
+
+        for (GW::HeroPartyMember& hero : info->heroes) {
+            if (hero.owner_player_id == player.login_number) {
+                party_indicies[hero.agent_id] = index++;
+            }
+        }
+    }
+    for (GW::HenchmanPartyMember& hench : info->henchmen) {
+        party_indicies[hench.agent_id] = index++;
+    }
+}
+
+void PartyStatisticsWindow::SetPartyMemberNames() {
+    const auto info = GW::PartyMgr::GetPartyInfo();
+    if (nullptr == info) return;
+
+    const auto players = info->players;
+
+    const auto party_size = GW::PartyMgr::GetPartySize();
+    if (static_cast<uint32_t>(0U) == party_size) return;
+
+    const auto agents = GW::Agents::GetAgentArray();
+    if (!agents.valid()) return;
+
+    for (const auto [agent_id, party_idx] : party_indicies) {
+        party_stats[party_idx] = {agent_id, SkillCounts{}};
+    }
+}
+
+void PartyStatisticsWindow::SetPartyMemberSkills() {
+    auto party_idx = size_t{0};
+    for (auto& member_stats : party_stats) {
+        auto& player_skill_counts = party_stats[party_idx];
+        ++party_idx;
+
+        const auto id = member_stats.agent_id;
+
+        const auto skillbar = GetPlayerSkillbar(id);
+        auto skill_counts = SkillCounts{};
+
+        /* Skillbar for other players is unknown init with No_Skill*/
+        if (nullptr == skillbar) {
+            for (size_t skill_idx = 0; skill_idx < MAX_NUM_SKILLS; ++skill_idx) {
+                const auto none_skill = static_cast<uint32_t>(GW::Constants::SkillID::No_Skill);
+                skill_counts[skill_idx] = {none_skill, 0U};
+            }
+            player_skill_counts.skill_counts = skill_counts;
+            continue;
+        }
+
+        auto skill_idx = size_t{0};
+        for (const auto& skill : skillbar->skills) {
+            skill_counts[skill_idx] = {skill.skill_id, 0U};
+            ++skill_idx;
+        }
+
+        player_skill_counts.skill_counts = skill_counts;
+    }
+}
+
+void PartyStatisticsWindow::SetPartyMember() {
+    if (!GW::PartyMgr::GetIsPartyLoaded()) return;
+    if (!GW::Map::GetIsMapLoaded()) return;
+
+    const auto party_size = GW::PartyMgr::GetPartySize();
+    if (static_cast<uint32_t>(0U) == party_size) return;
+
+    const auto agents = GW::Agents::GetAgentArray();
+    if (!agents.valid()) return;
+
+    party_stats = std::vector<PlayerSkillCounts>(party_size, PlayerSkillCounts{});
+
+    SetPartyIndicies();
+    SetPartyMemberNames();
+    SetPartyMemberSkills();
+}
+
+void PartyStatisticsWindow::Initialize() {
+    send_timer = TIMER_INIT();
+
+    ToolboxWindow::Initialize();
+
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::MapLoaded>(&MapLoaded_Entry, &MapLoadedCallback);
+
+    /* Skill on self or party mate */
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValue>(
+        &GenericValue_Entry, [this](GW::HookStatus* status, GW::Packet::StoC::GenericValue* packet) -> void {
+            UNREFERENCED_PARAMETER(status);
+
+            const auto value_id = packet->Value_id;
+            const auto caster_id = packet->agent_id;
+            const auto target_id = 0U;
+            const auto value = packet->value;
+            const auto no_target = true;
+            HandleGenericPacket(value_id, caster_id, target_id, value, no_target);
+        });
+
+    /* Skill on enemy */
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValueTarget>(&GenericValueTarget_Entry,
+        [this](GW::HookStatus* status, GW::Packet::StoC::GenericValueTarget* packet) -> void {
+            UNREFERENCED_PARAMETER(status);
+            const uint32_t value_id = packet->Value_id;
+            const uint32_t caster_id = packet->caster;
+            const uint32_t target_id = packet->target;
+            const uint32_t value = packet->value;
+            const bool no_target = false;
+            HandleGenericPacket(value_id, caster_id, target_id, value, no_target);
+        });
+
+    party_stats.clear();
+}
+
+void PartyStatisticsWindow::Draw(IDirect3DDevice9* pDevice) {
+    UNREFERENCED_PARAMETER(pDevice);
+    if (!visible) return;
+
+    if (!GW::PartyMgr::GetIsPartyLoaded()) return;
+    if (!GW::Map::GetIsMapLoaded()) return;
+
+    ClearOnPartySizeChange();
+
+    if (party_stats.empty()) {
+        SetPartyMember();
+    }
+
+    if (ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
+        ImGui::Text("Skill Name: Abs. Skill Count - Perc. Skill Count");
+
+        const auto party_size = party_stats.size();
+
+        for (const auto& party_member_stats : party_stats) {
+            DrawPartyMember(party_member_stats);
+        }
+
+        ImGui::End();
+    }
+}
+
+void PartyStatisticsWindow::DrawPartyMember(const PlayerSkillCounts& party_member_stats) {
+    const auto buffer_length = size_t{32};
+    char header_label[buffer_length] = {'\0'};
+
+    const auto agent = GW::Agents::GetAgentByID(party_member_stats.agent_id);
+
+    char agent_name[buffer_length] = {'\0'};
+
+    // hero id is unknown in outpost
+    if (nullptr == agent) {
+        if (ImGui::CollapsingHeader("Hero Slot")) {
+            ImGui::Text("Hero data cannot be loded in outpost n/a");
+        }
+        return;
+    }
+
+    GetPlayerName(agent, agent_name);
+
+    snprintf(header_label, buffer_length, "%s", agent_name);
+
+    static auto is_open = true;
+    if (ImGui::CollapsingHeader(header_label, &is_open, ImGuiTreeNodeFlags_DefaultOpen)) {
+        auto total_num_skills = uint32_t{0};
+        std::for_each(party_member_stats.skill_counts.begin(), party_member_stats.skill_counts.end(),
+            [&total_num_skills](const SkillCount& p) { total_num_skills += p.skill_count; });
+        if (static_cast<uint32_t>(0U) == total_num_skills) total_num_skills = 1U;
+
+        for (const auto [skill_id, count] : party_member_stats.skill_counts) {
+            char skill_name[buffer_length] = {'\0'};
+            GetSkillName(skill_id, skill_name);
+
+            const auto percentage = (static_cast<float>(count) / static_cast<float>(total_num_skills)) * 100.0F;
+
+            if (show_perc_values && show_abs_values) {
+                ImGui::Text("%s: %u\t-\t%-3.2f%%", skill_name, count, percentage);
+            } else if (show_perc_values && !show_abs_values) {
+                ImGui::Text("%s: %-3.2f%%", skill_name, percentage);
+            } else if (!show_perc_values && show_abs_values) {
+                ImGui::Text("%s: %u", skill_name, percentage);
+            } else {
+                ImGui::Text("%s", skill_name);
+            }
+        }
+    }
+}
+
+void PartyStatisticsWindow::LoadSettings(CSimpleIni* ini) {
+    ToolboxWindow::LoadSettings(ini);
+    show_abs_values = ini->GetBoolValue(Name(), VAR_NAME(show_abs_values), show_abs_values);
+    show_perc_values = ini->GetBoolValue(Name(), VAR_NAME(show_perc_values), show_perc_values);
+}
+
+void PartyStatisticsWindow::SaveSettings(CSimpleIni* ini) {
+    ToolboxWindow::SaveSettings(ini);
+    ini->SetBoolValue(Name(), VAR_NAME(show_abs_values), show_abs_values);
+    ini->SetBoolValue(Name(), VAR_NAME(show_perc_values), show_perc_values);
+}
+
+void PartyStatisticsWindow::DrawSettingInternal() {
+    ImGui::Checkbox("Show the absolute skill count", &show_abs_values);
+    ImGui::SameLine();
+    ImGui::Checkbox("Show the percentage skill count", &show_perc_values);
+}

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -306,7 +306,7 @@ void PartyStatisticsWindow::SetPartySkills() {
         const auto skillbar = GetPlayerSkillbar(id);
         auto skill_counts = SkillCounts{};
 
-        /* Skillbar for other players is unknown init with No_Skill*/
+        /* Skillbar for other players and henchmen is unknown init with No_Skill*/
         if (nullptr == skillbar) {
             for (size_t skill_idx = 0; skill_idx < MAX_NUM_SKILLS; ++skill_idx) {
                 skill_counts[skill_idx] = {NONE_SKILL, 0U};
@@ -349,7 +349,7 @@ void PartyStatisticsWindow::Initialize() {
 
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::MapLoaded>(&MapLoaded_Entry, &MapLoadedCallback);
 
-    /* Skill on self or party mate */
+    /* Skill on self or party player */
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValue>(
         &GenericValueSelf_Entry, [this](GW::HookStatus* status, GW::Packet::StoC::GenericValue* packet) -> void {
             UNREFERENCED_PARAMETER(status);
@@ -362,7 +362,7 @@ void PartyStatisticsWindow::Initialize() {
             SkillCallback(value_id, caster_id, target_id, value, no_target);
         });
 
-    /* Skill on enemy */
+    /* Skill on enemy player */
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValueTarget>(&GenericValueTarget_Entry,
         [this](GW::HookStatus* status, GW::Packet::StoC::GenericValueTarget* packet) -> void {
             UNREFERENCED_PARAMETER(status);
@@ -413,7 +413,7 @@ void PartyStatisticsWindow::DrawPartyMember(const PlayerSkillCounts& party_membe
     // hero or hench is unknown in outpost
     if (nullptr == agent) {
         if (ImGui::CollapsingHeader("Hero Slot")) {
-            ImGui::Text("Hero data cannot be loded in outpost n/a");
+            ImGui::Text("Hero data cannot be loded in outpost.");
         }
         return;
     }

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -397,9 +397,9 @@ void PartyStatisticsWindow::Draw(IDirect3DDevice9* pDevice) {
         for (const auto& party_member_stats : party_stats) {
             DrawPartyMember(party_member_stats);
         }
-
-        ImGui::End();
     }
+
+    ImGui::End();
 }
 
 void PartyStatisticsWindow::DrawPartyMember(const PlayerSkillCounts& party_member_stats) {

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -21,14 +21,21 @@
 #include <Modules/Resources.h>
 #include <Windows/PartyStatistics.h>
 
+/*************************/
+/* Static Helper Methods */
+/*************************/
+
 void PartyStatisticsWindow::GetSkillName(const uint32_t skill_id, char* const skill_name) {
     const auto& skill_data = GW::SkillbarMgr::GetSkillConstantData(skill_id);
 
-    const auto buffer_length = size_t{32};
-    wchar_t buffer[buffer_length] = {L'\0'};
+    wchar_t buffer[BUFFER_LENGTH] = {L'\0'};
 
-    if (GW::UI::UInt32ToEncStr(skill_data.name, buffer, buffer_length)) {
-        GW::UI::AsyncDecodeStr(buffer, skill_name, buffer_length);
+    if (GW::UI::UInt32ToEncStr(skill_data.name, buffer, BUFFER_LENGTH)) {
+        GW::UI::AsyncDecodeStr(buffer, skill_name, BUFFER_LENGTH);
+    }
+
+    if (nullptr != skill_name && 0 == strlen(skill_name)) {
+        snprintf(skill_name, BUFFER_LENGTH, NONE_SKILL_NAME);
     }
 }
 
@@ -38,41 +45,183 @@ void PartyStatisticsWindow::GetPlayerName(const GW::Agent* const agent, char* co
     auto buffer = GW::Agents::GetAgentEncName(agent);
     if (nullptr == buffer) return;
 
-    const auto buffer_length = size_t{32};
-    GW::UI::AsyncDecodeStr(buffer, agent_name, buffer_length);
+    GW::UI::AsyncDecodeStr(buffer, agent_name, BUFFER_LENGTH);
 }
 
-bool PartyStatisticsWindow::PartySizeChanged() {
-    static auto last_party_size = static_cast<size_t>(-1);
-    if (static_cast<size_t>(-1) == last_party_size) {
-        last_party_size = GW::PartyMgr::GetPartySize();
-        party_size = last_party_size;
+const GW::Skillbar* PartyStatisticsWindow::GetPlayerSkillbar(const uint32_t player_id) {
+    const auto skillbar_array = GW::SkillbarMgr::GetSkillbarArray();
+    if (!skillbar_array.valid()) return nullptr;
+
+    for (const auto& skillbar : skillbar_array) {
+        if (skillbar.agent_id == player_id) return &skillbar;
     }
 
-    const auto current_party_size = GW::PartyMgr::GetPartySize();
-    const auto party_size_change = current_party_size != last_party_size;
-    if (party_size_change) {
-        last_party_size = current_party_size;
-        party_size = last_party_size;
+    return nullptr;
+}
+
+std::string PartyStatisticsWindow::GetSkillFullInfoString(
+    const std::string agent_name, const std::string skill_name, const uint32_t skill_count) {
+    return agent_name + std::string{" Used Skill "} + skill_name + std::string{" "} + std::to_string(skill_count) +
+           std::string{" times."};
+}
+
+/**********************/
+/* Overridden Methods */
+/**********************/
+
+void PartyStatisticsWindow::Initialize() {
+    send_timer = TIMER_INIT();
+
+    ToolboxWindow::Initialize();
+
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::MapLoaded>(
+        &MapLoaded_Entry, [this](GW::HookStatus* status, GW::Packet::StoC::MapLoaded* packet) -> void {
+            UNREFERENCED_PARAMETER(status);
+            UNREFERENCED_PARAMETER(packet);
+
+            return MapLoadedCallback();
+        });
+
+    /* Skill on self or party player */
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValue>(
+        &GenericValueSelf_Entry, [this](GW::HookStatus* status, GW::Packet::StoC::GenericValue* packet) -> void {
+            UNREFERENCED_PARAMETER(status);
+
+            const auto value_id = packet->Value_id;
+            const auto caster_id = packet->agent_id;
+            const auto target_id = 0U;
+            const auto value = packet->value;
+            const auto no_target = true;
+            SkillCallback(value_id, caster_id, target_id, value, no_target);
+        });
+
+    /* Skill on enemy player */
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValueTarget>(&GenericValueTarget_Entry,
+        [this](GW::HookStatus* status, GW::Packet::StoC::GenericValueTarget* packet) -> void {
+            UNREFERENCED_PARAMETER(status);
+
+            const auto value_id = packet->Value_id;
+            const auto caster_id = packet->caster;
+            const auto target_id = packet->target;
+            const auto value = packet->value;
+            const auto no_target = false;
+            SkillCallback(value_id, caster_id, target_id, value, no_target);
+        });
+
+    UnsetPlayerStatistics();
+    SetPlayerStatistics();
+}
+
+void PartyStatisticsWindow::Update(float delta) {
+    UNREFERENCED_PARAMETER(delta);
+
+    const auto party_size_changed = PartySizeChanged();
+
+    if (party_size_changed && GW::Constants::InstanceType::Outpost == GW::Map::GetInstanceType()) {
+        SetPlayerStatistics();
     }
 
-    return party_size_change;
+    if (party_indicies.empty()) {
+        SetPartyIndicies();
+    }
+    if (party_names.empty()) {
+        SetPartyNames();
+    }
+    if (party_skills.empty()) {
+        SetPartySkills();
+    }
+
+    if (!chat_queue.empty() && TIMER_DIFF(send_timer) > TIME_DIFF_THRESH) {
+        send_timer = TIMER_INIT();
+        if (GW::Constants::InstanceType::Loading == GW::Map::GetInstanceType()) return;
+        if (!GW::Agents::GetPlayer()) return;
+
+        GW::Chat::SendChat('#', chat_queue.front().c_str());
+        chat_queue.pop();
+    }
 }
 
-void PartyStatisticsWindow::UnsetPlayerStatistics() {
-    party_ids.clear();
-    party_indicies.clear();
-    party_names.clear();
-    party_skills.clear();
+void PartyStatisticsWindow::Draw(IDirect3DDevice9* pDevice) {
+    UNREFERENCED_PARAMETER(pDevice);
+    if (!visible) return;
+
+    if (!GW::Map::GetIsMapLoaded()) return;
+
+    if (ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
+        for (const auto& member_stats : party_skills) {
+            DrawPartyMember(member_stats);
+        }
+    }
+
+    ImGui::End();
 }
+
+void PartyStatisticsWindow::LoadSettings(CSimpleIni* ini) {
+    ToolboxWindow::LoadSettings(ini);
+    show_abs_values = ini->GetBoolValue(Name(), VAR_NAME(show_abs_values), show_abs_values);
+    show_perc_values = ini->GetBoolValue(Name(), VAR_NAME(show_perc_values), show_perc_values);
+}
+
+void PartyStatisticsWindow::SaveSettings(CSimpleIni* ini) {
+    ToolboxWindow::SaveSettings(ini);
+    ini->SetBoolValue(Name(), VAR_NAME(show_abs_values), show_abs_values);
+    ini->SetBoolValue(Name(), VAR_NAME(show_perc_values), show_perc_values);
+}
+
+void PartyStatisticsWindow::DrawSettingInternal() {
+    ImGui::Checkbox("Show the absolute skill count", &show_abs_values);
+    ImGui::SameLine();
+    ImGui::Checkbox("Show the percentage skill count", &show_perc_values);
+}
+
+void PartyStatisticsWindow::Terminate() {
+    ToolboxWindow::Terminate();
+    UnsetPlayerStatistics();
+}
+
+/***********************/
+/* Draw Helper Methods */
+/***********************/
+
+void PartyStatisticsWindow::DrawPartyMember(const PlayerSkills& member_stats) {
+    char header_label[BUFFER_LENGTH] = {'\0'};
+
+    const auto agent_name = party_names[member_stats.agent_id];
+    snprintf(header_label, BUFFER_LENGTH, "%s###%u", agent_name.c_str(), member_stats.agent_id);
+
+    if (ImGui::CollapsingHeader(header_label)) {
+        auto total_num_skills = uint32_t{0};
+        std::for_each(member_stats.skills.begin(), member_stats.skills.end(),
+            [&total_num_skills](const Skill& p) { total_num_skills += p.count; });
+        if (static_cast<uint32_t>(0U) == total_num_skills) total_num_skills = 1U;
+
+        for (const auto [skill_id, skill_count, skill_name] : member_stats.skills) {
+            const auto percentage = (static_cast<float>(skill_count) / static_cast<float>(total_num_skills)) * 100.0F;
+
+            if (show_perc_values && show_abs_values) {
+                ImGui::Text("%s: %u\t-\t%-3.2f%%", skill_name.c_str(), skill_count, percentage);
+            } else if (show_perc_values && !show_abs_values) {
+                ImGui::Text("%s: %-3.2f%%", skill_name.c_str(), percentage);
+            } else if (!show_perc_values && show_abs_values) {
+                ImGui::Text("%s: %u", skill_name.c_str(), percentage);
+            } else {
+                ImGui::Text("%s", skill_name.c_str());
+            }
+        }
+    }
+}
+
+/********************/
+/* Callback Methods */
+/********************/
 
 void PartyStatisticsWindow::MapLoadedCallback() {
     switch (GW::Map::GetInstanceType()) {
-        case GW::Constants::InstanceType::Outpost:
         case GW::Constants::InstanceType::Explorable: {
             UnsetPlayerStatistics();
             break;
         }
+        case GW::Constants::InstanceType::Outpost:
         case GW::Constants::InstanceType::Loading:
         default: break;
     }
@@ -101,8 +250,6 @@ void PartyStatisticsWindow::SkillCallback(const uint32_t value_id, const uint32_
 
     if (party_indicies.empty() || party_skills.empty()) return;
 
-    const auto buffer_length = size_t{32};
-
     const auto agent_idx = party_indicies[agent_id];
     auto& member_skills = party_skills[agent_idx].skills;
 
@@ -115,7 +262,7 @@ void PartyStatisticsWindow::SkillCallback(const uint32_t value_id, const uint32_
         for (auto& [skill_id, count, name] : member_skills) {
             if (NONE_SKILL != skill_id) continue;
 
-            char skill_name[buffer_length] = {'\0'};
+            char skill_name[BUFFER_LENGTH] = {'\0'};
             GetSkillName(activated_skill_id, skill_name);
 
             skill_id = activated_skill_id;
@@ -135,104 +282,45 @@ void PartyStatisticsWindow::SkillCallback(const uint32_t value_id, const uint32_
     }
 }
 
-void PartyStatisticsWindow::Update(float delta) {
-    UNREFERENCED_PARAMETER(delta);
+bool PartyStatisticsWindow::PartySizeChanged() {
+    if (!GW::PartyMgr::GetIsPartyLoaded()) return false;
 
-    if (!chat_queue.empty() && TIMER_DIFF(send_timer) > TIME_DIFF_THRESH) {
-        send_timer = TIMER_INIT();
-        if (GW::Constants::InstanceType::Loading == GW::Map::GetInstanceType()) return;
-        if (!GW::Agents::GetPlayer()) return;
-
-        GW::Chat::SendChat('#', chat_queue.front().c_str());
-        chat_queue.pop();
-    }
-}
-
-std::string PartyStatisticsWindow::GetSkillFullInfoString(
-    const std::string agent_name, const std::string skill_name, const uint32_t skill_count) {
-    return agent_name + std::string{" Used Skill "} + skill_name + std::string{" "} + std::to_string(skill_count) +
-           std::string{" times."};
-}
-
-void PartyStatisticsWindow::WritePlayerStatisticsSingleSkill(const uint32_t player_idx, const uint32_t skill_idx) {
-    if (skill_idx > (MAX_NUM_SKILLS - 1)) return;
-
-    const auto& member_stats = party_skills[player_idx];
-    const auto& member_skills = member_stats.skills;
-    const auto& agent_name = party_names[member_stats.agent_id];
-
-    const auto skill_count = member_skills[skill_idx].count;
-    const auto skill_name = member_skills[skill_idx].name;
-
-    const auto member_stats_str = GetSkillFullInfoString(agent_name, skill_name, skill_count);
-
-    chat_queue.push(std::wstring(member_stats_str.begin(), member_stats_str.end()));
-}
-
-void PartyStatisticsWindow::WritePlayerStatisticsAllSkillsFullInfo(const uint32_t player_idx) {
-    const auto& member_stats = party_skills[player_idx];
-    const auto& member_skills = member_stats.skills;
-    const auto& agent_name = party_names[member_stats.agent_id];
-
-    for (const auto& [_, skill_count, skill_name] : member_skills) {
-        const auto member_stats_str = GetSkillFullInfoString(agent_name, skill_name, skill_count);
-
-        chat_queue.push(std::wstring(member_stats_str.begin(), member_stats_str.end()));
-    }
-}
-
-void PartyStatisticsWindow::WritePlayerStatisticsAllSkills(const uint32_t player_idx) {
-    const auto& member_stats = party_skills[player_idx];
-    const auto& member_skills = member_stats.skills;
-    const auto& agent_name = party_names[member_stats.agent_id];
-
-    auto member_stats_str = std::string(agent_name) + std::string{" ["};
-    const auto num_skills = member_skills.size();
-    for (size_t i = 0; i < num_skills; ++i) {
-        const auto skill_count = member_skills[i].count;
-
-        member_stats_str += std::to_string(skill_count);
-
-        if (i < (num_skills - 1)) {
-            member_stats_str += ", ";
-        }
+    static auto last_party_size = static_cast<size_t>(-1);
+    if (static_cast<size_t>(-1) == last_party_size) {
+        last_party_size = GW::PartyMgr::GetPartySize();
+        party_size = last_party_size;
     }
 
-    member_stats_str += "]";
-
-    chat_queue.push(std::wstring(member_stats_str.begin(), member_stats_str.end()));
-}
-
-void PartyStatisticsWindow::WritePlayerStatistics(
-    const uint32_t player_idx, const uint32_t skill_idx, const bool full_info) {
-    if (GW::Constants::InstanceType::Loading == GW::Map::GetInstanceType()) return;
-
-    if (player_idx >= party_skills.size()) return;
-
-    if (static_cast<uint32_t>(-1) != skill_idx) {
-        WritePlayerStatisticsSingleSkill(player_idx, skill_idx);
-    } else if (full_info) {
-        WritePlayerStatisticsAllSkillsFullInfo(player_idx);
-    } else {
-        WritePlayerStatisticsAllSkills(player_idx);
-    }
-}
-
-void PartyStatisticsWindow::WritePartyStatistics() {
-    for (size_t i = 0; i < party_skills.size(); ++i) {
-        WritePlayerStatistics(i);
-    }
-}
-
-const GW::Skillbar* PartyStatisticsWindow::GetPlayerSkillbar(const uint32_t player_id) {
-    const auto skillbar_array = GW::SkillbarMgr::GetSkillbarArray();
-    if (!skillbar_array.valid()) return nullptr;
-
-    for (const auto& skillbar : skillbar_array) {
-        if (skillbar.agent_id == player_id) return &skillbar;
+    const auto current_party_size = GW::PartyMgr::GetPartySize();
+    const auto party_size_change = current_party_size != last_party_size;
+    if (party_size_change) {
+        last_party_size = current_party_size;
+        party_size = last_party_size;
     }
 
-    return nullptr;
+    return party_size_change;
+}
+
+/********************/
+/* Set Data Methods */
+/********************/
+
+void PartyStatisticsWindow::UnsetPlayerStatistics() {
+    party_ids.clear();
+    party_indicies.clear();
+    party_names.clear();
+    party_skills.clear();
+}
+
+void PartyStatisticsWindow::SetPlayerStatistics() {
+    if (!GW::PartyMgr::GetIsPartyLoaded()) return;
+    if (!GW::Map::GetIsMapLoaded()) return;
+
+    party_size = GW::PartyMgr::GetPartySize();
+
+    SetPartyIndicies();
+    SetPartyNames();
+    SetPartySkills();
 }
 
 void PartyStatisticsWindow::SetPartyIndicies() {
@@ -275,12 +363,10 @@ void PartyStatisticsWindow::SetPartyNames() {
     const auto agents = GW::Agents::GetAgentArray();
     if (!agents.valid()) return;
 
-    const auto buffer_length = size_t{32};
-
     party_names.clear();
 
     for (const auto id : party_ids) {
-        party_names[id] = std::string{"Hero/Henchman Slot"};
+        party_names[id] = std::string{NONE_PLAYER_NAME};
     }
 
     for (const auto agent : agents) {
@@ -291,7 +377,7 @@ void PartyStatisticsWindow::SetPartyNames() {
         const auto it = party_ids.find(id);
         if (it == party_ids.end()) continue;
 
-        char agent_name[buffer_length] = {'\0'};
+        char agent_name[BUFFER_LENGTH] = {'\0'};
         GetPlayerName(agent, agent_name);
 
         if (0 == strlen(agent_name)) continue; /* Should not occur */
@@ -300,7 +386,7 @@ void PartyStatisticsWindow::SetPartyNames() {
     }
 }
 
-void PartyStatisticsWindow::SetPartyStats() {
+void PartyStatisticsWindow::SetPartySkills() {
     if (!GW::PartyMgr::GetIsPartyLoaded()) return;
 
     party_skills.clear();
@@ -309,8 +395,6 @@ void PartyStatisticsWindow::SetPartyStats() {
     for (const auto [agent_id, party_idx] : party_indicies) {
         party_skills[party_idx] = {agent_id, Skills{}};
     }
-
-    const auto buffer_length = size_t{32};
 
     auto party_idx = size_t{0};
     for (auto& member_stats : party_skills) {
@@ -325,7 +409,7 @@ void PartyStatisticsWindow::SetPartyStats() {
         /* Skillbar for other players and henchmen is unknown in outpost init with No_Skill */
         if (nullptr == skillbar) {
             for (size_t skill_idx = 0; skill_idx < MAX_NUM_SKILLS; ++skill_idx) {
-                skills[skill_idx] = {NONE_SKILL, 0U, std::string{"Unknown Skill"}};
+                skills[skill_idx] = {NONE_SKILL, 0U, std::string{NONE_SKILL_NAME}};
             }
             player_skills.skills = skills;
             continue;
@@ -333,7 +417,7 @@ void PartyStatisticsWindow::SetPartyStats() {
 
         auto skill_idx = size_t{0};
         for (const auto& skill : skillbar->skills) {
-            char skill_name[buffer_length] = {'\0'};
+            char skill_name[BUFFER_LENGTH] = {'\0'};
             GetSkillName(skill.skill_id, skill_name);
 
             skills[skill_idx] = {skill.skill_id, 0U, std::string{skill_name}};
@@ -344,135 +428,77 @@ void PartyStatisticsWindow::SetPartyStats() {
     }
 }
 
-void PartyStatisticsWindow::SetPlayerStatistics() {
-    if (!GW::PartyMgr::GetIsPartyLoaded()) return;
+/************************/
+/* Chat Command Methods */
+/************************/
 
-    SetPartyIndicies();
-    SetPartyNames();
-    SetPartyStats();
+void PartyStatisticsWindow::WritePartyStatistics() {
+    for (size_t i = 0; i < party_skills.size(); ++i) {
+        WritePlayerStatistics(i);
+    }
 }
 
-void PartyStatisticsWindow::Initialize() {
-    send_timer = TIMER_INIT();
+void PartyStatisticsWindow::WritePlayerStatistics(
+    const uint32_t player_idx, const uint32_t skill_idx, const bool full_info) {
+    if (GW::Constants::InstanceType::Loading == GW::Map::GetInstanceType()) return;
 
-    ToolboxWindow::Initialize();
+    if (player_idx >= party_skills.size()) return;
 
-    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::MapLoaded>(
-        &MapLoaded_Entry, [this](GW::HookStatus* status, GW::Packet::StoC::MapLoaded* packet) -> void {
-            UNREFERENCED_PARAMETER(status);
-            UNREFERENCED_PARAMETER(packet);
-
-            return MapLoadedCallback();
-        });
-
-    /* Skill on self or party player */
-    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValue>(
-        &GenericValueSelf_Entry, [this](GW::HookStatus* status, GW::Packet::StoC::GenericValue* packet) -> void {
-            UNREFERENCED_PARAMETER(status);
-
-            const auto value_id = packet->Value_id;
-            const auto caster_id = packet->agent_id;
-            const auto target_id = 0U;
-            const auto value = packet->value;
-            const auto no_target = true;
-            SkillCallback(value_id, caster_id, target_id, value, no_target);
-        });
-
-    /* Skill on enemy player */
-    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValueTarget>(&GenericValueTarget_Entry,
-        [this](GW::HookStatus* status, GW::Packet::StoC::GenericValueTarget* packet) -> void {
-            UNREFERENCED_PARAMETER(status);
-
-            const auto value_id = packet->Value_id;
-            const auto caster_id = packet->caster;
-            const auto target_id = packet->target;
-            const auto value = packet->value;
-            const auto no_target = false;
-            SkillCallback(value_id, caster_id, target_id, value, no_target);
-        });
-
-    UnsetPlayerStatistics();
+    if (static_cast<uint32_t>(-1) != skill_idx) {
+        WritePlayerStatisticsSingleSkillFullInfo(player_idx, skill_idx);
+    } else if (full_info) {
+        WritePlayerStatisticsAllSkillsFullInfo(player_idx);
+    } else {
+        WritePlayerStatisticsAllSkills(player_idx);
+    }
 }
 
-void PartyStatisticsWindow::Terminate() {
-    ToolboxWindow::Terminate();
-    UnsetPlayerStatistics();
-}
+void PartyStatisticsWindow::WritePlayerStatisticsAllSkills(const uint32_t player_idx) {
+    const auto& member_stats = party_skills[player_idx];
+    const auto& member_skills = member_stats.skills;
+    const auto& agent_name = party_names[member_stats.agent_id];
 
-void PartyStatisticsWindow::Draw(IDirect3DDevice9* pDevice) {
-    UNREFERENCED_PARAMETER(pDevice);
-    if (!visible) return;
+    auto member_stats_str = std::string(agent_name) + std::string{" ["};
+    const auto num_skills = member_skills.size();
+    for (size_t i = 0; i < num_skills; ++i) {
+        const auto skill_count = member_skills[i].count;
 
-    if (!GW::Map::GetIsMapLoaded()) return;
+        member_stats_str += std::to_string(skill_count);
 
-    const auto party_size_changed = PartySizeChanged();
-
-    if (party_size_changed && GW::Constants::InstanceType::Outpost == GW::Map::GetInstanceType()) {
-        SetPlayerStatistics();
-    }
-
-    if (party_indicies.empty()) {
-        SetPartyIndicies();
-    }
-    if (party_names.empty()) {
-        SetPartyNames();
-    }
-    if (party_skills.empty()) {
-        SetPartyStats();
-    }
-
-    if (ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
-        for (const auto& member_stats : party_skills) {
-            DrawPartyMember(member_stats);
+        if (i < (num_skills - 1)) {
+            member_stats_str += ", ";
         }
     }
 
-    ImGui::End();
+    member_stats_str += "]";
+
+    chat_queue.push(std::wstring(member_stats_str.begin(), member_stats_str.end()));
 }
 
-void PartyStatisticsWindow::DrawPartyMember(const PlayerSkills& member_stats) {
-    const auto buffer_length = size_t{32};
-    char header_label[buffer_length] = {'\0'};
+void PartyStatisticsWindow::WritePlayerStatisticsAllSkillsFullInfo(const uint32_t player_idx) {
+    const auto& member_stats = party_skills[player_idx];
+    const auto& member_skills = member_stats.skills;
+    const auto& agent_name = party_names[member_stats.agent_id];
 
-    const auto agent_name = party_names[member_stats.agent_id];
-    snprintf(header_label, buffer_length, "%s###%u", agent_name.c_str(), member_stats.agent_id);
+    for (const auto& [_, skill_count, skill_name] : member_skills) {
+        const auto member_stats_str = GetSkillFullInfoString(agent_name, skill_name, skill_count);
 
-    if (ImGui::CollapsingHeader(header_label)) {
-        auto total_num_skills = uint32_t{0};
-        std::for_each(member_stats.skills.begin(), member_stats.skills.end(),
-            [&total_num_skills](const Skill& p) { total_num_skills += p.count; });
-        if (static_cast<uint32_t>(0U) == total_num_skills) total_num_skills = 1U;
-
-        for (const auto [skill_id, skill_count, skill_name] : member_stats.skills) {
-            const auto percentage = (static_cast<float>(skill_count) / static_cast<float>(total_num_skills)) * 100.0F;
-
-            if (show_perc_values && show_abs_values) {
-                ImGui::Text("%s: %u\t-\t%-3.2f%%", skill_name.c_str(), skill_count, percentage);
-            } else if (show_perc_values && !show_abs_values) {
-                ImGui::Text("%s: %-3.2f%%", skill_name.c_str(), percentage);
-            } else if (!show_perc_values && show_abs_values) {
-                ImGui::Text("%s: %u", skill_name.c_str(), percentage);
-            } else {
-                ImGui::Text("%s", skill_name.c_str());
-            }
-        }
+        chat_queue.push(std::wstring(member_stats_str.begin(), member_stats_str.end()));
     }
 }
 
-void PartyStatisticsWindow::LoadSettings(CSimpleIni* ini) {
-    ToolboxWindow::LoadSettings(ini);
-    show_abs_values = ini->GetBoolValue(Name(), VAR_NAME(show_abs_values), show_abs_values);
-    show_perc_values = ini->GetBoolValue(Name(), VAR_NAME(show_perc_values), show_perc_values);
-}
+void PartyStatisticsWindow::WritePlayerStatisticsSingleSkillFullInfo(
+    const uint32_t player_idx, const uint32_t skill_idx) {
+    if (skill_idx > (MAX_NUM_SKILLS - 1)) return;
 
-void PartyStatisticsWindow::SaveSettings(CSimpleIni* ini) {
-    ToolboxWindow::SaveSettings(ini);
-    ini->SetBoolValue(Name(), VAR_NAME(show_abs_values), show_abs_values);
-    ini->SetBoolValue(Name(), VAR_NAME(show_perc_values), show_perc_values);
-}
+    const auto& member_stats = party_skills[player_idx];
+    const auto& member_skills = member_stats.skills;
+    const auto& agent_name = party_names[member_stats.agent_id];
 
-void PartyStatisticsWindow::DrawSettingInternal() {
-    ImGui::Checkbox("Show the absolute skill count", &show_abs_values);
-    ImGui::SameLine();
-    ImGui::Checkbox("Show the percentage skill count", &show_perc_values);
+    const auto skill_count = member_skills[skill_idx].count;
+    const auto skill_name = member_skills[skill_idx].name;
+
+    const auto member_stats_str = GetSkillFullInfoString(agent_name, skill_name, skill_count);
+
+    chat_queue.push(std::wstring(member_stats_str.begin(), member_stats_str.end()));
 }

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -225,18 +225,49 @@ void PartyStatisticsWindow::DrawPartyMember(const PlayerSkills& player_stats, co
             ImGui::SetCursorPos(ImVec2{ImGui::GetCursorPos().x, ImGui::GetCursorPos().y - height});
         }
 
+        char table_name[BUFFER_LENGTH] = {'\0'};
+        snprintf(table_name, BUFFER_LENGTH, "###Table%d", party_idx);
+
+        const float width = ImGui::GetWindowWidth();
+
+        if (show_perc_values && show_abs_values) {
+            ImGui::Columns(3, table_name, false);
+            ImGui::SetColumnWidth(0, width * 0.6F);
+            ImGui::SetColumnWidth(1, width * 0.2F);
+            ImGui::SetColumnWidth(2, width * 0.2F);
+        } else if (show_perc_values || show_abs_values) {
+            ImGui::Columns(2, table_name, false);
+            ImGui::SetColumnWidth(0, width * 0.7F);
+            ImGui::SetColumnWidth(1, width * 0.3F);
+        }
+
         for (const auto [skill_id, skill_count, skill_name] : player_stats.skills) {
             const float percentage = (static_cast<float>(skill_count) / static_cast<float>(total_num_skills)) * 100.0F;
 
+            ImGui::Text("%ls", skill_name.c_str());
+
             if (show_perc_values && show_abs_values) {
-                ImGui::Text("%ls: %u\t-\t%-3.2f%%", skill_name.c_str(), skill_count, percentage);
+                ImGui::NextColumn();
+                ImGui::Text("%u", skill_count);
+                ImGui::NextColumn();
+                ImGui::Text("%.2f%%", percentage);
+                ImGui::NextColumn();
+                ImGui::Separator();
             } else if (show_perc_values && !show_abs_values) {
-                ImGui::Text("%ls: %-3.2f%%", skill_name.c_str(), percentage);
+                ImGui::NextColumn();
+                ImGui::Text("%.2f%%", percentage);
+                ImGui::NextColumn();
+                ImGui::Separator();
             } else if (!show_perc_values && show_abs_values) {
-                ImGui::Text("%ls: %u", skill_name.c_str(), percentage);
-            } else {
-                ImGui::Text("%ls", skill_name.c_str());
+                ImGui::NextColumn();
+                ImGui::Text("%u", skill_count);
+                ImGui::NextColumn();
+                ImGui::Separator();
             }
+        }
+
+        if (show_perc_values || show_abs_values) {
+            ImGui::EndColumns();
         }
     }
 }

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -84,13 +84,7 @@ void PartyStatisticsWindow::Initialize() {
 
     ToolboxWindow::Initialize();
 
-    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::MapLoaded>(
-        &MapLoaded_Entry, [this](GW::HookStatus* status, GW::Packet::StoC::MapLoaded* packet) -> void {
-            UNREFERENCED_PARAMETER(status);
-            UNREFERENCED_PARAMETER(packet);
-
-            return MapLoadedCallback();
-        });
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::MapLoaded>(&MapLoaded_Entry, &MapLoadedCallback);
 
     /* Skill on self or party player */
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValue>(
@@ -276,17 +270,17 @@ void PartyStatisticsWindow::DrawPartyMember(const PlayerSkills& player_stats, co
 /* Callback Methods */
 /********************/
 
-void PartyStatisticsWindow::MapLoadedCallback() {
+void PartyStatisticsWindow::MapLoadedCallback(GW::HookStatus*, GW::Packet::StoC::MapLoaded*) {
     switch (GW::Map::GetInstanceType()) {
         case GW::Constants::InstanceType::Explorable: {
-            if (!in_explorable) {
-                in_explorable = true;
-                UnsetPlayerStatistics();
+            if (!Instance().in_explorable) {
+                Instance().in_explorable = true;
+                Instance().UnsetPlayerStatistics();
             }
             break;
         }
         case GW::Constants::InstanceType::Outpost: {
-            in_explorable = false;
+            Instance().in_explorable = false;
             break;
         }
         case GW::Constants::InstanceType::Loading:

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -27,33 +27,36 @@
 #include <Modules/Resources.h>
 #include <Windows/PartyStatistics.h>
 
-
 /*************************/
 /* Static Helper Methods */
 /*************************/
 
 std::wstring& PartyStatisticsWindow::GetSkillName(const uint32_t skill_id) {
+    const auto found_it = skill_names.find(skill_id);
 
-    auto found = skill_names.find(skill_id);
-    if (found == skill_names.end()) {
+    if (found_it == skill_names.end()) {
         const GW::Skill& skill_data = GW::SkillbarMgr::GetSkillConstantData(skill_id);
 
         skill_names[skill_id] = new GuiUtils::EncString(skill_data.name);
     }
+
     return skill_names[skill_id]->wstring();
 }
 
 std::wstring& PartyStatisticsWindow::GetPlayerName(uint32_t agent_id) {
     auto& agent_names = Instance().agent_names;
-    auto found = agent_names.find(agent_id);
-    if (found == agent_names.end()) {
+    const auto found_it = agent_names.find(agent_id);
+
+    if (found_it == agent_names.end()) {
         agent_names[agent_id] = new GuiUtils::EncString(GW::Agents::GetAgentEncName(agent_id));
     }
+
     return agent_names[agent_id]->wstring();
 }
 
 const GW::Skillbar* PartyStatisticsWindow::GetPlayerSkillbar(const uint32_t player_id) {
     const GW::SkillbarArray skillbar_array = GW::SkillbarMgr::GetSkillbarArray();
+
     if (!skillbar_array.valid()) return nullptr;
 
     for (const GW::Skillbar& skillbar : skillbar_array) {
@@ -116,7 +119,6 @@ void PartyStatisticsWindow::Update(float delta) {
     UNREFERENCED_PARAMETER(delta);
 
     const bool party_size_changed = PartySizeChanged();
-
 
     if ((party_size_changed || (party_size == 1U)) &&
         (GW::Constants::InstanceType::Outpost == GW::Map::GetInstanceType())) {
@@ -195,7 +197,7 @@ void PartyStatisticsWindow::DrawPartyMember(const PlayerSkills& player_stats, co
     char header_label[BUFFER_LENGTH] = {'\0'};
 
     std::wstring* agent_name = party_names[player_stats.agent_id];
-    snprintf(header_label, BUFFER_LENGTH, "%ls###%u", agent_name ? agent_name->c_str() : L"Unknown party name", party_idx);
+    snprintf(header_label, BUFFER_LENGTH, "%ls###%u", agent_name ? agent_name->c_str() : L"Unknown Player", party_idx);
 
     if (ImGui::CollapsingHeader(header_label)) {
         uint32_t total_num_skills{0};
@@ -369,17 +371,18 @@ bool PartyStatisticsWindow::PartySizeChanged() {
 /********************/
 
 void PartyStatisticsWindow::UnsetPlayerStatistics() {
-
     party_ids.clear();
     party_indicies.clear();
     party_names.clear();
     party_stats.clear();
-    for (auto& it : skill_names) {
-        if (it.second) delete it.second;
+
+    for (auto& [_, encoder] : skill_names) {
+        if (encoder) delete encoder;
     }
     skill_names.clear();
-    for (auto& it : agent_names) {
-        if (it.second) delete it.second;
+
+    for (auto& [_, encoder] : agent_names) {
+        if (encoder) delete encoder;
     }
     agent_names.clear();
 }

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -88,6 +88,8 @@ void PartyStatisticsWindow::Initialize() {
 
     ToolboxWindow::Initialize();
 
+    GW::Chat::CreateCommand(L"skillstats", CmdSkillStatistics);
+
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::MapLoaded>(&MapLoaded_Entry, &MapLoadedCallback);
 
     /* Skill on self or party player */
@@ -520,6 +522,51 @@ void PartyStatisticsWindow::SetPartySkills() {
 /************************/
 /* Chat Command Methods */
 /************************/
+
+void PartyStatisticsWindow::CmdSkillStatistics(const wchar_t* message, int argc, LPWSTR* argv) {
+    UNREFERENCED_PARAMETER(message);
+
+    /* command: /skillstats */
+    /* will write the stats of the self player */
+    if (argc < 2) {
+        PartyStatisticsWindow::Instance().WritePlayerStatistics();
+        return;
+    }
+
+    const auto arg1 = GuiUtils::ToLower(argv[1]);
+
+    if (argc == 2) {
+        /* command: /skillstats reset */
+        if (arg1 == L"reset") {
+            PartyStatisticsWindow::Instance().UnsetPlayerStatistics();
+        }
+        /* command: /skllstats playerNum */
+        else {
+            auto player_number = uint32_t{0};
+            GuiUtils::ParseUInt(argv[1], &player_number);
+            --player_number; // List will start at index zero
+
+            PartyStatisticsWindow::Instance().WritePlayerStatistics(player_number);
+        }
+
+        return;
+    }
+
+    /* command: /skillstats playerNum skillNum */
+    if (argc >= 3) {
+        const auto player_number_arg = argv[1];
+        auto player_number = uint32_t{0};
+
+        GuiUtils::ParseUInt(player_number_arg, &player_number);
+        --player_number; // List will start at index zero
+
+        auto skill_number = uint32_t{0};
+        GuiUtils::ParseUInt(argv[2], &skill_number);
+        --skill_number; // List will start at index zero
+
+        PartyStatisticsWindow::Instance().WritePlayerStatistics(player_number, skill_number);
+    }
+}
 
 void PartyStatisticsWindow::WritePlayerStatistics(const uint32_t player_idx, const uint32_t skill_idx) {
     if (GW::Constants::InstanceType::Loading == GW::Map::GetInstanceType()) return;

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -508,6 +508,7 @@ void PartyStatisticsWindow::SetPartySkills() {
                 skills[skill_idx] = {NONE_SKILL, 0U, std::wstring{UNKNOWN_SKILL_NAME}};
             }
             player_skills.skills = skills;
+            ++party_idx;
             continue;
         }
 

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -79,7 +79,7 @@ void PartyStatisticsWindow::MapLoadedCallback(GW::HookStatus*, GW::Packet::StoC:
     }
 }
 
-void PartyStatisticsWindow::HandleGenericPacket(const uint32_t value_id, const uint32_t caster_id,
+void PartyStatisticsWindow::SkillCallback(const uint32_t value_id, const uint32_t caster_id,
     const uint32_t target_id, const uint32_t value, const bool no_target) {
     auto agent_id = caster_id;
     const auto activated_skill_id = value;
@@ -358,7 +358,7 @@ void PartyStatisticsWindow::Initialize() {
             const auto target_id = 0U;
             const auto value = packet->value;
             const auto no_target = true;
-            HandleGenericPacket(value_id, caster_id, target_id, value, no_target);
+            SkillCallback(value_id, caster_id, target_id, value, no_target);
         });
 
     /* Skill on enemy */
@@ -371,7 +371,7 @@ void PartyStatisticsWindow::Initialize() {
             const auto target_id = packet->target;
             const auto value = packet->value;
             const auto no_target = false;
-            HandleGenericPacket(value_id, caster_id, target_id, value, no_target);
+            SkillCallback(value_id, caster_id, target_id, value, no_target);
         });
 
     party_stats.clear();

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -21,7 +21,7 @@
 #include <Modules/Resources.h>
 #include <Windows/PartyStatistics.h>
 
-void PartyStatisticsWindow::GetSkillName(const uint32_t skill_id, char* skill_name) {
+void PartyStatisticsWindow::GetSkillName(const uint32_t skill_id, char* const skill_name) {
     const auto& skill_data = GW::SkillbarMgr::GetSkillConstantData(skill_id);
 
     const auto length = size_t{32};
@@ -32,7 +32,7 @@ void PartyStatisticsWindow::GetSkillName(const uint32_t skill_id, char* skill_na
     }
 }
 
-void PartyStatisticsWindow::GetPlayerName(const GW::Agent* const agent, char* agent_name) {
+void PartyStatisticsWindow::GetPlayerName(const GW::Agent* const agent, char* const agent_name) {
     if (nullptr == agent_name || nullptr == agent) return;
 
     auto buffer = GW::Agents::GetAgentEncName(agent);

--- a/GWToolboxdll/Windows/PartyStatistics.cpp
+++ b/GWToolboxdll/Windows/PartyStatistics.cpp
@@ -391,8 +391,6 @@ void PartyStatisticsWindow::Draw(IDirect3DDevice9* pDevice) {
     }
 
     if (ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
-        ImGui::Text("Skill Name: Abs. Skill Count - Perc. Skill Count");
-
         const auto party_size = party_stats.size();
 
         for (const auto& party_member_stats : party_stats) {
@@ -411,10 +409,10 @@ void PartyStatisticsWindow::DrawPartyMember(const PlayerSkillCounts& party_membe
 
     char agent_name[buffer_length] = {'\0'};
 
-    // hero id is unknown in outpost
+    // hero or hench is unknown in outpost
     if (nullptr == agent) {
-        if (ImGui::CollapsingHeader("Hero Slot")) {
-            ImGui::Text("Hero data cannot be loded in outpost n/a");
+        if (ImGui::CollapsingHeader("Hero/Henchman Slot")) {
+            ImGui::Text("Hero/Henchman data cannot be loded in outpost n/a");
         }
         return;
     }

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -60,7 +60,6 @@ public:
     void SaveSettings(CSimpleIni* ini) override;
     void DrawSettingInternal() override;
 
-    static void PartyClearCallback();
     static void MapLoadedCallback(GW::HookStatus*, GW::Packet::StoC::MapLoaded* packet);
     static void SkillCallback(const uint32_t value_id, const uint32_t caster_id, const uint32_t target_id,
         const uint32_t value, const bool no_target);
@@ -74,6 +73,7 @@ private:
     static void GetSkillName(const uint32_t skill_id, char* const skill_name);
     static void GetPlayerName(const GW::Agent* const agent, char* const agent_name);
 
+    void PartyClear();
     void ClearPartyIndicies();
     void ClearPartyStats();
 
@@ -83,8 +83,6 @@ private:
     void SetPartyData();
 
     GW::HookEntry MapLoaded_Entry;
-    GW::HookEntry PartyPlayerAdd_Callback;
-    GW::HookEntry PartyPlayerRemove_Callback;
     GW::HookEntry GenericValueSelf_Entry;
     GW::HookEntry GenericValueTarget_Entry;
 

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -21,7 +21,6 @@ protected:
     static constexpr auto MAX_NUM_SKILLS = size_t{8};
     static constexpr auto NONE_PLAYER_NAME = L"Hero/Henchman Slot";
     static constexpr auto NONE_SKILL = static_cast<uint32_t>(GW::Constants::SkillID::No_Skill);
-    static constexpr auto NONE_SKILL_NAME = L"(none)";
     static constexpr auto UNKNOWN_SKILL_NAME = L"Unknown Skill";
     static constexpr auto BUFFER_LENGTH = size_t{256};
 

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -96,8 +96,6 @@ private:
     void SetPartyNames();
     void SetPartyStats();
 
-    bool in_explorable = false;
-
     GW::HookEntry MapLoaded_Entry;
     GW::HookEntry GenericValueSelf_Entry;
     GW::HookEntry GenericValueTarget_Entry;

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -58,7 +58,7 @@ public:
     void DrawSettingInternal() override;
 
     static void MapLoadedCallback(GW::HookStatus*, GW::Packet::StoC::MapLoaded* packet);
-    static void HandleGenericPacket(const uint32_t value_id, const uint32_t caster_id, const uint32_t target_id,
+    static void SkillCallback(const uint32_t value_id, const uint32_t caster_id, const uint32_t target_id,
         const uint32_t value, const bool no_target);
 
     void WritePlayerStatistics(const uint32_t player_idx, const uint32_t skill_idx = -1, const bool full_info = false);

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -21,7 +21,8 @@ protected:
     static constexpr auto MAX_NUM_SKILLS = size_t{8};
     static constexpr auto NONE_PLAYER_NAME = L"Hero/Henchman Slot";
     static constexpr auto NONE_SKILL = static_cast<uint32_t>(GW::Constants::SkillID::No_Skill);
-    static constexpr auto NONE_SKILL_NAME = L"Unknown Skill";
+    static constexpr auto NONE_SKILL_NAME = L"(none)";
+    static constexpr auto UNKNOWN_SKILL_NAME = L"Unknown Skill";
     static constexpr auto BUFFER_LENGTH = size_t{256};
 
     using PartyIds = std::set<uint32_t>;
@@ -44,7 +45,7 @@ protected:
     using PartySkills = std::vector<PlayerSkills>;
 
     static const GW::Skillbar* GetPlayerSkillbar(const uint32_t player_id);
-    static void GetSkillName(const uint32_t id, wchar_t* const skill_name);
+    static std::wstring GetSkillName(const uint32_t id);
     static void GetPlayerName(const GW::Agent* const agent, wchar_t* const agent_name);
     static std::wstring GetSkillString(
         const std::wstring agent_name, const std::wstring& skill_name, const uint32_t& skill_count);

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -18,7 +18,6 @@
 
 class PartyStatisticsWindow : public ToolboxWindow {
 protected:
-    static constexpr auto TIME_DIFF_THRESH = float{600.0F};
     static constexpr auto MAX_NUM_SKILLS = size_t{8};
     static constexpr auto NONE_PLAYER_NAME = L"Hero/Henchman Slot";
     static constexpr auto NONE_SKILL = static_cast<uint32_t>(GW::Constants::SkillID::No_Skill);
@@ -52,14 +51,15 @@ protected:
 
 public:
     PartyStatisticsWindow()
-        : party_size(size_t{})
+        : in_explorable(false)
+        , party_size(size_t{})
         , self_party_idx(static_cast<size_t>(-1))
         , party_ids(PartyIds{})
-        , party_stats(PartySkills{})
         , party_indicies(PartyIndicies{})
         , party_names(PartyNames{})
-        , chat_queue(std::queue<std::wstring>{})
-        , send_timer(clock_t{}){};
+        , party_stats(PartySkills{})
+        , send_timer(clock_t{})
+        , chat_queue(std::queue<std::wstring>{}){};
     ~PartyStatisticsWindow(){};
 
     static PartyStatisticsWindow& Instance() {
@@ -98,12 +98,8 @@ private:
     void SetPartyNames();
     void SetPartySkills();
 
-    bool in_explorable = false;
-
-    GW::HookEntry MapLoaded_Entry;
-    GW::HookEntry GenericValueSelf_Entry;
-    GW::HookEntry GenericValueTarget_Entry;
-
+    /* Internal data  */
+    bool in_explorable;
     size_t party_size;
     size_t self_party_idx;
     PartyIds party_ids;
@@ -111,9 +107,16 @@ private:
     PartyNames party_names;
     PartySkills party_stats;
 
+    /* Chat messaging */
     clock_t send_timer;
     std::queue<std::wstring> chat_queue;
 
+    /* Callbacks */
+    GW::HookEntry MapLoaded_Entry;
+    GW::HookEntry GenericValueSelf_Entry;
+    GW::HookEntry GenericValueTarget_Entry;
+
+    /* Window settings */
     bool show_abs_values = true;
     bool show_perc_values = true;
     bool print_by_click = true;

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <utility>
 
+#include <GWCA/Constants/Constants.h>
 #include <GWCA/GameEntities/Agent.h>
 #include <GWCA/GameEntities/Skill.h>
 #include <GWCA/Managers/StoCMgr.h>
@@ -18,6 +19,7 @@ class PartyStatisticsWindow : public ToolboxWindow {
 public:
     static constexpr float TIME_DIFF_THRESH = 600.0F;
     static constexpr uint32_t MAX_NUM_SKILLS = 8;
+    static constexpr uint32_t NONE_SKILL = static_cast<uint32_t>(GW::Constants::SkillID::No_Skill);
 
     typedef struct {
         uint32_t skill_id;
@@ -58,6 +60,7 @@ public:
     void SaveSettings(CSimpleIni* ini) override;
     void DrawSettingInternal() override;
 
+    static void PartyClearCallback();
     static void MapLoadedCallback(GW::HookStatus*, GW::Packet::StoC::MapLoaded* packet);
     static void SkillCallback(const uint32_t value_id, const uint32_t caster_id, const uint32_t target_id,
         const uint32_t value, const bool no_target);
@@ -73,7 +76,6 @@ private:
 
     void ClearPartyIndicies();
     void ClearPartyStats();
-    void ClearCallback();
 
     void SetPartyIndicies();
     void SetPartyStats();
@@ -81,7 +83,9 @@ private:
     void SetPartyData();
 
     GW::HookEntry MapLoaded_Entry;
-    GW::HookEntry GenericValue_Entry;
+    GW::HookEntry PartyPlayerAdd_Callback;
+    GW::HookEntry PartyPlayerRemove_Callback;
+    GW::HookEntry GenericValueSelf_Entry;
     GW::HookEntry GenericValueTarget_Entry;
 
     PartyIndicies party_indicies;

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -90,13 +90,14 @@ public:
     void SaveSettings(CSimpleIni* ini) override;
     void DrawSettingInternal() override;
 
-    void WritePlayerStatistics(const uint32_t player_idx = -1, const uint32_t skill_idx = -1);
+    static void CmdSkillStatistics(const wchar_t *message, int argc, LPWSTR *argv);
     void UnsetPlayerStatistics();
 
     static void MapLoadedCallback(GW::HookStatus*, GW::Packet::StoC::MapLoaded*);
 
 private:
     void DrawPartyMember(const PlayerSkills& player_stats, const size_t party_idx);
+    void WritePlayerStatistics(const uint32_t player_idx = -1, const uint32_t skill_idx = -1);
     void WritePlayerStatisticsAllSkills(const uint32_t player_idx);
     void WritePlayerStatisticsSingleSkill(const uint32_t player_idx, const uint32_t skill_idx);
 

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -31,6 +31,7 @@ public:
     } PlayerSkillCounts;
 
     using PartySkillCounts = std::vector<PlayerSkillCounts>;
+    using PartyIndicies = std::map<uint32_t, size_t>;
 
     PartyStatisticsWindow()
         : party_stats(PartySkillCounts{})
@@ -70,20 +71,21 @@ private:
     static void GetPlayerName(const GW::Agent* const agent, char* agent_name);
 
     void ClearPartyIndicies();
-    void ClearPartyMember();
-    void ClearOnPartySizeChange();
+    void ClearPartyStats();
+    void ClearCallback();
 
     void SetPartyIndicies();
-    void SetPartyMemberNames();
-    void SetPartyMemberSkills();
-    void SetPartyMember();
+    void SetPartyStats();
+    void SetPartySkills();
+    void SetPartyData();
 
     GW::HookEntry MapLoaded_Entry;
     GW::HookEntry GenericValue_Entry;
     GW::HookEntry GenericValueTarget_Entry;
 
-    std::map<uint32_t, size_t> party_indicies;
+    PartyIndicies party_indicies;
     PartySkillCounts party_stats;
+
     clock_t send_timer;
     std::queue<std::wstring> chat_queue;
 

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <Timer.h>
+#include <array>
+#include <map>
+#include <queue>
+#include <string>
+#include <utility>
+
+#include <GWCA/GameEntities/Agent.h>
+#include <GWCA/GameEntities/Skill.h>
+#include <GWCA/Managers/StoCMgr.h>
+#include <GWCA/Packets/StoC.h>
+
+#include <ToolboxWindow.h>
+
+class PartyStatisticsWindow : public ToolboxWindow {
+public:
+    static constexpr uint32_t MAX_NUM_SKILLS = 8;
+
+    typedef struct {
+        uint32_t skill_id;
+        uint32_t skill_count;
+    } SkillCount;
+
+    using SkillCounts = std::array<SkillCount, MAX_NUM_SKILLS>;
+
+    typedef struct {
+        uint32_t agent_id;
+        SkillCounts skill_counts;
+    } PlayerSkillCounts;
+
+    using PartySkillCounts = std::vector<PlayerSkillCounts>;
+
+    PartyStatisticsWindow()
+        : party_stats(PartySkillCounts{})
+        , chat_queue(std::queue<std::wstring>{})
+        , send_timer(clock_t{}){};
+    ~PartyStatisticsWindow(){};
+
+    static PartyStatisticsWindow& Instance() {
+        static PartyStatisticsWindow instance;
+        return instance;
+    }
+
+    const char* Name() const override { return "PartyStatistics"; }
+    const char* Icon() const override { return ICON_FA_TABLE; }
+
+    void Initialize() override;
+
+    void Draw(IDirect3DDevice9* pDevice) override;
+    void DrawPartyMember(const PlayerSkillCounts& party_member_stats);
+    void Update(float delta) override;
+
+    void LoadSettings(CSimpleIni* ini) override;
+    void SaveSettings(CSimpleIni* ini) override;
+    void DrawSettingInternal() override;
+
+    static void MapLoadedCallback(GW::HookStatus*, GW::Packet::StoC::MapLoaded* packet);
+    static void HandleGenericPacket(const uint32_t value_id, const uint32_t caster_id, const uint32_t target_id,
+        const uint32_t value, const bool no_target);
+
+    void WritePlayerStatistics(const uint32_t player_idx, const uint32_t skill_idx = -1, const bool full_info = false);
+    void WritePartyStatistics();
+    void ResetPlayerStatistics();
+
+private:
+    static const GW::Skillbar* GetPlayerSkillbar(const uint32_t player_id);
+    static void GetSkillName(const uint32_t skill_id, char* skill_name);
+    static void GetPlayerName(const GW::Agent* const agent, char* agent_name);
+
+    void ClearPartyIndicies();
+    void ClearPartyMember();
+    void ClearOnPartySizeChange();
+
+    void SetPartyIndicies();
+    void SetPartyMemberNames();
+    void SetPartyMemberSkills();
+    void SetPartyMember();
+
+    GW::HookEntry MapLoaded_Entry;
+    GW::HookEntry GenericValue_Entry;
+    GW::HookEntry GenericValueTarget_Entry;
+
+    std::map<uint32_t, size_t> party_indicies;
+    PartySkillCounts party_stats;
+    clock_t send_timer;
+    std::queue<std::wstring> chat_queue;
+
+    bool show_abs_values = true;
+    bool show_perc_values = true;
+};

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -26,36 +26,28 @@ protected:
 
     using PartyIds = std::set<uint32_t>;
     using PartyIndicies = std::map<uint32_t, size_t>;
-    using PartyNames = std::map<uint32_t, std::wstring>;
+    using PartyNames = std::map<uint32_t, std::wstring*>;
 
-    typedef struct {
+    struct Skill {
         uint32_t id;
         uint32_t count;
-        std::wstring name;
-    } Skill;
+        std::wstring* name = 0;
+    };
 
     using Skills = std::array<Skill, MAX_NUM_SKILLS>;
 
-    typedef struct {
+    struct PlayerSkills {
         uint32_t agent_id;
         Skills skills;
-    } PlayerSkills;
+    };
 
     using PartySkills = std::vector<PlayerSkills>;
 
-    typedef struct {
-        GuiUtils::EncString* encoder;
-        size_t party_idx;
-        size_t skill_idx;
-    } EncodingSkill;
-
-    using EncodingSkills = std::map<uint32_t, EncodingSkill>;
-
     static const GW::Skillbar* GetPlayerSkillbar(const uint32_t player_id);
-    std::wstring GetSkillName(const uint32_t skill_id, const size_t party_idx, const size_t skill_idx);
-    static void GetPlayerName(const GW::Agent* const agent, wchar_t* const agent_name);
+    std::wstring& GetSkillName(const uint32_t skill_id);
+    static std::wstring& GetPlayerName(uint32_t agent_id);
     static std::wstring GetSkillString(
-        const std::wstring agent_name, const std::wstring& skill_name, const uint32_t& skill_count);
+        const std::wstring& agent_name, const std::wstring& skill_name, const uint32_t& skill_count);
 
 public:
     PartyStatisticsWindow()
@@ -66,10 +58,11 @@ public:
         , party_indicies(PartyIndicies{})
         , party_names(PartyNames{})
         , party_stats(PartySkills{})
-        , skills_to_encode(EncodingSkills{})
         , send_timer(clock_t{})
         , chat_queue(std::queue<std::wstring>{}){};
-    ~PartyStatisticsWindow(){};
+    ~PartyStatisticsWindow(){
+        UnsetPlayerStatistics();
+    };
 
     static PartyStatisticsWindow& Instance() {
         static PartyStatisticsWindow instance;
@@ -117,7 +110,9 @@ private:
     PartyIndicies party_indicies;
     PartyNames party_names;
     PartySkills party_stats;
-    EncodingSkills skills_to_encode;
+
+    std::map<uint32_t, GuiUtils::EncString*> skill_names;
+    std::map<GW::AgentID, GuiUtils::EncString*> agent_names;
 
     /* Chat messaging */
     clock_t send_timer;

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -84,12 +84,13 @@ public:
     void WritePlayerStatistics(const uint32_t player_idx = -1, const uint32_t skill_idx = -1);
     void UnsetPlayerStatistics();
 
+    static void MapLoadedCallback(GW::HookStatus*, GW::Packet::StoC::MapLoaded*);
+
 private:
     void DrawPartyMember(const PlayerSkills& player_stats, const size_t party_idx);
     void WritePlayerStatisticsAllSkills(const uint32_t player_idx);
     void WritePlayerStatisticsSingleSkill(const uint32_t player_idx, const uint32_t skill_idx);
 
-    void MapLoadedCallback();
     void SkillCallback(const uint32_t value_id, const uint32_t caster_id, const uint32_t target_id,
         const uint32_t value, const bool no_target);
     bool PartySizeChanged();

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -16,6 +16,7 @@
 
 class PartyStatisticsWindow : public ToolboxWindow {
 public:
+    static constexpr float TIME_DIFF_THRESH = 600.0F;
     static constexpr uint32_t MAX_NUM_SKILLS = 8;
 
     typedef struct {

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -3,6 +3,7 @@
 #include <Timer.h>
 #include <array>
 #include <map>
+#include <set>
 #include <queue>
 #include <string>
 #include <utility>
@@ -21,6 +22,10 @@ public:
     static constexpr uint32_t MAX_NUM_SKILLS = 8;
     static constexpr uint32_t NONE_SKILL = static_cast<uint32_t>(GW::Constants::SkillID::No_Skill);
 
+    using PartyIds = std::set<uint32_t>;
+    using PartyIndicies = std::map<uint32_t, size_t>;
+    using PartyNames = std::map<uint32_t, std::string>;
+
     typedef struct {
         uint32_t skill_id;
         uint32_t skill_count;
@@ -34,10 +39,12 @@ public:
     } PlayerSkillCounts;
 
     using PartySkillCounts = std::vector<PlayerSkillCounts>;
-    using PartyIndicies = std::map<uint32_t, size_t>;
 
     PartyStatisticsWindow()
-        : party_stats(PartySkillCounts{})
+        : party_ids(PartyIds{})
+        , party_stats(PartySkillCounts{})
+        , party_indicies(PartyIndicies{})
+        , party_names(PartyNames{})
         , chat_queue(std::queue<std::wstring>{})
         , send_timer(clock_t{}){};
     ~PartyStatisticsWindow(){};
@@ -64,8 +71,12 @@ public:
     static void SkillCallback(const uint32_t value_id, const uint32_t caster_id, const uint32_t target_id,
         const uint32_t value, const bool no_target);
 
+    void WritePlayerStatisticsSingleSkill(const uint32_t player_idx, const uint32_t skill_idx);
+    void WritePlayerStatisticsAllSkillsFullInfo(const uint32_t player_idx);
+    void WritePlayerStatisticsAllSkills(const uint32_t player_idx);
     void WritePlayerStatistics(const uint32_t player_idx, const uint32_t skill_idx = -1, const bool full_info = false);
     void WritePartyStatistics();
+
     void ResetPlayerStatistics();
 
 private:
@@ -73,20 +84,21 @@ private:
     static void GetSkillName(const uint32_t skill_id, char* const skill_name);
     static void GetPlayerName(const GW::Agent* const agent, char* const agent_name);
 
-    void PartyClear();
-    void ClearPartyIndicies();
-    void ClearPartyStats();
+    bool PartySizeChange();
+
+    void SetPlayerStatistics();
 
     void SetPartyIndicies();
+    void SetPartyNames();
     void SetPartyStats();
-    void SetPartySkills();
-    void SetPartyData();
 
     GW::HookEntry MapLoaded_Entry;
     GW::HookEntry GenericValueSelf_Entry;
     GW::HookEntry GenericValueTarget_Entry;
 
+    PartyIds party_ids;
     PartyIndicies party_indicies;
+    PartyNames party_names;
     PartySkillCounts party_stats;
 
     clock_t send_timer;

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Timer.h>
 #include <array>
 #include <map>
 #include <queue>
@@ -14,13 +13,17 @@
 #include <GWCA/Managers/StoCMgr.h>
 #include <GWCA/Packets/StoC.h>
 
+#include <Timer.h>
 #include <ToolboxWindow.h>
 
 class PartyStatisticsWindow : public ToolboxWindow {
-public:
+protected:
     static constexpr auto TIME_DIFF_THRESH = float{600.0F};
-    static constexpr auto MAX_NUM_SKILLS = uint32_t{8};
+    static constexpr auto MAX_NUM_SKILLS = size_t{8};
+    static constexpr auto NONE_PLAYER_NAME = "Hero/Henchman Slot";
     static constexpr auto NONE_SKILL = static_cast<uint32_t>(GW::Constants::SkillID::No_Skill);
+    static constexpr auto NONE_SKILL_NAME = "Unknown Skill";
+    static constexpr auto BUFFER_LENGTH = size_t{256};
 
     using PartyIds = std::set<uint32_t>;
     using PartyIndicies = std::map<uint32_t, size_t>;
@@ -41,6 +44,13 @@ public:
 
     using PartySkills = std::vector<PlayerSkills>;
 
+    static const GW::Skillbar* GetPlayerSkillbar(const uint32_t player_id);
+    static void GetSkillName(const uint32_t id, char* const skill_name);
+    static void GetPlayerName(const GW::Agent* const agent, char* const agent_name);
+    static std::string GetSkillFullInfoString(
+        const std::string agent_name, const std::string skill_name, const uint32_t skill_count);
+
+public:
     PartyStatisticsWindow()
         : party_size(size_t{})
         , party_ids(PartyIds{})
@@ -70,32 +80,24 @@ public:
     void SaveSettings(CSimpleIni* ini) override;
     void DrawSettingInternal() override;
 
-    void MapLoadedCallback();
-    void SkillCallback(const uint32_t value_id, const uint32_t caster_id, const uint32_t target_id,
-        const uint32_t value, const bool no_target);
-
-    void WritePlayerStatisticsSingleSkill(const uint32_t player_idx, const uint32_t skill_idx);
-    void WritePlayerStatisticsAllSkillsFullInfo(const uint32_t player_idx);
-    void WritePlayerStatisticsAllSkills(const uint32_t player_idx);
-    void WritePlayerStatistics(const uint32_t player_idx, const uint32_t skill_idx = -1, const bool full_info = false);
     void WritePartyStatistics();
+    void WritePlayerStatistics(const uint32_t player_idx, const uint32_t skill_idx = -1, const bool full_info = false);
+    void WritePlayerStatisticsAllSkills(const uint32_t player_idx);
+    void WritePlayerStatisticsAllSkillsFullInfo(const uint32_t player_idx);
+    void WritePlayerStatisticsSingleSkillFullInfo(const uint32_t player_idx, const uint32_t skill_idx);
 
     void UnsetPlayerStatistics();
 
 private:
-    static const GW::Skillbar* GetPlayerSkillbar(const uint32_t player_id);
-    static void GetSkillName(const uint32_t id, char* const skill_name);
-    static void GetPlayerName(const GW::Agent* const agent, char* const agent_name);
-    static std::string GetSkillFullInfoString(
-        const std::string agent_name, const std::string skill_name, const uint32_t skill_count);
-
+    void MapLoadedCallback();
+    void SkillCallback(const uint32_t value_id, const uint32_t caster_id, const uint32_t target_id,
+        const uint32_t value, const bool no_target);
     bool PartySizeChanged();
 
     void SetPlayerStatistics();
-
     void SetPartyIndicies();
     void SetPartyNames();
-    void SetPartyStats();
+    void SetPartySkills();
 
     GW::HookEntry MapLoaded_Entry;
     GW::HookEntry GenericValueSelf_Entry;

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -67,8 +67,8 @@ public:
 
 private:
     static const GW::Skillbar* GetPlayerSkillbar(const uint32_t player_id);
-    static void GetSkillName(const uint32_t skill_id, char* skill_name);
-    static void GetPlayerName(const GW::Agent* const agent, char* agent_name);
+    static void GetSkillName(const uint32_t skill_id, char* const skill_name);
+    static void GetPlayerName(const GW::Agent* const agent, char* const agent_name);
 
     void ClearPartyIndicies();
     void ClearPartyStats();

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -18,9 +18,9 @@
 
 class PartyStatisticsWindow : public ToolboxWindow {
 public:
-    static constexpr float TIME_DIFF_THRESH = 600.0F;
-    static constexpr uint32_t MAX_NUM_SKILLS = 8;
-    static constexpr uint32_t NONE_SKILL = static_cast<uint32_t>(GW::Constants::SkillID::No_Skill);
+    static constexpr auto TIME_DIFF_THRESH = float{600.0F};
+    static constexpr auto MAX_NUM_SKILLS = uint32_t{8};
+    static constexpr auto NONE_SKILL = static_cast<uint32_t>(GW::Constants::SkillID::No_Skill);
 
     using PartyIds = std::set<uint32_t>;
     using PartyIndicies = std::map<uint32_t, size_t>;
@@ -42,7 +42,8 @@ public:
     using PartySkills = std::vector<PlayerSkills>;
 
     PartyStatisticsWindow()
-        : party_ids(PartyIds{})
+        : party_size(size_t{})
+        , party_ids(PartyIds{})
         , party_skills(PartySkills{})
         , party_indicies(PartyIndicies{})
         , party_names(PartyNames{})
@@ -100,6 +101,7 @@ private:
     GW::HookEntry GenericValueSelf_Entry;
     GW::HookEntry GenericValueTarget_Entry;
 
+    size_t party_size;
     PartyIds party_ids;
     PartyIndicies party_indicies;
     PartyNames party_names;

--- a/GWToolboxdll/Windows/PartyStatistics.h
+++ b/GWToolboxdll/Windows/PartyStatistics.h
@@ -44,8 +44,16 @@ protected:
 
     using PartySkills = std::vector<PlayerSkills>;
 
+    typedef struct {
+        GuiUtils::EncString* encoder;
+        size_t party_idx;
+        size_t skill_idx;
+    } EncodingSkill;
+
+    using EncodingSkills = std::map<uint32_t, EncodingSkill>;
+
     static const GW::Skillbar* GetPlayerSkillbar(const uint32_t player_id);
-    static std::wstring GetSkillName(const uint32_t id);
+    std::wstring GetSkillName(const uint32_t skill_id, const size_t party_idx, const size_t skill_idx);
     static void GetPlayerName(const GW::Agent* const agent, wchar_t* const agent_name);
     static std::wstring GetSkillString(
         const std::wstring agent_name, const std::wstring& skill_name, const uint32_t& skill_count);
@@ -59,6 +67,7 @@ public:
         , party_indicies(PartyIndicies{})
         , party_names(PartyNames{})
         , party_stats(PartySkills{})
+        , skills_to_encode(EncodingSkills{})
         , send_timer(clock_t{})
         , chat_queue(std::queue<std::wstring>{}){};
     ~PartyStatisticsWindow(){};
@@ -108,6 +117,7 @@ private:
     PartyIndicies party_indicies;
     PartyNames party_names;
     PartySkills party_stats;
+    EncodingSkills skills_to_encode;
 
     /* Chat messaging */
     clock_t send_timer;


### PR DESCRIPTION
Hey,
I've added a new Window for the statistics of the skill usage of the team members, as suggested in #535.

The new feature consist of the following:

- Get the names of the players and their skills:
  - Load the skillbar for the player and his heroes
  - For other players or henchmen the skillbar cannot be loaded, therefore the skills are initialized with "Unknown Skill" 
   - When entering an explorable and the other player/henchman will activate their skills, these will then replace the beforehand "Unknown Skills"
- After leaving an explorable and going back to the outpost, the data from the previous run will be displayed until any party member leaves or a new party member joins

Example:

![Screenshot_8](https://user-images.githubusercontent.com/20141069/155142989-401bc98b-5b4e-4836-9daf-95603b373440.png)

For every player/hero/henchman in the party:
- The absolute number of activations for each skill, if the setting for displaying the absolute number is active
- The percentage of activations for each skill, if the setting for displaying the percentage value is active

These stats can be posted in the chat by the following commands:
- /skillstats: Will display the stats for the player
- /skillstats 1: Will display the stats for the team member at position 1
- /skillstats 1 1: Will display the stats for the first skill of the first team member
- /skillstats reset: Will reset the statistics

Note: Skills that were not activated yet (abs. count of 0) will not be printed in the chat.

![Screenshot_4](https://user-images.githubusercontent.com/20141069/155087678-493121ea-d6e7-4783-8f73-79489a57ec87.png)

One alternative to posting the info in the chat is by pressing Ctrl and Left Clicking on the player's stats in the party statistics window.