### PR TITLE
add option to not flip minimap on reverse camera (default)

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -166,12 +166,12 @@ void Minimap::Initialize()
     GW::UI::RegisterKeydownCallback(&AgentPinged_Entry, [this](GW::HookStatus* ,uint32_t key) {
         if (key != GW::UI::ControlAction_ReverseCamera)
             return;
-        reverse_camera = true;
+        camera_currently_reversed = true;
         });
     GW::UI::RegisterKeyupCallback(&AgentPinged_Entry, [this](GW::HookStatus*, uint32_t key) {
         if (key != GW::UI::ControlAction_ReverseCamera)
             return;
-        reverse_camera = false;
+        camera_currently_reversed = false;
         });
 
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::AgentPinged>(&AgentPinged_Entry, [this](GW::HookStatus *, GW::Packet::StoC::AgentPinged *pak) -> void {
@@ -568,7 +568,7 @@ float Minimap::GetMapRotation() const
     if (rotate_minimap) {
         yaw = smooth_rotation ? GW::CameraMgr::GetCamera()->GetCurrentYaw() : GW::CameraMgr::GetYaw();
     }
-    if (reverse_camera && flip_on_reverse) {
+    if (camera_currently_reversed && flip_on_reverse) {
         yaw = M_PI_F + yaw;
     }
     return yaw;

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -451,10 +451,13 @@ void Minimap::DrawSettingInternal()
     ImGui::ShowHelp("Additional pings on the same agents will increase the duration of the existing ping, rather than create a new one.");
     ImGui::NextSpacedElement(); ImGui::Checkbox("Map Rotation", &rotate_minimap);
     ImGui::ShowHelp("Map rotation on (e.g. Compass), or off (e.g. Mission Map).");
+    ImGui::NextSpacedElement();
+    ImGui::Checkbox("Flip when reversed", &flip_on_reverse);
+    ImGui::ShowHelp("Whether the minimap rotation should flip 180 degrees when you reverse your camera.");
     ImGui::NextSpacedElement(); ImGui::Checkbox("Map rotation smoothing", &smooth_rotation);
     ImGui::ShowHelp("Minimap rotation speed matches compass rotation speed.");
     ImGui::NextSpacedElement(); ImGui::Checkbox("Circular", &circular_map);
-    ImGui::ShowHelp("Whether the map should be circular like the compass or a square (default).");
+    ImGui::ShowHelp("Whether the map should be circular like the compass (default) or a square.");
 }
 
 void Minimap::LoadSettings(CSimpleIni *ini)
@@ -478,6 +481,7 @@ void Minimap::LoadSettings(CSimpleIni *ini)
     mouse_clickthrough_in_outpost = ini->GetBoolValue(Name(), VAR_NAME(mouse_clickthrough_in_outpost), mouse_clickthrough_in_outpost);
     mouse_clickthrough_in_explorable = ini->GetBoolValue(Name(), VAR_NAME(mouse_clickthrough_in_explorable), mouse_clickthrough_in_explorable);
     rotate_minimap = ini->GetBoolValue(Name(), VAR_NAME(rotate_minimap), rotate_minimap);
+    flip_on_reverse = ini->GetBoolValue(Name(), VAR_NAME(flip_on_reverse), flip_on_reverse);
     smooth_rotation = ini->GetBoolValue(Name(), VAR_NAME(smooth_rotation), smooth_rotation);
     circular_map = ini->GetBoolValue(Name(), VAR_NAME(circular_map), circular_map);
     key_none_behavior = static_cast<MinimapModifierBehaviour>(ini->GetLongValue(Name(), VAR_NAME(key_none_behavior), 1));
@@ -509,6 +513,7 @@ void Minimap::SaveSettings(CSimpleIni *ini)
     ini->SetLongValue(Name(), VAR_NAME(key_alt_behavior), static_cast<long>(key_alt_behavior));
     ini->SetBoolValue(Name(), VAR_NAME(reduce_ping_spam), pingslines_renderer.reduce_ping_spam);
     ini->SetBoolValue(Name(), VAR_NAME(rotate_minimap), rotate_minimap);
+    ini->SetBoolValue(Name(), VAR_NAME(flip_on_reverse), flip_on_reverse);
     ini->SetBoolValue(Name(), VAR_NAME(smooth_rotation), smooth_rotation);
     ini->SetBoolValue(Name(), VAR_NAME(circular_map), circular_map);
     range_renderer.SaveSettings(ini, Name());
@@ -563,7 +568,7 @@ float Minimap::GetMapRotation() const
     if (rotate_minimap) {
         yaw = smooth_rotation ? GW::CameraMgr::GetCamera()->GetCurrentYaw() : GW::CameraMgr::GetYaw();
     }
-    if (reverse_camera) {
+    if (reverse_camera && flip_on_reverse) {
         yaw = M_PI_F + yaw;
     }
     return yaw;

--- a/GWToolboxdll/Widgets/Minimap/Minimap.h
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.h
@@ -110,7 +110,7 @@ private:
     bool IsKeyDown(MinimapModifierBehaviour mmb) const;
 
     bool mousedown = false;
-    bool reverse_camera = false;
+    bool camera_currently_reversed = false;
 
     Vec2i location;
     Vec2i size;

--- a/GWToolboxdll/Widgets/Minimap/Minimap.h
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.h
@@ -129,6 +129,7 @@ private:
 
     bool mouse_clickthrough_in_explorable = false;
     bool mouse_clickthrough_in_outpost = false;
+    bool flip_on_reverse = false;
     bool rotate_minimap = true;
     bool smooth_rotation = true;
     bool circular_map = true;


### PR DESCRIPTION
this has been bugging me for a while now, the regular gw compass doesn't flip so the mismatch was irritating

I've made it the default behaviour that the minimap does not flip on reverse