### PR TITLE
Fixed Minimap on WorldMapShown

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -919,6 +919,8 @@ void Minimap::SelectTarget(GW::Vec2f pos) const
 
 bool Minimap::WndProc(UINT Message, WPARAM wParam, LPARAM lParam)
 {
+    if (GW::UI::GetIsWorldMapShowing()) 
+        return false;
     if (is_observing)
         return false;
     if (mouse_clickthrough_in_explorable && GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable)


### PR DESCRIPTION
fixed a bug where minimap is hidden while world map of guild wars is shown but still captured the click events - making it unable to enter outposts or zoom out/in.