### PR TITLE
chore: cleanup merchant window override

### DIFF
--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -753,11 +753,9 @@ namespace {
         if (merchant_list_tab == 0xb) {
             const auto item = reinterpret_cast<InventoryManager::Item*>(GW::Items::GetItemById(item_id));
 
-            if (item) {
-                if (item->IsHiddenFromMerchants()) {
-                    GW::Hook::LeaveHook();
-                    return;
-                }
+            if (item && item->IsHiddenFromMerchants()) {
+                GW::Hook::LeaveHook();
+                return;
             }
         }
         RetAddItemRowToWindow(ecx, edx, frame, item_id);

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -51,11 +51,6 @@ namespace {
         "Bag 2"
     };
 
-    bool hide_unsellable_items = false;
-    bool hide_weapon_sets_and_customized_items = false;
-    std::map<uint32_t, std::string> hide_from_merchant_items;
-
-
     bool GetIsProfessionUnlocked(GW::Constants::Profession prof)
     {
         const auto world = GW::GetWorldContext();
@@ -756,20 +751,10 @@ namespace {
     {
         GW::Hook::EnterHook();
         if (merchant_list_tab == 0xb) {
-            const auto item = GW::Items::GetItemById(item_id);
+            const auto item = reinterpret_cast<InventoryManager::Item*>(GW::Items::GetItemById(item_id));
 
             if (item) {
-                if (hide_unsellable_items && !item->value) {
-                    GW::Hook::LeaveHook();
-                    return;
-                }
-
-                if (hide_weapon_sets_and_customized_items && (item->customized || item->equipped)) {
-                    GW::Hook::LeaveHook();
-                    return;
-                }
-
-                if (hide_from_merchant_items.contains(item->model_id)) {
+                if (item->IsHiddenFromMerchants()) {
                     GW::Hook::LeaveHook();
                     return;
                 }
@@ -2385,6 +2370,20 @@ bool InventoryManager::Item::IsArmor()
         default:
             return false;
     }
+}
+
+bool InventoryManager::Item::IsHiddenFromMerchants()
+{
+    if (Instance().hide_unsellable_items && !InventoryManager::Item::value) {
+        return true;
+    }
+    if (Instance().hide_weapon_sets_and_customized_items && (InventoryManager::Item::customized || InventoryManager::Item::IsWeaponSetItem())) {
+        return true;
+    }
+    if (Instance().hide_from_merchant_items.contains(InventoryManager::Item::model_id)) {
+        return true;
+    }
+    return false;
 }
 
 GW::ItemModifier* InventoryManager::Item::GetModifier(const uint32_t identifier) const

--- a/GWToolboxdll/Modules/InventoryManager.h
+++ b/GWToolboxdll/Modules/InventoryManager.h
@@ -98,6 +98,9 @@ private:
     bool show_salvage_all_popup = true;
     bool salvage_listeners_attached = false;
     bool only_use_superior_salvage_kits = false;
+    bool hide_unsellable_items = false;
+    bool hide_weapon_sets_and_customized_items = false;
+    std::map<uint32_t, std::string> hide_from_merchant_items;
     bool salvage_rare_mats = false;
     bool show_transact_quantity_popup = false;
     bool transaction_listeners_attached = false;
@@ -154,6 +157,7 @@ public:
         bool IsWeapon();
         bool IsArmor();
         bool IsSalvagable();
+        bool IsHiddenFromMerchants();
 
         bool IsRareMaterial() const;
         bool IsWeaponSetItem();


### PR DESCRIPTION
With #948 in the pipeline, I felt like I was writing code twice just to make it work in & out of the `OnAddItemToWindow` call.

This should resolve that feeling by enabling use of InventoryManager's functions, and creates a new one: `IsHiddenFromMerchants`