### PR TITLE
Fix UI checkboxes for Position and Size lock of the Main Window

### DIFF
--- a/GWToolboxdll/Windows/SettingsWindow.cpp
+++ b/GWToolboxdll/Windows/SettingsWindow.cpp
@@ -175,15 +175,17 @@ bool SettingsWindow::DrawSettingsSection(const char* section)
         ImGui::GetWindowDrawList()->AddText(ImVec2(pos.x + text_offset_x, pos.y + style.ItemSpacing.y / 2), ImColor(style.Colors[ImGuiCol_Text]), icon);
     }
 
-    if (is_showing) ImGui::PushID(section);
-    size_t i = 0;
-    for (auto& entry : settings_section->second) {
-        ImGui::PushID(&settings_section->second);
-        if (i && is_showing) ImGui::Separator();
-        entry.second(&settings_section->first, is_showing);
-        i++;
+    if (is_showing) {
+        ImGui::PushID(section);
+        size_t i = 0;
+        for (auto& entry : settings_section->second) {
+            if (i) ImGui::Separator();
+            ImGui::PushID(i);
+            entry.second(&settings_section->first, is_showing);
+            i++;
+            ImGui::PopID();
+        }
         ImGui::PopID();
     }
-    if (is_showing) ImGui::PopID();
     return true;
 }


### PR DESCRIPTION
This is a partial revert of commit 433ec627b1c029c4e06fddaf8aa9d52c75d806bd which undid part of a fix made by commit 575ee5554fe691b5061e267f5374f99ae0ede366

These checkboxes appear to be dead/disabled since (binary) release 5.6
 
Funny enough the tag for 5.5 does not appear to reflect the binary release of version 5.5 which seemes to have the original fix.  