### PR TITLE
rename players according to friends list alias

### DIFF
--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -47,6 +47,8 @@
 #include <Utils/GuiUtils.h>
 #include <Utils/ToolboxUtils.h>
 
+#include <Modules/PartyWindowModule.h>
+
 #ifdef _DEBUG
 #include <Windows/StringDecoderWindow.h>
 #endif
@@ -707,7 +709,14 @@ namespace {
                 }
                 if (IsPlayerInParty(pending_reinvite.identifier))
                     return;
-                GW::PartyMgr::InvitePlayer(pending_reinvite.identifier);
+                const auto aliases = PartyWindowModule::Instance().GetAliasedPlayerNames();
+                if (aliases.find(player->name) != aliases.end()) {
+                    auto orig_name = aliases.at(player->name).c_str();
+                    GW::PartyMgr::InvitePlayer(const_cast<wchar_t*>(orig_name));
+                }
+                else {
+                    GW::PartyMgr::InvitePlayer(pending_reinvite.identifier);
+                }
                 return pending_reinvite.reset();
             }
             break;

--- a/GWToolboxdll/Modules/PartyWindowModule.h
+++ b/GWToolboxdll/Modules/PartyWindowModule.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ToolboxModule.h>
+#include <GWCA/Packets/StoC.h>
 
 class PartyWindowModule : public ToolboxModule {
     PartyWindowModule() = default;
@@ -21,9 +22,12 @@ public:
     void LoadSettings(ToolboxIni* ini) override;
     void SaveSettings(ToolboxIni* ini) override;
     void DrawSettingsInternal() override;
+    const std::map<std::wstring, std::wstring>& GetAliasedPlayerNames();
 
 private:
     static void LoadDefaults();
+    void SetAliasedPlayerName(GW::Packet::StoC::PlayerJoinInstance* pak);
+    std::map<std::wstring, std::wstring> aliased_player_names{};
 
 private:
 };


### PR DESCRIPTION
This PR adds a setting to the party window module (defaulted to **off**) to rename players according to an alias set in the friends list.

## Example:
![image](https://github.com/HasKha/GWToolboxpp/assets/78256408/9a2d938c-c8cd-488c-8a92-6914b8f2ac55)

## Setting location:
![image](https://github.com/HasKha/GWToolboxpp/assets/78256408/c3ce0863-e5ac-49ef-ad54-0ddb4c177780)


## Functionality tested:
- [x] players not on friend list are unaffected
- [x] works in explorable and outpost
- [x] friends list entry with no alias is unaffected
- [x] trading / following works on renamed players (assuming other functionality is similarly unaffected too)
- [x] changing alias doesn't break anything for current map session