### PR TITLE
Fix colour of NPC allies on minimap

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.cpp
@@ -887,7 +887,7 @@ Color AgentRenderer::GetColor(const GW::Agent* agent, const CustomAgent* ca) con
     // friendly
     if (living->GetIsDead()) return color_ally_dead;
     switch (living->allegiance) {
-    case GW::Constants::Allegiance::Ally_NonAttackable: return color_ally; // ally
+    case GW::Constants::Allegiance::Ally_NonAttackable: return (living->IsNPC() ? color_ally_npc : color_ally); // ally
     case GW::Constants::Allegiance::Npc_Minipet: return color_ally_npc; // npc / minipet
     case GW::Constants::Allegiance::Spirit_Pet: return color_ally_spirit; // spirit / pet
     case GW::Constants::Allegiance::Minion: return color_ally_minion; // minion


### PR DESCRIPTION
It would appear that the colour used for "Non-attackable allies" is always `color_ally`, corresponding to the "Ally (player)" setting. There are however two types of agents that would fall under this category: NPCs which are henchmen/heroes (which should use `color_ally_npc`), and player allies.

The issue can be seen by going into an outpost with henchmen and observing that the colour used is the one intended for player allies.

The fix is to check whether the agent is an NPC before deciding which of two colours to use.

Attached are a couple of images to demonstrate.

Tested: Outpost + Explorable.

energy#4904

*Minimap as of master:*, Sunspear Great Hall, observe how henchmen use the player ally colour.
![original](https://user-images.githubusercontent.com/131253637/233637056-845af515-0381-44dd-a196-fdd7a7c9b867.PNG)

*Minimap as of this commit:*
![fixed](https://user-images.githubusercontent.com/131253637/233637047-72b0b643-f204-463e-9065-137802093b02.PNG)


*Settings used:*
![settings](https://user-images.githubusercontent.com/131253637/233637061-ebc81829-a029-48bb-90e1-0bf7750c8ad3.PNG)
