### PR TITLE
Fix EffectsMonitor crash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,9 @@ set(CMAKE_GENERATOR_PLATFORM win32)
 project(gwtoolbox)
 
 set(GWTOOLBOXEXE_VERSION "4.0")
-set(GWTOOLBOXDLL_VERSION "6.11")
+set(GWTOOLBOXDLL_VERSION "6.12")
 set(GWTOOLBOXDLL_VERSION_BETA "") # can be anything. Marks beta version if not empty.
-set(GWTOOLBOX_MODULE_VERSION "6,11,0,0") # used for Dll module info. See GWToolboxdll/GWToolbox.rc
+set(GWTOOLBOX_MODULE_VERSION "6,12,0,0") # used for Dll module info. See GWToolboxdll/GWToolbox.rc
 
 # this is no longer required, but in case we have to add an installer again some day
 # configure_file(${PROJECT_SOURCE_DIR}/gwtoolbox.wxs.in ${PROJECT_SOURCE_DIR}/gwtoolbox.wxs @ONLY)

--- a/GWToolboxdll/Modules/ObserverModule.h
+++ b/GWToolboxdll/Modules/ObserverModule.h
@@ -398,8 +398,8 @@ public:
     public:
         ObservableMap(const GW::AreaInfo& area_info);
 
-        uint32_t campaign;
-        uint32_t continent;
+        GW::Constants::Campaign campaign;
+        GW::Continent continent;
         GW::Region region;
         GW::RegionType type;
         uint32_t flags;

--- a/GWToolboxdll/Utils/ToolboxUtils.h
+++ b/GWToolboxdll/Utils/ToolboxUtils.h
@@ -32,6 +32,19 @@ namespace ToolboxUtils {
     bool IsOutpost();
     bool IsExplorable();
 
+    enum MissionState : uint8_t {
+        Primary = 0x1,
+        Expert = 0x2,
+        Master = 0x4
+    };
+
+    // Returns bitwise state of MissionState enum
+    uint8_t GetMissionState(GW::Constants::MapID map_id, const GW::Array<uint32_t>& missions_completed, const GW::Array<uint32_t>& missions_bonus);
+    // Returns bitwise state of MissionState enum
+    uint8_t GetMissionState(GW::Constants::MapID map_id, bool is_hard_mode = false);
+    // Returns bitwise state of MissionState enum
+    uint8_t GetMissionState();
+
     // Player
 
     // Return player name without guild tag or player number

--- a/GWToolboxdll/Widgets/EffectsMonitorWidget.cpp
+++ b/GWToolboxdll/Widgets/EffectsMonitorWidget.cpp
@@ -530,6 +530,7 @@ void EffectsMonitorWidget::Draw(IDirect3DDevice9*)
                     ImGui::PopFont();
                     ImGui::End();
                     ImGui::PopStyleVar(2);
+                    return;
                 }
             }
             else if (effect.skill_id == GW::Constants::SkillID::Hard_mode) {

--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -96,10 +96,11 @@ namespace {
 
     wchar_t last_player_name[20];
 
-    void GetOutpostIcons(GW::Constants::MapID map_id, WorldMapIcon icons_out[4], uint8_t mission_state) {
+    void GetOutpostIcons(GW::Constants::MapID map_id, WorldMapIcon icons_out[4], uint8_t mission_state, bool is_hard_mode = false) {
         icons_out = { 0 };
         const auto area_info = GW::Map::GetMapInfo(map_id);
         uint32_t icon_idx = 0;
+        (is_hard_mode); // TODO: Change these icons out for Hard Mode
         switch (area_info->continent) {
         case GW::Continent::Kryta: {
             switch (area_info->type) {
@@ -118,6 +119,45 @@ namespace {
                 break;
             case GW::RegionType::Challenge:
                 icons_out[0] = WorldMapIcon::Kryta_Outpost;
+                break;
+            }
+        } break;
+        case GW::Continent::Cantha: {
+            switch (area_info->type) {
+            case GW::RegionType::CooperativeMission:
+                icons_out[icon_idx++] = WorldMapIcon::Cantha_Mission;
+                if ((mission_state & ToolboxUtils::MissionState::Primary) != 0)
+                    icons_out[icon_idx++] = WorldMapIcon::Cantha_CompletePrimary;
+                if((mission_state & ToolboxUtils::MissionState::Expert) != 0)
+                    icons_out[icon_idx++] = WorldMapIcon::Cantha_CompleteExpert;
+                if((mission_state & ToolboxUtils::MissionState::Expert) != 0)
+                    icons_out[icon_idx++] = WorldMapIcon::Cantha_CompleteMaster;
+                break;
+            }
+        } break;
+        case GW::Continent::Elona: {
+            switch (area_info->type) {
+            case GW::RegionType::CooperativeMission:
+                icons_out[icon_idx++] = WorldMapIcon::Elona_Mission;
+                if ((mission_state & ToolboxUtils::MissionState::Primary) != 0)
+                    icons_out[icon_idx++] = WorldMapIcon::Elona_CompletePrimary;
+                if((mission_state & ToolboxUtils::MissionState::Expert) != 0)
+                    icons_out[icon_idx++] = WorldMapIcon::Elona_CompleteExpert;
+                if((mission_state & ToolboxUtils::MissionState::Expert) != 0)
+                    icons_out[icon_idx++] = WorldMapIcon::Elona_CompleteMaster;
+                break;
+            }
+        } break;
+        case GW::Continent::RealmOfTorment: {
+            switch (area_info->type) {
+            case GW::RegionType::CooperativeMission:
+                icons_out[icon_idx++] = WorldMapIcon::Elona_Mission;
+                if ((mission_state & ToolboxUtils::MissionState::Primary) != 0)
+                    icons_out[icon_idx++] = WorldMapIcon::Elona_CompletePrimary;
+                if((mission_state & ToolboxUtils::MissionState::Expert) != 0)
+                    icons_out[icon_idx++] = WorldMapIcon::Elona_CompleteExpert;
+                if((mission_state & ToolboxUtils::MissionState::Expert) != 0)
+                    icons_out[icon_idx++] = WorldMapIcon::Elona_CompleteMaster;
                 break;
             }
         } break;
@@ -727,7 +767,7 @@ void Mission::CheckProgress(const std::wstring& player_name)
 
     mission_state = ToolboxUtils::GetMissionState(outpost, complete_arr, bonus_arr);
 
-    GetOutpostIcons(outpost, outpost_icons, mission_state);
+    GetOutpostIcons(outpost, outpost_icons, mission_state, hard_mode);
 }
 
 IDirect3DTexture9* Mission::GetMissionImage()

--- a/GWToolboxdll/Windows/CompletionWindow.h
+++ b/GWToolboxdll/Windows/CompletionWindow.h
@@ -6,6 +6,10 @@
 #include <ToolboxWindow.h>
 #include <Color.h>
 
+namespace CompletionWindow_Constants {
+    enum class WorldMapIcon : uint32_t;
+}
+
 namespace Missions {
     struct MissionImage {
         const wchar_t* file_name;
@@ -39,6 +43,9 @@ namespace Missions {
         bool is_completed = false;
         bool bonus = false;
         bool map_unlocked = true;
+
+        uint8_t mission_state = 0;
+        CompletionWindow_Constants::WorldMapIcon outpost_icons[4] = { (CompletionWindow_Constants::WorldMapIcon)0 };
 
         virtual const char* Name();
         virtual bool Draw(IDirect3DDevice9*);

--- a/GWToolboxdll/Windows/CompletionWindow_Constants.h
+++ b/GWToolboxdll/Windows/CompletionWindow_Constants.h
@@ -10,6 +10,57 @@ namespace CompletionWindow_Constants {
     const char* hero_names[] = {"", "Norgu", "Goren", "Tahlkora", "Master of Whispers", "Acolyte Jin", "Koss", "Dunkoro", "Acolyte Sousuke", "Melonni", "Zhed Shadowhoof", "General Morgahn", "Margrid the Sly", "Zenmai", "Olias", "Razah", "M.O.X.",
                                 "Keiran Thackeray", "Jora", "Pyre Fierceshot", "Anton", "Livia", "Hayda", "Kahmu", "Gwen", "Xandra", "Vekk", "Ogden Stonehealer", "", "", "", "", "", "", "", "", "Miku", "Zei Ri"};
 
+
+    // GW loads these icons as an array of file hashes once, and then keeps it in memory - I can't find where these are in RDATA reliably, so have to define them here :(
+    enum class WorldMapIcon : uint32_t {
+        None = 0,
+        Kryta_Mission = 0x2ac223,
+        Kryta_CompletePrimary = 0x2ac27,
+        Kryta_CompleteSecondary = 0x2ac29,
+        Kryta_City = 0x2ac2f,
+        Kryta_Outpost = 0x2ac2d,
+        Kryta_Arena = 0x2ac2b,
+
+        Cantha_Mission = 0x2ac35,
+        Cantha_CompletePrimary = 0x2ac39,
+        Cantha_CompleteExpert = 0x2ac3b,
+        Cantha_CompleteMaster = 0x2ac3d,
+        Cantha_City = 0x2ac43,
+        Cantha_Outpost = 0x2ac41,
+        Cantha_ChallengeMission = 0x2ac33,
+        Cantha_LuxonsOwned = 0x2ac31, // NB: Kurshit owned is Luxon texture with blue overlay; proof that Luxons hold the true claim to Cantha!
+
+        Elona_Mission = 0x38048,
+        Elona_CompletePrimary = 0x3804c,
+        Elona_CompleteExpert = 0x3804e,
+        Elona_CompleteMaster = 0x38050,
+        Elona_City = 0x322ad,
+        Elona_Outpost = 0x322ab,
+        Elona_ChallengeMission = 0x38046,
+
+        RealmOfTorment_Outpost = 0x322af,
+        RealmOfTorment_City = 0x322b1,
+        RealmOfTorment_Mission = 0x38058,
+        RealmOfTorment_ChallengeMission = 0x38056,
+
+        RealmOfTorment_EliteArea = 0x43466,
+
+        EyeOfTheNorth_Dungeon = 0x50830,
+        EyeOfTheNorth_DungeonComplete = 0x50830, // TODO
+        EyeOfTheNorth_Mission = 0x50831,
+        EyeOfTheNorth_MissionComplete = 0x50831, // TODO
+        EyeOfTheNorth_HardMode_Dungeon = 0x50832,
+        EyeOfTheNorth_HardMode_DungeonComplete = 0x50832, // TODO
+        EyeOfTheNorth_HardMode_Mission = 0x50833,
+        EyeOfTheNorth_HardMode_MissionComplete = 0x50833, // TODO
+
+        HardMode = 0x45563,
+        HardMode_CompletePrimary = 0x45567,
+        HardMode_CompleteExpert = 0x45569,
+        HardMode_CompleteMaster = 0x4556b,
+        HardMode_CompleteAll = 0x4556d // Gold helm
+    };
+
     const wchar_t* encoded_festival_hat_names[] = {
         // Halloween
         L"\x8102\x5C2B\xB7F4\xC976\x5CE1", // Charr hat

--- a/GWToolboxdll/Windows/Hotkeys.cpp
+++ b/GWToolboxdll/Windows/Hotkeys.cpp
@@ -883,7 +883,7 @@ int HotkeyUseItem::Description(char* buf, const size_t bufsz)
 
 bool HotkeyUseItem::Draw()
 {
-    bool hotkey_changed = ImGui::InputInt("Item ID", (int*)&item_id);
+    bool hotkey_changed = ImGui::InputInt("Item Model ID", (int*)&item_id);
     hotkey_changed |= ImGui::InputText("Item Name", name, _countof(name));
     hotkey_changed |= ImGui::Checkbox("Display error message on failure", &show_error_on_failure);
     return hotkey_changed;

--- a/GWToolboxdll/Windows/InfoWindow.cpp
+++ b/GWToolboxdll/Windows/InfoWindow.cpp
@@ -610,6 +610,98 @@ namespace {
         }
         return false;
     }
+
+
+    typedef uint32_t*(__cdecl* CreateTexture_pt)(wchar_t* file_name, uint32_t flags);
+    CreateTexture_pt CreateTexture_Func = nullptr;
+    CreateTexture_pt CreateTexture_Ret = nullptr;
+    std::map<uint32_t,IDirect3DTexture9**> textures_created;
+
+    bool record_textures = false;
+
+    uint32_t FileHashToFileId(wchar_t* param_1) {
+        if (!param_1)
+            return 0;
+        if (((0xff < *param_1) && (0xff < param_1[1])) &&
+            ((param_1[2] == 0 || ((0xff < param_1[2] && (param_1[3] == 0)))))) {
+            return (*param_1 - 0xff00ff) + (uint32_t)param_1[1] * 0xff00;
+        }
+        return 0;
+    }
+
+    uint32_t* OnCreateTexture(wchar_t* file_name, uint32_t flags) {
+        GW::Hook::EnterHook();
+        const auto out = CreateTexture_Ret(file_name, flags);
+        uint32_t file_id = FileHashToFileId(file_name);
+        if (record_textures && textures_created.find(file_id) == textures_created.end()) {
+            textures_created[file_id] = GwDatTextureModule::LoadTextureFromFileId(file_id);
+        }
+        GW::Hook::LeaveHook();
+        return out;
+    }
+
+    void DrawDebugInfo() {
+        if (ImGui::CollapsingHeader("Quoted Item")) {
+            ImGui::Text("Most recently quoted item (buy or sell) from trader");
+            static GuiUtils::EncString quoted_name;
+            DrawItemInfo(GW::Items::GetItemById(quoted_item_id), &quoted_name);
+        }
+
+        record_textures = ImGui::CollapsingHeader("Loaded Textures");
+        if (record_textures) {
+
+            const ImVec2 scaled_size = { 64.f,64.f };
+            constexpr ImVec4 tint(1, 1, 1, 1);
+            const auto normal_bg = ImColor(IM_COL32(0, 0, 0, 0));
+            constexpr auto uv0 = ImVec2(0, 0);
+
+            if (ImGui::SmallButton("Reset")) {
+                textures_created.clear();
+            }
+
+            ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
+            ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
+            ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.f, 0.5f));
+
+            ImGui::StartSpacedElements(scaled_size.x);
+
+            for (auto& it : textures_created) {
+                ImGui::PushID(it.first);
+                const auto texture = it.second;
+                if (!texture || !*texture) {
+                    ImGui::PopID();
+                    continue;
+                }
+
+                const auto uv1 = ImGui::CalculateUvCrop(*texture, scaled_size);
+                ImGui::NextSpacedElement();
+                ImGui::ImageButton(*texture, scaled_size, uv0, uv1, -1, normal_bg, tint);
+                if (ImGui::IsItemHovered()) {
+                    ImGui::SetTooltip("File ID 0x%08x", it.first);
+                }
+                ImGui::PopID();
+            }
+
+            ImGui::PopStyleColor();
+            ImGui::PopStyleVar();
+            ImGui::PopStyleVar();
+        }
+
+
+        // For debugging changes to flags/arrays etc
+        [[maybe_unused]] const GW::GameContext* g = GW::GetGameContext();
+        [[maybe_unused]] const GW::GuildContext* gu = g->guild;
+        [[maybe_unused]] const GW::CharContext* c = g->character;
+        [[maybe_unused]] const GW::WorldContext* w = g->world;
+        [[maybe_unused]] const GW::PartyContext* p = g->party;
+        [[maybe_unused]] const GW::MapContext* m = g->map;
+        [[maybe_unused]] const GW::AccountContext* acc = g->account;
+        [[maybe_unused]] const GW::ItemContext* i = g->items;
+        [[maybe_unused]] const GW::AgentLiving* me = GW::Agents::GetPlayerAsAgentLiving();
+        [[maybe_unused]] const GW::Player* me_player = me ? GW::PlayerMgr::GetPlayerByID(me->player_number) : nullptr;
+        [[maybe_unused]] const GW::Chat::ChatBuffer* log = GW::Chat::GetChatLog();
+        [[maybe_unused]] const GW::AreaInfo* ai = GW::Map::GetMapInfo(GW::Map::GetMapID());
+    }
 }
 
 void InfoWindow::Terminate()
@@ -618,6 +710,11 @@ void InfoWindow::Terminate()
         delete achievement;
     }
     target_achievements.clear();
+
+    if (CreateTexture_Func) {
+        GW::HookBase::RemoveHook(CreateTexture_Func);
+        CreateTexture_Func = nullptr;
+    }
 }
 
 void InfoWindow::Initialize()
@@ -631,6 +728,16 @@ void InfoWindow::Initialize()
                                                                         });
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::InstanceLoadFile>(&InstanceLoadFile_Entry, OnInstanceLoad);
     GW::Chat::CreateCommand(L"resignlog", CmdResignLog);
+#ifdef _DEBUG
+    CreateTexture_Func = (CreateTexture_pt)GW::Scanner::FindAssertion("p:\\code\\engine\\gr\\grtex2d.cpp", "!(flags & GR_TEXTURE_TRANSFER_OWNERSHIP)", -0x32);
+#endif
+    if (CreateTexture_Func) {
+        GW::HookBase::CreateHook(CreateTexture_Func, OnCreateTexture, (void**)&CreateTexture_Ret);
+        GW::HookBase::EnableHooks(CreateTexture_Func);
+    }
+
+
+
 }
 
 void InfoWindow::Draw(IDirect3DDevice9*)
@@ -785,13 +892,6 @@ void InfoWindow::Draw(IDirect3DDevice9*)
             static GuiUtils::EncString item_name;
             DrawItemInfo(GW::Items::GetItemBySlot(GW::Constants::Bag::Backpack, 1), &item_name);
         }
-#ifdef _DEBUG
-        if (show_item && ImGui::CollapsingHeader("Quoted Item")) {
-            ImGui::Text("Most recently quoted item (buy or sell) from trader");
-            static GuiUtils::EncString quoted_name;
-            DrawItemInfo(GW::Items::GetItemById(quoted_item_id), &quoted_name);
-        }
-#endif
         if (show_quest && ImGui::CollapsingHeader("Quest")) {
             const GW::Quest* q = GW::QuestMgr::GetActiveQuest();
             if (q) {
@@ -872,22 +972,11 @@ void InfoWindow::Draw(IDirect3DDevice9*)
             DrawResignlog();
         }
     }
-    ImGui::End();
 #ifdef _DEBUG
-    // For debugging changes to flags/arrays etc
-    [[maybe_unused]] const GW::GameContext* g = GW::GetGameContext();
-    [[maybe_unused]] const GW::GuildContext* gu = g->guild;
-    [[maybe_unused]] const GW::CharContext* c = g->character;
-    [[maybe_unused]] const GW::WorldContext* w = g->world;
-    [[maybe_unused]] const GW::PartyContext* p = g->party;
-    [[maybe_unused]] const GW::MapContext* m = g->map;
-    [[maybe_unused]] const GW::AccountContext* acc = g->account;
-    [[maybe_unused]] const GW::ItemContext* i = g->items;
-    [[maybe_unused]] const GW::AgentLiving* me = GW::Agents::GetPlayerAsAgentLiving();
-    [[maybe_unused]] const GW::Player* me_player = me ? GW::PlayerMgr::GetPlayerByID(me->player_number) : nullptr;
-    [[maybe_unused]] const GW::Chat::ChatBuffer* log = GW::Chat::GetChatLog();
-    [[maybe_unused]] const GW::AreaInfo* ai = GW::Map::GetMapInfo(GW::Map::GetMapID());
+    DrawDebugInfo();
 #endif
+    ImGui::End();
+
 }
 
 void InfoWindow::Update(const float)

--- a/GWToolboxdll/Windows/InfoWindow.cpp
+++ b/GWToolboxdll/Windows/InfoWindow.cpp
@@ -48,6 +48,9 @@
 #include <GWCA/Managers/QuestMgr.h>
 #include <Modules/HallOfMonumentsModule.h>
 #include <Modules/Resources.h>
+#include <GWCA/Utilities/Hooker.h>
+#include <Modules/GwDatTextureModule.h>
+#include <Utils/ToolboxUtils.h>
 
 namespace {
     enum class Status {
@@ -748,6 +751,7 @@ void InfoWindow::Draw(IDirect3DDevice9*)
     ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowSize(ImVec2(300, 0), ImGuiCond_FirstUseEver);
     if (ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
+
         if (show_widgets) {
             const auto& widgets = GWToolbox::GetWidgets();
 
@@ -822,6 +826,7 @@ void InfoWindow::Draw(IDirect3DDevice9*)
                     InfoField("Continent", "%d", map_info->continent);
                     InfoField("Region", "%d", map_info->region);
                     InfoField("Type", "%d", map_info->type);
+                    InfoField("Mission Complete?", "%d", ToolboxUtils::GetMissionState(GW::Map::GetMapID(), GW::PartyMgr::GetIsPartyInHardMode()));
                     InfoField("Instance Info Type", "%d", GW::Map::GetMapTypeInstanceInfo(map_info->type)->request_instance_map_type);
                     InfoField("Flags", "0x%X", map_info->flags);
                     InfoField("Thumbnail ID", "%d", map_info->thumbnail_id);

--- a/docs/history.md
+++ b/docs/history.md
@@ -7,6 +7,10 @@ layout: default
 Previous releases are available on Github as dll files. There is no support for older releases. If you are looking for
 the latest version, go to the [Home Page](./) instead.
 
+## Version 6.12
+* [Fix] You can search in the TravelWindow again
+* [Minor] Added Festive Winter Hood to ArmoryWindow
+
 ## Version 6.11
 
 * [New] Added item upgrade unlocks to completion window


### PR DESCRIPTION
When cached_effects was invalidated, and two effects expired simultaneously in the same frame, ImGui::PopFont was called twice, leading to a fatal assertion.  Based on the comment, it looks like it's just a missing return statement needed.