### PR TITLE
fix rendering, no longer dependent on GWCA::GetTransform

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
@@ -180,9 +180,10 @@ bool GameWorldRenderer::SetD3DTransform(IDirect3DDevice9* device, const GW::Came
     // clang-format off
     DirectX::XMStoreFloat4x4A(&mat_proj,
         DirectX::XMMatrixTranspose(
-            DirectX::XMMatrixPerspectiveFovLH(actual_fov, aspect_ratio, 1.0f, 10000.0f)
+            DirectX::XMMatrixPerspectiveFovLH(actual_fov, aspect_ratio, 0.1f, 100000.0f)
         )
     );
+    // clang-format on
     if (device->SetVertexShaderConstantF(vertex_shader_proj_matrix_offset, (const float*)&mat_proj, 4) != D3D_OK) {
         GWCA_ERR("GameWorldRenderer: unable to SetVertexShaderConstantF(projection), aborting render.");
         return false;

--- a/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
@@ -153,7 +153,6 @@ bool GameWorldRenderer::SetD3DTransform(IDirect3DDevice9* device, const GW::Came
     constexpr auto vertex_shader_proj_matrix_offset = 4u;
 
     // compute view matrix:
-
     DirectX::XMFLOAT4X4A mat_view{};
     DirectX::XMFLOAT3 eye_pos = {cam->position.x, cam->position.y, cam->position.z};
     DirectX::XMFLOAT3 player_pos = {cam->look_at_target.x, cam->look_at_target.y, cam->look_at_target.z};
@@ -165,10 +164,11 @@ bool GameWorldRenderer::SetD3DTransform(IDirect3DDevice9* device, const GW::Came
         )
     );
     // clang-format on
-    if (device->SetVertexShaderConstantF(vertex_shader_view_matrix_offset, (const float*)&mat_view, 4) != D3D_OK) {
+    if (device->SetVertexShaderConstantF(vertex_shader_view_matrix_offset, reinterpret_cast<const float*>(&mat_view), 4) != D3D_OK) {
         GWCA_ERR("GameWorldRenderer: unable to SetVertexShaderConstantF(view), aborting render.");
         return false;
     }
+
     // compute projection matrix:
     DirectX::XMFLOAT4X4A mat_proj{};
     // compute the "actual" field of view. GW uses a different value than reported by `camera->field_of_view`.
@@ -184,7 +184,7 @@ bool GameWorldRenderer::SetD3DTransform(IDirect3DDevice9* device, const GW::Came
         )
     );
     // clang-format on
-    if (device->SetVertexShaderConstantF(vertex_shader_proj_matrix_offset, (const float*)&mat_proj, 4) != D3D_OK) {
+    if (device->SetVertexShaderConstantF(vertex_shader_proj_matrix_offset, reinterpret_cast<const float*>(&mat_proj), 4) != D3D_OK) {
         GWCA_ERR("GameWorldRenderer: unable to SetVertexShaderConstantF(projection), aborting render.");
         return false;
     }

--- a/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.h
@@ -2,6 +2,7 @@
 
 #include <GWCA/Constants/Constants.h>
 #include <GWCA/GameContainers/GamePos.h>
+#include <GWCA/GameEntities/Camera.h>
 #include <ToolboxIni.h>
 #include <Widgets/Minimap/D3DVertex.h>
 
@@ -40,7 +41,7 @@ private:
     void SyncMarkers(IDirect3DDevice9* device);
     void SyncAllMarkers(IDirect3DDevice9* device);
     bool ConfigureProgrammablePipeline(IDirect3DDevice9* device);
-    static bool SetD3DTransform(IDirect3DDevice9* device);
+    static bool SetD3DTransform(IDirect3DDevice9* device, const GW::Camera* cam);
 
     IDirect3DVertexShader9* vshader = nullptr;
     IDirect3DPixelShader9* pshader = nullptr;


### PR DESCRIPTION
GWCA's `GetTransform` was unstable at best. Depending on which particular UI elements were enabled, it could return unusable values. This PR changes the transforms to be manually constructed, with matching equations as the client itself uses. This makes it much more robust.