### PR TITLE
Added custom marker for the missing doa tendril at 6-0 or 3-3

### DIFF
--- a/resources/Markers.ini
+++ b/resources/Markers.ini
@@ -178,6 +178,16 @@ map = 474
 visible = true
 
 
+[custommarker014]
+name = tendril
+x = 10476.000000
+y = -10867.000000
+size = 100.000000
+shape = 0
+map = 474
+visible = true
+
+
 [custommarker015]
 name = fow cave 1
 x = -7252.000000


### PR DESCRIPTION
One tendril at 6-0/3-3 was missing from the default custom markers. This change adds the missing tendril to the resource file.