### PR TITLE
prevent rendering custom world items in outposts

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
@@ -219,8 +219,7 @@ void GameWorldRenderer::Render(IDirect3DDevice9* device)
         }
     }
 
-    if (GW::Map::GetInstanceType() == GW::Constants::InstanceType::Loading) {
-        // perhaps not actually needed, but it's here to be safe.
+    if (GW::Map::GetInstanceType() != GW::Constants::InstanceType::Explorable) {
         return;
     }
 


### PR DESCRIPTION
in DoA, outpost map ID matches explorable map ID, and the terrain is not the same.