### PR TITLE
Add res toast

### DIFF
--- a/GWToolboxdll/Modules/ToastNotifications.cpp
+++ b/GWToolboxdll/Modules/ToastNotifications.cpp
@@ -324,7 +324,7 @@ ToastNotifications::Toast* ToastNotifications::SendToast(const wchar_t* title, c
         toast = new Toast(title, message);
         toasts[toast->title] = toast;
     }
-    if (toast->message == message)
+    else if (toast->message == message)
         return toast; // Avoid spamming desktop notifications
     toast->message = message;
     toast->callback = callback;


### PR DESCRIPTION
Add a toast notification for when the current player is resurrected, as per issue #88 (here you go, Misty).  As part of this, fix a bug with toasts with a static message, wherein the toast will never actually be sent.

This feature may require some more tweaking, as I am finding it easy to accidentally not activate or dismiss the toast, and then just not have any future resurrection notifications appear for the entire game session.  It may be worth adding an automatic dismissal, such as on the player's death, or on map change.

The downside to on death is for death/res loops such as with a UA hero when dead in sulfur in the desolation.  The downside to map change is that future resses during the map may not trigger a toast notification.