### PR TITLE
block packets from players on our ignore list

### DIFF
--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -1849,48 +1849,6 @@ void GameSettings::OnPlayerJoinInstance(GW::HookStatus* status, GW::Packet::StoC
     }
 }
 
-// Allow clickable name when a player pings "I'm following X" or "I'm targeting X"
-void GameSettings::OnLocalChatMessage(GW::HookStatus* status, GW::Packet::StoC::MessageLocal* pak) {
-    if (const auto friendlist = GW::FriendListMgr::GetFriendList(); friendlist != nullptr) {
-        const auto sender = GetPlayerName(pak->player_number);
-        for (const auto& frnd : friendlist->friends) {
-            if (frnd->type != 1) continue; // check only for ignores
-            if (wcscmp(frnd->charname, sender.c_str()) == 0) {
-                status->blocked = true; // block packet if player is ignored
-                break;
-            }
-        }
-    }
-    if (pak->channel != static_cast<uint32_t>(GW::Chat::Channel::CHANNEL_GROUP) || !pak->player_number)
-        return; // Not team chat or no sender
-    std::wstring message(GetMessageCore());
-    if (message[0] != 0x778 && message[0] != 0x781)
-        return; // Not "I'm Following X" or "I'm Targeting X" message.
-    size_t start_idx = message.find(L"\xba9\x107");
-    if (start_idx == std::wstring::npos)
-        return; // Not a player name.
-    start_idx += 2;
-    size_t end_idx = message.find(L"\x1", start_idx);
-    if (end_idx == std::wstring::npos)
-        return; // Not a player name, this should never happen.
-    std::wstring player_pinged = GuiUtils::SanitizePlayerName(message.substr(start_idx, end_idx));
-    if (player_pinged.empty())
-        return; // No recipient
-    GW::Player* sender = GW::PlayerMgr::GetPlayerByID(pak->player_number);
-    if (!sender)
-        return;// No sender
-    auto instance = &Instance();
-    if (instance->flash_window_on_name_ping && GetPlayerName() == player_pinged)
-        FlashWindow(); // Flash window - we've been followed!
-    // Allow clickable player name
-    message.insert(start_idx, L"<a=1>");
-    message.insert(end_idx + 5, L"</a>");
-    PendingChatMessage* m = PendingChatMessage::queuePrint(GW::Chat::Channel::CHANNEL_GROUP, message.c_str(), sender->name_enc);
-    if (m) instance->pending_messages.push_back(m);
-    ::ClearMessageCore();
-    status->blocked = true; // consume original packet.
-}
-
 // Open links on player name click, Ctrl + click name to target, Ctrl + Shift + click name to invite
 void GameSettings::OnStartWhisper(GW::HookStatus* status, wchar_t* _name) {
     if (!_name) return;
@@ -2182,24 +2140,61 @@ void GameSettings::OnServerMessage(GW::HookStatus* status, GW::Packet::StoC::Mes
     }
 }
 
-// Flash window on guild chat message
 void GameSettings::OnGlobalMessage(GW::HookStatus* status, GW::Packet::StoC::MessageGlobal* pak) {
     if (const auto friendlist = GW::FriendListMgr::GetFriendList(); friendlist != nullptr) {
         for (const auto& frnd : friendlist->friends) {
-            if (frnd->type != 1) continue; // check only for ignores
+            if (frnd == nullptr || frnd->type != GW::FriendType::FriendType_Ignore) continue; // check only for ignores
             if (wcscmp(frnd->charname, pak->sender_name) == 0) {
                 status->blocked = true; // block packet if player is ignored
-                break;
+                return;
             }
         }
     }
-    if (!Instance().flash_window_on_guild_chat ||
+    if (!Instance().flash_window_on_guild_chat ||   // Flash window on guild chat message
         static_cast<GW::Chat::Channel>(pak->channel) != GW::Chat::Channel::CHANNEL_GUILD)
         return; // Disabled or messsage not from guild chat
         const auto sender_name = std::wstring(pak->sender_name);
     if (const auto player_name = GetPlayerName(); sender_name == player_name)
         return; // we sent the message ourselves
     FlashWindow();
+}
+
+// Allow clickable name when a player pings "I'm following X" or "I'm targeting X"
+void GameSettings::OnLocalChatMessage(GW::HookStatus* status, GW::Packet::StoC::MessageLocal* pak) {
+    if (const auto friendlist = GW::FriendListMgr::GetFriendList(); friendlist != nullptr) {
+        const auto sender = GetPlayerName(pak->player_number);
+        for (const auto& frnd : friendlist->friends) {
+            if (frnd == nullptr || frnd->type != GW::FriendType::FriendType_Ignore) continue; // check only for ignores
+            if (wcscmp(frnd->charname, sender.c_str()) == 0) {
+                status->blocked = true; // block packet if player is ignored
+                break;
+            }
+        }
+    }
+    if (pak->channel != static_cast<uint32_t>(GW::Chat::Channel::CHANNEL_GROUP) || !pak->player_number)
+        return; // Not team chat or no sender
+    std::wstring message(GetMessageCore());
+    if (message[0] != 0x778 && message[0] != 0x781) return; // Not "I'm Following X" or "I'm Targeting X" message.
+    size_t start_idx = message.find(L"\xba9\x107");
+    if (start_idx == std::wstring::npos) return; // Not a player name.
+    start_idx += 2;
+    size_t end_idx = message.find(L"\x1", start_idx);
+    if (end_idx == std::wstring::npos) return; // Not a player name, this should never happen.
+    std::wstring player_pinged = GuiUtils::SanitizePlayerName(message.substr(start_idx, end_idx));
+    if (player_pinged.empty()) return; // No recipient
+    GW::Player* sender = GW::PlayerMgr::GetPlayerByID(pak->player_number);
+    if (!sender) return; // No sender
+    auto instance = &Instance();
+    if (instance->flash_window_on_name_ping && GetPlayerName() == player_pinged)
+        FlashWindow(); // Flash window - we've been followed!
+    // Allow clickable player name
+    message.insert(start_idx, L"<a=1>");
+    message.insert(end_idx + 5, L"</a>");
+    PendingChatMessage* m =
+        PendingChatMessage::queuePrint(GW::Chat::Channel::CHANNEL_GROUP, message.c_str(), sender->name_enc);
+    if (m) instance->pending_messages.push_back(m);
+    ::ClearMessageCore();
+    status->blocked = true; // consume original packet.
 }
 
 // Print NPC speech bubbles to emote chat.

--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -58,8 +58,8 @@ namespace {
         flashInfo.cbSize = sizeof(FLASHWINFO);
         flashInfo.hwnd = GW::MemoryMgr::GetGWWindowHandle();
         if (!flashInfo.hwnd) return;
-        flashInfo.dwFlags = FLASHW_TIMER | FLASHW_TRAY | FLASHW_TIMERNOFG;
-        flashInfo.uCount = 0;
+        flashInfo.dwFlags = FLASHW_TRAY | FLASHW_TIMERNOFG;
+        flashInfo.uCount = 5;
         flashInfo.dwTimeout = 0;
         FlashWindowEx(&flashInfo);
     }

--- a/GWToolboxdll/Modules/GameSettings.h
+++ b/GWToolboxdll/Modules/GameSettings.h
@@ -196,7 +196,7 @@ public:
     static void OnSpeechBubble(GW::HookStatus*, GW::Packet::StoC::SpeechBubble*);
     static void OnSpeechDialogue(GW::HookStatus*, GW::Packet::StoC::DisplayDialogue*);
     static void OnServerMessage(GW::HookStatus*, GW::Packet::StoC::MessageServer*);
-    static void OnGlobalMessage(GW::HookStatus* status, GW::Packet::StoC::MessageGlobal* pak);
+    static void OnGlobalMessage(GW::HookStatus*, GW::Packet::StoC::MessageGlobal*);
     static void OnScreenShake(GW::HookStatus*, void* packet);
     static void OnCheckboxPreferenceChanged(GW::HookStatus*, uint32_t msgid, void* wParam, void* lParam);
     static void OnChangeTarget(GW::HookStatus*, uint32_t msgid, void* wParam, void* lParam);

--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
@@ -24,9 +24,8 @@ public:
 
     bool show_hidden_npcs = false;
     bool boss_colors = true;
-    bool agent_border = true;
-
-    unsigned int agent_border_thickness = 0;
+    bool agent_border = false;
+    unsigned int agent_border_thickness = 20;
 
     uint32_t auto_target_id = 0;
 
@@ -143,12 +142,12 @@ private:
     void BuildCustomAgentsMap();
     //const CustomAgent* FindValidCustomAgent(DWORD modelid) const;
 
-    float size_default = 75.f;
-    float size_player = 100.f;
-    float size_signpost = 50.f;
-    float size_item = 25.f;
-    float size_boss = 125.f;
-    float size_minion = 50.f;
+    float size_default = 0.f;
+    float size_player = 0.f;
+    float size_signpost = 0.f;
+    float size_item = 0.f;
+    float size_boss = 0.f;
+    float size_minion = 0.f;
     Shape_e default_shape = Tear;
 
     bool agentcolors_changed = false;

--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
@@ -142,12 +142,12 @@ private:
     void BuildCustomAgentsMap();
     //const CustomAgent* FindValidCustomAgent(DWORD modelid) const;
 
-    float size_default = 0.f;
-    float size_player = 0.f;
-    float size_signpost = 0.f;
-    float size_item = 0.f;
-    float size_boss = 0.f;
-    float size_minion = 0.f;
+    float size_default = 75.f;
+    float size_player = 100.f;
+    float size_signpost = 50.f;
+    float size_item = 25.f;
+    float size_boss = 125.f;
+    float size_minion = 50.f;
     Shape_e default_shape = Tear;
 
     bool agentcolors_changed = false;


### PR DESCRIPTION
this is really weird as most of the time the messages are never even received by the hook, as if GW filters them out, but then sometimes they are received and TB has to block them

couldn't figure out a pattern though and this will make sure everything is blocked

@3vcloud please update the comment in GWCA saying 0 = friend, 1 = ignore, etc. It's 1 = friend, 2 = ignore, etc. like listed in the enum