### PR TITLE
Fix file paths in some CMake files

### DIFF
--- a/cmake/gwca.cmake
+++ b/cmake/gwca.cmake
@@ -1,24 +1,24 @@
 include_guard()
 
-set(GWCA_FOLDER "${PROJECT_SOURCE_DIR}/Dependencies/GWCA/")
+set(GWCA_FOLDER "${PROJECT_SOURCE_DIR}/Dependencies/GWCA")
 
 add_library(gwca)
 
 file(GLOB SOURCES
-    "${GWCA_FOLDER}/source/stdafx.h"
-    "${GWCA_FOLDER}/source/*.cpp"
-    "${GWCA_FOLDER}/include/gwca/*.h"
-    "${GWCA_FOLDER}/include/gwca/constants/*.h"
-    "${GWCA_FOLDER}/include/gwca/context/*.h"
-    "${GWCA_FOLDER}/include/gwca/gamecontainers/*.h"
-    "${GWCA_FOLDER}/include/gwca/gameentities/*.h"
-    "${GWCA_FOLDER}/include/gwca/managers/*.h"
-    "${GWCA_FOLDER}/include/gwca/packets/*.h"
-    "${GWCA_FOLDER}/include/gwca/utilities/*.h")
+    "${GWCA_FOLDER}/Source/stdafx.h"
+    "${GWCA_FOLDER}/Source/*.cpp"
+    "${GWCA_FOLDER}/Include/GWCA/*.h"
+    "${GWCA_FOLDER}/Include/GWCA/Constants/*.h"
+    "${GWCA_FOLDER}/Include/GWCA/Context/*.h"
+    "${GWCA_FOLDER}/Include/GWCA/GameContainers/*.h"
+    "${GWCA_FOLDER}/Include/GWCA/GameEntities/*.h"
+    "${GWCA_FOLDER}/Include/GWCA/Managers/*.h"
+    "${GWCA_FOLDER}/Include/GWCA/Packets/*.h"
+    "${GWCA_FOLDER}/Include/GWCA/Utilities/*.h")
 source_group(TREE "${GWCA_FOLDER}" FILES ${SOURCES})
 target_sources(gwca PRIVATE ${SOURCES})
-target_precompile_headers(gwca PRIVATE "${GWCA_FOLDER}/source/stdafx.h")
-target_include_directories(gwca PUBLIC "${GWCA_FOLDER}/include/")
+target_precompile_headers(gwca PRIVATE "${GWCA_FOLDER}/Source/stdafx.h")
+target_include_directories(gwca PUBLIC "${GWCA_FOLDER}/Include/")
 set_target_properties(gwca PROPERTIES CXX_STANDARD 17)
 target_compile_options(gwca PRIVATE /W4 /WX)
 target_link_options(gwca PRIVATE /WX /SAFESEH:NO)

--- a/cmake/gwtoolboxdll_plugins.cmake
+++ b/cmake/gwtoolboxdll_plugins.cmake
@@ -5,10 +5,10 @@
 # Below is for toolbox plugins (WIP):
 add_library(plugin_base INTERFACE)
 target_sources(plugin_base INTERFACE
-    "plugins/base/dllmain.cpp"
-    "plugins/base/ToolboxPlugin.h")
+    "plugins/Base/dllmain.cpp"
+    "plugins/Base/ToolboxPlugin.h")
 target_include_directories(plugin_base INTERFACE
-    "plugins/base"
+    "plugins/Base"
     "GWToolboxdll" # careful here, we only get access to exported and header functions!
     )
 target_link_libraries(plugin_base INTERFACE


### PR DESCRIPTION
Some file paths in a couple CMake files had the wrong case.

This has been gotten away with when compiling directly from Windows, as paths are *usually* case insensitive and so, for instance, "includes/" matches "INCLUDES/".

However, on a very specific setup (using `msvc-wine` to cross-compile w/ MSVC from Linux), the host OS's CMake is used and thus the CMake files containing paths with a differing case from their names on-disk cause an issue.

By the way, it's the easiest way to cross-compile GWToolbox that I found, in case other people were interested in trying too.