### PR TITLE
prevent unwanted copies by looping with const references

### DIFF
--- a/GWToolboxdll/Modules/AprilFools.cpp
+++ b/GWToolboxdll/Modules/AprilFools.cpp
@@ -93,7 +93,7 @@ void AprilFools::SetEnabled(bool is_enabled) {
         Log::Info("April Fools 2020 enabled. Type '/aprilfools' to disable it");
     }
     else {
-        for (auto agent : player_agents) {
+        for (const auto& agent : player_agents) {
             SetInfected(agent.second, false);
         }
         player_agents.clear();

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -1006,7 +1006,7 @@ GW::UI::WindowID ChatCommands::MatchingGWWindow(const wchar_t*, int argc, LPWSTR
         return GW::UI::WindowID_Count;
     const std::wstring arg = GuiUtils::ToLower(argv[1]);
     if (arg.size() && arg != L"all") {
-        for (auto it : gw_windows) {
+        for (const auto& it : gw_windows) {
             if (wcscmp(it.second, arg.c_str()) == 0)
                 return it.first;
         }

--- a/GWToolboxdll/Modules/ChatCommands.h
+++ b/GWToolboxdll/Modules/ChatCommands.h
@@ -125,7 +125,7 @@ private:
         void Init(const wchar_t* search, TargetType type = Npc);
         void Update();
         ~SearchAgent() {
-            for (auto it : npc_names)
+            for (const auto& it : npc_names)
                 delete it.second;
             npc_names.clear();
         }

--- a/GWToolboxdll/Modules/DialogModule.cpp
+++ b/GWToolboxdll/Modules/DialogModule.cpp
@@ -270,7 +270,7 @@ uint32_t DialogModule::AcceptFirstAvailableQuest() {
             break;
         }
     }
-    for (auto quest_id : available_quests) {
+    for (const auto quest_id : available_quests) {
         if (quest_id == (uint32_t)GW::Constants::QuestID::UW_UWG 
             && available_quests.size() > 1) {
             // skip unless it's the only available dialog - certain quests almost always want to be taken last

--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -923,7 +923,7 @@ void GameSettings::Initialize() {
         GW::UI::UIMessage::kDialogBody,
         GW::UI::UIMessage::kDialogButton
     };
-    for (auto message_id : dialog_ui_messages) {
+    for (const auto message_id : dialog_ui_messages) {
         GW::UI::RegisterUIMessageCallback(&OnPreSendDialog_Entry, message_id, OnDialogUIMessage);
     }
     
@@ -2068,7 +2068,7 @@ void GameSettings::OnFactionDonate(GW::HookStatus* status, GW::UI::UIMessage, vo
     if (dialog_id != 0x87)
         return;
     GW::UI::DialogButtonInfo* found = 0;
-    for (auto dialog : DialogModule::Instance().GetDialogButtons()) {
+    for (const auto dialog : DialogModule::Instance().GetDialogButtons()) {
         if (dialog->dialog_id != dialog_id)
             continue;
         found = dialog;

--- a/GWToolboxdll/Modules/HintsModule.cpp
+++ b/GWToolboxdll/Modules/HintsModule.cpp
@@ -238,7 +238,7 @@ void HintsModule::Update(float) {
         && GW::Map::GetInstanceType() != GW::Constants::InstanceType::Loading
         && GW::Agents::GetPlayer()) {
         clock_t _now = clock();
-        for (auto it = delayed_hints.begin(); it != delayed_hints.end();it++) {
+        for (auto it = delayed_hints.begin(); it != delayed_hints.end(); it++) {
             if (it->first < _now) {
                 it->second->Show();
                 delete it->second;

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -655,7 +655,7 @@ void InventoryManager::Initialize() {
         GW::UI::UIMessage::kMoveItem,
         GW::UI::UIMessage::kSendUseItem
     };
-    for (auto message_id : message_id_hooks) {
+    for (const auto message_id : message_id_hooks) {
         GW::UI::RegisterUIMessageCallback(&ItemClick_Entry, message_id, OnUIMessage);
     }
 

--- a/GWToolboxdll/Modules/ItemFilter.cpp
+++ b/GWToolboxdll/Modules/ItemFilter.cpp
@@ -209,7 +209,7 @@ void ItemFilter::SaveSettings(CSimpleIniA* ini) {
 }
 
 void ItemFilter::SpawnSuppressedItems() {
-    for (auto const& packet : suppressed_packets)
+    for (const auto& packet : suppressed_packets)
         EmulatePacket(packet);
 
     suppressed_packets.clear();

--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -84,15 +84,15 @@ Resources::Resources() {
 Resources::~Resources() {
     Cleanup();
     ShutdownCurl();
-    for (auto it : skill_images) {
+    for (const auto& it : skill_images) {
         delete it.second;
     }
     skill_images.clear();
-    for (auto it : item_images) {
+    for (const auto& it : item_images) {
         delete it.second;
     }
     item_images.clear();
-    for (auto it : map_names) {
+    for (const auto& it : map_names) {
         delete it.second;
     }
     map_names.clear();

--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -243,7 +243,7 @@ void ToolboxSettings::DrawSettingInternal() {
     ImGui::Columns(static_cast<int>(cols), "global_enable_cols", false);
     size_t items_per_col = (size_t)ceil(features.size() / static_cast<float>(cols));
     size_t col_count = 0;
-    for (auto feature : features) {
+    for (const auto& feature : features) {
         ImGui::Checkbox(feature.first, feature.second);
         col_count++;
         if (col_count == items_per_col) {

--- a/GWToolboxdll/Widgets/Minimap/EffectRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/EffectRenderer.cpp
@@ -56,36 +56,36 @@ void EffectRenderer::LoadDefaults() {
     aoe_effect_triggers.emplace(Spike_Trap_Activate, new EffectTrigger(Spike_Trap, 2000, GW::Constants::Range::Nearby));
 }
 EffectRenderer::~EffectRenderer() {
-    for (auto settings : aoe_effect_settings) {
+    for (const auto& settings : aoe_effect_settings) {
         delete settings.second;
     }
     aoe_effect_settings.clear();
-    for (auto triggers : aoe_effect_triggers) {
+    for (const auto& triggers : aoe_effect_triggers) {
         delete triggers.second;
     }
     aoe_effect_triggers.clear();
 }
 void EffectRenderer::Invalidate() {
     VBuffer::Invalidate();
-    for (auto p : aoe_effects) {
+    for (const auto p : aoe_effects) {
         delete p;
     }
     aoe_effects.clear();
-    for (auto trigger : aoe_effect_triggers) {
+    for (const auto& trigger : aoe_effect_triggers) {
         trigger.second->triggers_handled.clear();
     }
 }
 void EffectRenderer::LoadSettings(CSimpleIni* ini, const char* section) {
     Invalidate();
     LoadDefaults();
-    for (auto settings : aoe_effect_settings) {
+    for (const auto& settings : aoe_effect_settings) {
         char color_buf[64];
         sprintf(color_buf, "color_aoe_effect_%d", settings.first);
         settings.second->color = Colors::Load(ini, section, color_buf, settings.second->color);
     }
 }
 void EffectRenderer::SaveSettings(CSimpleIni* ini, const char* section) const {
-    for (auto settings : aoe_effect_settings) {
+    for (const auto& settings : aoe_effect_settings) {
         char color_buf[64];
         sprintf(color_buf, "color_aoe_effect_%d", settings.first);
         Colors::Save(ini, section, color_buf, settings.second->color);
@@ -96,7 +96,7 @@ void EffectRenderer::DrawSettings() {
     if (ImGui::SmallConfirmButton("Restore Defaults", &confirm)) {
         LoadDefaults();
     }
-    for (auto s : aoe_effect_settings) {
+    for (const auto& s : aoe_effect_settings) {
         ImGui::PushID(static_cast<int>(s.first));
         Colors::DrawSettingHueWheel("", &s.second->color, 0);
         ImGui::SameLine();

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -212,7 +212,7 @@ void Minimap::Initialize()
         GW::UI::UIMessage::kChangeTarget,
         GW::UI::UIMessage::kSkillActivated
     };
-    for (auto message_id : hook_messages) {
+    for (const auto message_id : hook_messages) {
         GW::UI::RegisterUIMessageCallback(&UIMsg_Entry, message_id, OnUIMessage);
     }
 

--- a/GWToolboxdll/Widgets/TimerWidget.cpp
+++ b/GWToolboxdll/Widgets/TimerWidget.cpp
@@ -161,7 +161,7 @@ void TimerWidget::LoadSettings(CSimpleIni *ini) {
         show_dungeon_traps_timer = ini->GetBoolValue(Name(), VAR_NAME(show_dungeon_traps_timer), show_dungeon_traps_timer);
     }
     show_spirit_timers = ini->GetBoolValue(Name(), VAR_NAME(show_spirit_timers), show_spirit_timers);
-    for (auto it : spirit_effects) {
+    for (const auto& it : spirit_effects) {
         char ini_name[32];
         snprintf(ini_name, 32, "spirit_effect_%d", it.first);
         spirit_effects_enabled[it.first] = ini->GetBoolValue(Name(), ini_name, spirit_effects_enabled[it.first]);
@@ -185,7 +185,7 @@ void TimerWidget::SaveSettings(CSimpleIni *ini) {
     ini->SetBoolValue(Name(), VAR_NAME(show_urgoz_timer), show_urgoz_timer);
     ini->SetBoolValue(Name(), VAR_NAME(show_dhuum_timer), show_dhuum_timer);
     ini->SetBoolValue(Name(), VAR_NAME(show_dungeon_traps_timer), show_dungeon_traps_timer);
-    for (auto it : spirit_effects) {
+    for (const auto& it : spirit_effects) {
         char ini_name[32];
         snprintf(ini_name, 32, "spirit_effect_%d", it.first);
         ini->SetBoolValue(Name(), ini_name, spirit_effects_enabled[it.first]);
@@ -248,7 +248,7 @@ void TimerWidget::DrawSettingInternal() {
     if (show_spirit_timers) {
         ImGui::Indent();
         ImGui::StartSpacedElements(140.f);
-        for (auto it : spirit_effects) {
+        for (const auto& it : spirit_effects) {
             ImGui::NextSpacedElement();
             ImGui::Checkbox(it.second, &spirit_effects_enabled[it.first]);
         }

--- a/GWToolboxdll/Windows/BuildsWindow.cpp
+++ b/GWToolboxdll/Windows/BuildsWindow.cpp
@@ -645,7 +645,7 @@ void BuildsWindow::LoadPcons(const TeamBuild& tbuild, unsigned int idx) {
     if (pcons_loaded.size()) {
         std::string pcons_str;
         size_t i = 0;
-        for (auto pcon : pcons_loaded) {
+        for (const auto pcon : pcons_loaded) {
             if (i) pcons_str += ", ";
             i = 1;
             pcons_str += pcon->abbrev;
@@ -656,7 +656,7 @@ void BuildsWindow::LoadPcons(const TeamBuild& tbuild, unsigned int idx) {
     if (pcons_not_visible.size()) {
         std::string pcons_str;
         size_t i = 0;
-        for (auto pcon : pcons_not_visible) {
+        for (const auto pcon : pcons_not_visible) {
             if (i) pcons_str += ", ";
             i = 1;
             pcons_str += pcon->abbrev;
@@ -681,7 +681,7 @@ void BuildsWindow::SendPcons(const TeamBuild& tbuild, unsigned int idx, bool inc
         pconsStr = buf;
     }
     size_t cnt = 0;
-    for (auto pcon : PconsWindow::Instance().pcons) {
+    for (const auto pcon : PconsWindow::Instance().pcons) {
         if (build.pcons.find(pcon->ini) == build.pcons.end())
             continue;
         if (cnt) pconsStr += ", ";

--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -1516,7 +1516,7 @@ void CompletionWindow::Terminate()
 	clear_vec(elite_skills);
 	clear_vec(heros);
 
-	for (auto camp : character_completion)
+	for (const auto& camp : character_completion)
 		delete camp.second;
 	character_completion.clear();
 }

--- a/GWToolboxdll/Windows/FriendListWindow.cpp
+++ b/GWToolboxdll/Windows/FriendListWindow.cpp
@@ -1028,7 +1028,7 @@ void FriendListWindow::LoadFromFile() {
             // Grab char names
             std::unordered_map<std::wstring, uint8_t> charnames;
             LoadCharnames(entry.pItem, &charnames);
-            for (auto it : charnames) {
+            for (const auto& it : charnames) {
                 lf->SetCharacter(it.first.c_str(), it.second);
             }
             if (lf->characters.empty()) {
@@ -1069,14 +1069,14 @@ void FriendListWindow::SaveToFile() {
             // Append to existing charnames, but don't duplicate. This allows multiple accounts to contribute to the friend list.
             std::unordered_map<std::wstring, uint8_t> charnames;
             LoadCharnames(uuid, &charnames);
-            for (auto char_it : lf.characters) {
+            for (const auto& char_it : lf.characters) {
                 const auto& found = charnames.find(char_it.first);
                 // Note: Don't overwrite the profession
                 if (found == charnames.end() || char_it.second.profession != 0)
                     charnames.emplace(char_it.first, char_it.second.profession);
             }
             inifile->DeleteValue(uuid, "charname", NULL);
-            for (auto char_it : charnames) {
+            for (const auto& char_it : charnames) {
                 char charname[128] = { 0 };
                 snprintf(charname, 128, "%s,%d",
                     GuiUtils::WStringToString(char_it.first).c_str(),
@@ -1085,5 +1085,5 @@ void FriendListWindow::SaveToFile() {
             }
         }
         inifile->SaveFile(Resources::GetPath(ini_filename).c_str());
-        });
+    });
 }

--- a/GWToolboxdll/Windows/GuildWarsPreferencesWindow.cpp
+++ b/GWToolboxdll/Windows/GuildWarsPreferencesWindow.cpp
@@ -125,7 +125,7 @@ namespace {
     };
 
     void GetCurrentPreferences(GWPreferences* out) {
-        for (auto it : out->window_positions) {
+        for (const auto it : out->window_positions) {
             delete it;
         }
         out->window_positions.clear();
@@ -134,7 +134,7 @@ namespace {
                 continue;
             out->window_positions.push_back(new WindowPreference(i,GW::UI::GetWindowPosition(i)));
         }
-        for (auto it : out->preferences) {
+        for (const auto it : out->preferences) {
             delete it;
         }
         out->preferences.clear();

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -172,7 +172,7 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*) {
                 ImGui::GetStyle().ButtonTextAlign = ImVec2(0.0f, 0.5f);
                 if (ImGui::Button(tbuild.name, ImVec2(ImGui::GetContentRegionAvail().x - item_spacing - btn_width, 0))) {
                     if (one_teambuild_at_a_time && !tbuild.edit_open) {
-                        for (auto &tb : teambuilds) {
+                        for (auto& tb : teambuilds) {
                             tb.edit_open = false;
                         }
                     }

--- a/GWToolboxdll/Windows/Hotkeys.cpp
+++ b/GWToolboxdll/Windows/Hotkeys.cpp
@@ -235,7 +235,7 @@ TBHotkey::TBHotkey(CSimpleIni *ini, const char *section)
         
         GuiUtils::IniToArray(ini_str, prof_ids_tmp);
         if (!prof_ids_tmp.empty()) {
-            for (auto prof_id : prof_ids_tmp) {
+            for (const auto prof_id : prof_ids_tmp) {
                 if (prof_id < _countof(prof_ids))
                     prof_ids[prof_id] = true;
             }
@@ -652,7 +652,7 @@ bool TBHotkey::IsInRangeOfNPC() {
     if (!agents)
         return false;
     auto* me = GW::Agents::GetPlayer();
-    for (auto agent : *agents) {
+    for (const auto agent : *agents) {
         if (!(agent && agent->type == 0xDB)) 
             continue;
         auto* living = agent->GetAsAgentLiving();
@@ -1007,7 +1007,7 @@ GW::Item* HotkeyEquipItem::FindMatchingItem(GW::Constants::Bag _bag_idx) {
     GW::Bag* bag = GW::Items::GetBag(_bag_idx);
     if (!bag) return nullptr;
     GW::ItemArray& items = bag->items;
-    for (auto _item : items) {
+    for (const auto _item : items) {
         if (item_attributes.check(_item))
             return _item;
     }
@@ -1832,10 +1832,10 @@ int HotkeyGWKey::Description(char* buf, size_t bufsz)
 }
 bool HotkeyGWKey::Draw()
 {
-    if (!labels.size()) {
+    if (labels.empty()) {
         bool waiting = false;
-        for (auto it : control_labels) {
-            if (!it.second->string().size()) {
+        for (const auto& it : control_labels) {
+            if (it.second->string().empty()) {
                 waiting = true;
                 break;
             }
@@ -1845,7 +1845,7 @@ bool HotkeyGWKey::Draw()
             labels.clear();
         }
     }
-    if (!labels.size()) {
+    if (labels.empty()) {
         ImGui::Text("Waiting on endoded strings");
         return false;
     }

--- a/GWToolboxdll/Windows/HotkeysWindow.cpp
+++ b/GWToolboxdll/Windows/HotkeysWindow.cpp
@@ -223,7 +223,7 @@ void HotkeysWindow::Draw(IDirect3DDevice9* pDevice) {
         };
         switch (group_by) {
             case Profession:
-                for (auto it : by_profession) {
+                for (auto& it : by_profession) {
                     if (ImGui::CollapsingHeader(TBHotkey::professions[it.first])) {
                         ImGui::Indent();
                         if (draw_hotkeys_vec(it.second)) {
@@ -237,7 +237,7 @@ void HotkeysWindow::Draw(IDirect3DDevice9* pDevice) {
                 break;
             case Map: {
                 char* map_name = 0;
-                for (auto it : by_map) {
+                for (auto& it : by_map) {
                     if (it.first == 0)
                         map_name = "Any";
                     else if (it.first >= 0 && it.first < _countof(GW::Constants::NAME_FROM_ID))
@@ -257,7 +257,7 @@ void HotkeysWindow::Draw(IDirect3DDevice9* pDevice) {
             } break;
             case PlayerName: {
                 char* player_name = "";
-                for (auto it : by_player_name) {
+                for (auto& it : by_player_name) {
                     if (it.first.empty())
                         player_name = "Any";
                     else

--- a/GWToolboxdll/Windows/InfoWindow.cpp
+++ b/GWToolboxdll/Windows/InfoWindow.cpp
@@ -54,7 +54,7 @@
 
 InfoWindow::~InfoWindow()
 {
-    for (auto a : target_achievements) {
+    for (const auto& a : target_achievements) {
         delete a.second;
     }
     target_achievements.clear();

--- a/GWToolboxdll/Windows/MainWindow.cpp
+++ b/GWToolboxdll/Windows/MainWindow.cpp
@@ -50,7 +50,7 @@ void MainWindow::RefreshButtons() {
     pending_refresh_buttons = false;
     const std::vector<ToolboxUIElement*>& ui = GWToolbox::Instance().GetUIElements();
     modules_to_draw.clear();
-    for (auto &ui_module : ui) {
+    for (auto& ui_module : ui) {
         if (!ui_module->show_menubutton)
             continue;
         float weighting = GetModuleWeighting(ui_module);
@@ -79,7 +79,7 @@ void MainWindow::Draw(IDirect3DDevice9* device) {
             auto &ui_module = modules_to_draw[i].second;
             if (ui_module->DrawTabButton(device, show_icons, true, center_align_text)) {
                 if (one_panel_at_time_only && ui_module->visible && ui_module->IsWindow()) {
-                    for (auto &ui_module2 : modules_to_draw) {
+                    for (const auto& ui_module2 : modules_to_draw) {
                         if (ui_module2.second == ui_module) continue;
                         if (!ui_module2.second->IsWindow()) continue;
                         ui_module2.second->visible = false;

--- a/GWToolboxdll/Windows/MaterialsWindow.cpp
+++ b/GWToolboxdll/Windows/MaterialsWindow.cpp
@@ -171,7 +171,7 @@ void MaterialsWindow::Initialize() {
         GW::MerchItemArray* items = GW::Merchant::GetMerchantItemsArray();
         merch_items.clear();
         if (items) {
-            for (auto item_id : *items)
+            for (const auto item_id : *items)
                 merch_items.push_back(item_id);
         }
 

--- a/GWToolboxdll/Windows/ObjectiveTimerWindow.cpp
+++ b/GWToolboxdll/Windows/ObjectiveTimerWindow.cpp
@@ -988,7 +988,7 @@ void ObjectiveTimerWindow::SaveRuns()
                 file.open(Resources::GetPath(L"runs", it.first));
                 if (file.is_open()) {
                     nlohmann::json os_json_arr;
-                    for (auto os : it.second) {
+                    for (const auto os : it.second) {
                         os_json_arr.push_back(os->ToJson());
                     }
                     file << os_json_arr << std::endl;

--- a/GWToolboxdll/Windows/PacketLoggerWindow.cpp
+++ b/GWToolboxdll/Windows/PacketLoggerWindow.cpp
@@ -73,7 +73,7 @@ namespace {
     }
     void ExportMapInfo() {
         nlohmann::json json;
-        for (auto it : maps) {
+        for (const auto& it : maps) {
             json[it.first] = it.second->ToJson();
             delete it.second;
         }
@@ -578,7 +578,7 @@ void PacketLoggerWindow::SaveMessageLog() {
     std::wofstream myFile(filename.bytes);
 
     // Send column names to the stream
-    for (auto it : message_log)
+    for (const auto& it : message_log)
     {
         if (!it.second || !it.second->length())
             continue;
@@ -592,7 +592,7 @@ void PacketLoggerWindow::SaveMessageLog() {
 }
 
 void PacketLoggerWindow::ClearMessageLog() {
-    for (auto it : message_log) {
+    for (const auto& it : message_log) {
         if (it.second)
             delete it.second;
     }

--- a/GWToolboxdll/Windows/PartySearchWindow.cpp
+++ b/GWToolboxdll/Windows/PartySearchWindow.cpp
@@ -500,7 +500,7 @@ bool PartySearchWindow::IsLfpAlert(std::string &message)
     std::regex word_regex;
     std::smatch m;
     static const std::regex regex_check = std::regex("^/(.*)/[a-z]?$", std::regex::ECMAScript | std::regex::icase);
-    for (auto &word : alert_words) {
+    for (const auto& word : alert_words) {
         if (std::regex_search(word, m, regex_check)) {
             try {
                 word_regex = std::regex(m._At(1).str(), std::regex::ECMAScript | std::regex::icase);
@@ -604,7 +604,7 @@ void PartySearchWindow::Draw(IDirect3DDevice9* device) {
         int32_t district = GW::Map::GetDistrict();
         uint32_t map = static_cast<uint32_t>(GW::Map::GetMapID());
         //auto& parties = party_ctx->party_search;
-        for (auto it : party_advertisements) {
+        for (const auto& it : party_advertisements) {
             auto* party = it.second;
             if (!party) continue;
             if (!display_party_types[party->search_type])

--- a/GWToolboxdll/Windows/Pcons.cpp
+++ b/GWToolboxdll/Windows/Pcons.cpp
@@ -67,7 +67,7 @@ Pcon::Pcon(const char* chatname,
     ini = ininame ? ininame : GuiUtils::ToSlug(chat);
 }
 Pcon::~Pcon() {
-    for (auto c : settings_by_charname) {
+    for (const auto& c : settings_by_charname) {
         delete c.second;
     }
     settings_by_charname.clear();
@@ -77,7 +77,7 @@ Pcon::~Pcon() {
 void Pcon::ResetCounts() {
     refill_attempted = false;
     pcon_quantity_checked = false;
-    for (auto i : reserved_bag_slots) {
+    for (auto& i : reserved_bag_slots) {
         i.clear();
     }
 }
@@ -450,7 +450,7 @@ void Pcon::SaveSettings(CSimpleIni* inifile, const char* section) {
     inifile->SetLongValue(section, buf_threshold, threshold);
     inifile->SetBoolValue(section, buf_visible, visible);
 
-    for (auto charname_pcons : settings_by_charname) {
+    for (const auto& charname_pcons : settings_by_charname) {
         bool* _enabled = charname_pcons.second;
         if (charname_pcons.first == L"default") {
             inifile->SetBoolValue(section, buf_active, *_enabled);

--- a/GWToolboxdll/Windows/RerollWindow.cpp
+++ b/GWToolboxdll/Windows/RerollWindow.cpp
@@ -146,7 +146,7 @@ namespace {
 }
 
 RerollWindow::~RerollWindow() {
-    for (auto it : account_characters) {
+    for (const auto& it : account_characters) {
         delete it.second;
     }
     account_characters.clear();
@@ -617,7 +617,7 @@ void RerollWindow::LoadSettings(CSimpleIni* ini) {
 }
 void RerollWindow::SaveSettings(CSimpleIni* ini) {
     ToolboxWindow::SaveSettings(ini);
-    for (auto it : account_characters) {
+    for (const auto& it : account_characters) {
         std::string email_s = GuiUtils::WStringToString(it.first);
         auto chars = it.second;
         for (auto it2 = chars->begin(); it2 != chars->end(); it2++) {

--- a/GWToolboxdll/Windows/TradeWindow.cpp
+++ b/GWToolboxdll/Windows/TradeWindow.cpp
@@ -314,7 +314,7 @@ bool TradeWindow::IsTradeAlert(std::string &message)
     std::regex word_regex;
     std::smatch m;
     static const std::regex regex_check = std::regex("^/(.*)/[a-z]?$", std::regex::ECMAScript | std::regex::icase);
-    for (auto &word : alert_words) {
+    for (const auto& word : alert_words) {
         if (std::regex_search(word, m, regex_check)) {
             try {
                 word_regex = std::regex(m._At(1).str(), std::regex::ECMAScript | std::regex::icase);

--- a/GWToolboxdll/Windows/TravelWindow.cpp
+++ b/GWToolboxdll/Windows/TravelWindow.cpp
@@ -619,7 +619,7 @@ void TravelWindow::Initialize() {
 }
 void TravelWindow::Terminate() {
     ToolboxWindow::Terminate();
-    for (auto it : searchable_explorable_areas) {
+    for (const auto it : searchable_explorable_areas) {
         delete[] it;
     }
     searchable_explorable_areas.clear();


### PR DESCRIPTION
noticed we had a lot of these, partially consuming a lot of extra memory (plenty of std::pairs or even std::vectors), this doesn't change anything but to loop via (const) reference for performance and memory sake

may not have caught all of them (only searched for `for (auto ` and fixed manually