### PR TITLE
move GWToolboxpp directory to My Documents

### DIFF
--- a/Core/Path.cpp
+++ b/Core/Path.cpp
@@ -142,7 +142,7 @@ bool PathCompose(wchar_t *dest, size_t length, const wchar_t *left, const wchar_
     return true;
 }
 
-fs::path PathGetComputer()
+fs::path PathGetComputerName()
 {
     constexpr auto INFO_BUFFER_SIZE = 32;
     WCHAR computername[INFO_BUFFER_SIZE];
@@ -179,7 +179,7 @@ bool PathMoveDataAndCreateSymlink(bool create_symlink = true)
         return true;
     }
 
-    if (fs::is_symlink(appdir) && fs::is_directory(docpath) && fs::is_directory(docpath / PathGetComputer())) {
+    if (fs::is_symlink(appdir) && fs::is_directory(docpath) && fs::is_directory(docpath / PathGetComputerName())) {
         return true;
     }
 
@@ -198,15 +198,15 @@ bool PathMoveDataAndCreateSymlink(bool create_symlink = true)
         for (fs::path p : fs::directory_iterator(apppath)) {
             if (!fs::exists(docpath / p.filename())) {
                 if (fs::is_directory(p)) {
-                    fs::path dir = (docpath / PathGetComputer() / p.filename()).parent_path();
+                    fs::path dir = (docpath / PathGetComputerName() / p.filename()).parent_path();
                     if (!fs::exists(dir)) {
                         fs::create_directories(dir, error);
                     }
-                    fs::rename(p, docpath / PathGetComputer() / p.filename(), error);
+                    fs::rename(p, docpath / PathGetComputerName() / p.filename(), error);
                 } else if (p.extension() != ".dll" && p.extension() != ".exe") {
-                    fs::path dir = (docpath / PathGetComputer() / p.filename()).parent_path();
+                    fs::path dir = (docpath / PathGetComputerName() / p.filename()).parent_path();
                     if (fs::exists(dir)) fs::create_directories(dir);
-                    fs::rename(p, docpath / PathGetComputer() / p.filename(), error);
+                    fs::rename(p, docpath / PathGetComputerName() / p.filename(), error);
                 } else {
                     fs::rename(p, docpath / p.filename(), error);
                 }
@@ -219,7 +219,7 @@ bool PathMoveDataAndCreateSymlink(bool create_symlink = true)
     }
 
     if (create_symlink) {
-        fs::create_directory_symlink(docpath, apppath, error);
+        fs::create_directory_symlink(docpath / PathGetComputerName(), apppath, error);
 
         if (error.value()) {
             fprintf(stderr, "Couldn't create symlink from appdir to docdir.\n");

--- a/Core/Path.cpp
+++ b/Core/Path.cpp
@@ -46,16 +46,11 @@ void PathGetProgramDirectory(wchar_t *path, size_t length)
         filename[0] = 0;
 }
 
-bool PathGetAppDataDirectory(wchar_t *path, size_t length)
+bool PathGetDocumentsDirectory(wchar_t *path, size_t length)
 {
     assert(MAX_PATH <= length);
 
-    HRESULT result = SHGetFolderPathW(
-        nullptr,
-        CSIDL_LOCAL_APPDATA | CSIDL_FLAG_CREATE,
-        NULL,
-        0,
-        path);
+    HRESULT result = SHGetFolderPathW(nullptr, CSIDL_MYDOCUMENTS, NULL, 0, path);
 
     if (FAILED(result)) {
         fprintf(stderr, "SHGetFolderPathW failed (HRESULT:0x%lX)\n", result);
@@ -65,8 +60,35 @@ bool PathGetAppDataDirectory(wchar_t *path, size_t length)
     return true;
 }
 
-bool PathGetAppDataPath(wchar_t *path, size_t length, const wchar_t *suffix)
+bool PathGetDocumentsPath(wchar_t *path, size_t length, const wchar_t *suffix)
 {
+    if (!PathGetDocumentsDirectory(path, length)) {
+        fprintf(stderr, "PathGetDocumentsDirectory failed\n");
+        return false;
+    }
+
+    if (PathAppendW(path, suffix) != TRUE) {
+        fprintf(stderr, "PathAppendW failed\n");
+        return false;
+    }
+
+    return true;
+}
+
+bool PathGetAppDataDirectory(wchar_t* path, size_t length) {
+    assert(MAX_PATH <= length);
+
+    HRESULT result = SHGetFolderPathW(nullptr, CSIDL_LOCAL_APPDATA | CSIDL_FLAG_CREATE, NULL, 0, path);
+
+    if (FAILED(result)) {
+        fprintf(stderr, "SHGetFolderPathW failed (HRESULT:0x%lX)\n", result);
+        return false;
+    }
+
+    return true;
+}
+
+bool PathGetAppDataPath(wchar_t* path, size_t length, const wchar_t* suffix) {
     if (!PathGetAppDataDirectory(path, length)) {
         fprintf(stderr, "PathGetAppDataDirectory failed\n");
         return false;

--- a/Core/Path.h
+++ b/Core/Path.h
@@ -6,8 +6,10 @@ void PathGetExeFileName(wchar_t *path, size_t length);
 
 void PathGetProgramDirectory(wchar_t *path, size_t length);
 
-bool PathGetAppDataDirectory(wchar_t *path, size_t length);
-bool PathGetAppDataPath(wchar_t *path, size_t length, const wchar_t *suffix);
+bool PathGetDocumentsDirectory(wchar_t *path, size_t length);
+bool PathGetDocumentsPath(wchar_t* path, size_t length, const wchar_t* suffix);
+bool PathGetAppDataDirectory(wchar_t* path, size_t length);
+bool PathGetAppDataPath(wchar_t* path, size_t length, const wchar_t* suffix);
 
 bool PathCreateDirectory(const wchar_t *path);
 

--- a/Core/Path.h
+++ b/Core/Path.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <filesystem>
+
 // @Cleanup: Add return values
 void PathGetExeFullPath(wchar_t *path, size_t length);
 void PathGetExeFileName(wchar_t *path, size_t length);
@@ -14,3 +16,6 @@ bool PathGetAppDataPath(wchar_t* path, size_t length, const wchar_t* suffix);
 bool PathCreateDirectory(const wchar_t *path);
 
 bool PathCompose(wchar_t *dest, size_t length, const wchar_t *left, const wchar_t *right);
+
+std::filesystem::path PathGetComputer();
+bool PathMoveDataAndCreateSymlink(bool create_symlink = true);

--- a/Core/Path.h
+++ b/Core/Path.h
@@ -17,5 +17,5 @@ bool PathCreateDirectory(const wchar_t *path);
 
 bool PathCompose(wchar_t *dest, size_t length, const wchar_t *left, const wchar_t *right);
 
-std::filesystem::path PathGetComputer();
+std::filesystem::path PathGetComputerName();
 bool PathMoveDataAndCreateSymlink(bool create_symlink = true);

--- a/Core/stdafx.h
+++ b/Core/stdafx.h
@@ -20,3 +20,4 @@
 #include <stdio.h>
 
 #include <algorithm>
+#include <filesystem>

--- a/GWToolbox/Download.cpp
+++ b/GWToolbox/Download.cpp
@@ -171,7 +171,7 @@ bool DownloadWindow::DownloadAllFiles()
     release_string[0] = 0;
 
     wchar_t dll_path[MAX_PATH];
-    PathGetAppDataPath(dll_path, MAX_PATH, L"GWToolboxpp\\GWToolboxdll.dll");
+    PathGetDocumentsPath(dll_path, MAX_PATH, L"GWToolboxpp\\GWToolboxdll.dll");
 
     char buffer[64];
     snprintf(buffer, 64, "Downloading version '%s'", release.tag_name.c_str());

--- a/GWToolbox/Install.cpp
+++ b/GWToolbox/Install.cpp
@@ -159,7 +159,7 @@ static bool EnsureInstallationDirectoryExist(void)
     }
 
     // Create %USERPROFILE%\Documents\GWToolboxpp\<Computername>\logs
-    if (!PathCompose(temp, MAX_PATH, path, (PathGetComputer() / L"logs").c_str())) {
+    if (!PathCompose(temp, MAX_PATH, path, (PathGetComputerName() / L"logs").c_str())) {
         fprintf(stderr, "PathCompose failed ('%ls', '%ls')\n", path, L"logs");
         return false;
     }
@@ -169,7 +169,7 @@ static bool EnsureInstallationDirectoryExist(void)
     }
 
     // Create %USERPROFILE%\Documents\GWToolboxpp\<Computername>\crashes
-    if (!PathCompose(temp, MAX_PATH, path, (PathGetComputer() / L"crashes").c_str())) {
+    if (!PathCompose(temp, MAX_PATH, path, (PathGetComputerName() / L"crashes").c_str())) {
         fprintf(stderr, "PathCompose failed ('%ls', '%ls')\n", path, L"crashes");
         return false;
     }
@@ -179,7 +179,7 @@ static bool EnsureInstallationDirectoryExist(void)
     }
 
     // Create %USERPROFILE%\Documents\GWToolboxpp\<Computername>\plugins
-    if (!PathCompose(temp, MAX_PATH, path, (PathGetComputer() / L"plugins").c_str())) {
+    if (!PathCompose(temp, MAX_PATH, path, (PathGetComputerName() / L"plugins").c_str())) {
         fprintf(stderr, "PathCompose failed ('%ls', '%ls')\n", path, L"plugins");
         return false;
     }
@@ -189,7 +189,7 @@ static bool EnsureInstallationDirectoryExist(void)
     }
 
     // Create %USERPROFILE%\Documents\GWToolboxpp\<Computername>\data
-    if (!PathCompose(temp, MAX_PATH, path, (PathGetComputer() / L"data").c_str())) {
+    if (!PathCompose(temp, MAX_PATH, path, (PathGetComputerName() / L"data").c_str())) {
         fprintf(stderr, "PathCompose failed ('%ls', '%ls')\n", path, L"data");
         return false;
     }

--- a/GWToolbox/Install.h
+++ b/GWToolbox/Install.h
@@ -5,4 +5,3 @@ bool Uninstall(bool quiet);
 
 bool IsInstalled();
 bool GetInstallationLocation(wchar_t *path, size_t length);
-bool MoveDataAndCreateSymlink();

--- a/GWToolbox/Install.h
+++ b/GWToolbox/Install.h
@@ -5,3 +5,4 @@ bool Uninstall(bool quiet);
 
 bool IsInstalled();
 bool GetInstallationLocation(wchar_t *path, size_t length);
+bool MoveDataAndCreateSymlink();

--- a/GWToolbox/main.cpp
+++ b/GWToolbox/main.cpp
@@ -105,6 +105,15 @@ INT WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
         RestartWithSameArgs(true);
     }
 
+    if (IsInstalled() && !MoveDataAndCreateSymlink() && !IsRunningAsAdmin()) {
+        int iRet = MessageBoxW(
+            0, L"In order to update, the application will have to be restarted with administrative rights once.\nDo you wish to restart now?", L"GWToolbox", MB_YESNO);
+
+        if (iRet == IDYES) {
+            RestartWithSameArgs(true);
+        }
+    }
+
     AsyncRestScopeInit RestInitializer;
 
     Process proc;
@@ -137,7 +146,7 @@ INT WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
             MB_YESNO);
 
         if (iRet == IDNO) {
-            fprintf(stderr, "Use doesn't want to install GWToolbox\n");
+            fprintf(stderr, "User doesn't want to install GWToolbox\n");
             return 1;
         }
 

--- a/GWToolbox/main.cpp
+++ b/GWToolbox/main.cpp
@@ -105,7 +105,7 @@ INT WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
         RestartWithSameArgs(true);
     }
 
-    if (IsInstalled() && !MoveDataAndCreateSymlink() && !IsRunningAsAdmin()) {
+    if (IsInstalled() && !PathMoveDataAndCreateSymlink() && !IsRunningAsAdmin() && settings.noupdate) {
         int iRet = MessageBoxW(
             0, L"In order to update, the application will have to be restarted with administrative rights once.\nDo you wish to restart now?", L"GWToolbox", MB_YESNO);
 

--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -177,7 +177,7 @@ std::filesystem::path Resources::GetSettingsFolderPath()
     WCHAR docbuf[MAX_PATH];
     SHGetFolderPathW(NULL, CSIDL_MYDOCUMENTS, NULL, 0, docbuf);
 
-    auto docpath = std::filesystem::path(docbuf) / "GWToolboxpp" / PathGetComputer();
+    auto docpath = std::filesystem::path(docbuf) / "GWToolboxpp" / PathGetComputerName();
 
     if (PathMoveDataAndCreateSymlink(false)) {
         return docpath;

--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -13,6 +13,7 @@
 #include <Modules/Resources.h>
 #include <GWCA/GameEntities/Item.h>
 #include <Timer.h>
+#include <Path.h>
 
 namespace {
     const char* d3dErrorMessage(HRESULT code) {
@@ -176,15 +177,11 @@ std::filesystem::path Resources::GetSettingsFolderPath()
     WCHAR docbuf[MAX_PATH];
     SHGetFolderPathW(NULL, CSIDL_MYDOCUMENTS, NULL, 0, docbuf);
 
-    constexpr auto INFO_BUFFER_SIZE = 32;
-    wchar_t computername[INFO_BUFFER_SIZE];
-    DWORD bufCharCount = INFO_BUFFER_SIZE;
+    auto docpath = std::filesystem::path(docbuf) / "GWToolboxpp" / PathGetComputer();
 
-    if (!GetComputerNameW(computername, &bufCharCount)) {
-        fprintf(stderr, "Cannot get computer name.\n");
-        return apppath;
-    }
-    auto docpath = std::filesystem::path(docbuf) / "GWToolboxpp" / std::filesystem::path(computername);
+    if (PathMoveDataAndCreateSymlink(false)) {
+        return docpath;
+    };
 
     if (std::filesystem::exists(docpath) && std::filesystem::exists(docpath / "GWToolbox.ini")) {
         return docpath;


### PR DESCRIPTION
move launcher/dll to %USERPROFILE%/Documents
and settings to %USERPROFILE%/Documents/<Computername>

creates a symlink from %localappdata%/GWToolboxpp to %USERPROFILE%/Documents/<Computername> so that you may still run old gwtoolboxdll versions. new gwtoolboxdll will use the new settings directory if it exists