### PR TITLE
Fix SymbolRenderer reinitialisation

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/SymbolsRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/SymbolsRenderer.cpp
@@ -113,6 +113,12 @@ void SymbolsRenderer::Initialize(IDirect3DDevice9* device)
     buffer->Unlock();
 }
 
+void SymbolsRenderer::Invalidate()
+{
+    VBuffer::Invalidate();
+    this->initialized = false;
+}
+
 void SymbolsRenderer::Render(IDirect3DDevice9* device)
 {
     Initialize(device);

--- a/GWToolboxdll/Widgets/Minimap/SymbolsRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/SymbolsRenderer.h
@@ -6,6 +6,7 @@ class SymbolsRenderer : public VBuffer {
 public:
     SymbolsRenderer() = default;
 
+    void Invalidate() override;
     void Render(IDirect3DDevice9* device) override;
 
     void DrawSettings();


### PR DESCRIPTION
#944 

VBuffer::Invalidate frees the dx buffer with an expectation that it will be reinitialized, but SymbolsRenderer did not reinitialise.  Now it will.