### PR TITLE
Fix ImGui crash

### DIFF
--- a/GWToolboxdll/Widgets/EffectsMonitorWidget.cpp
+++ b/GWToolboxdll/Widgets/EffectsMonitorWidget.cpp
@@ -530,6 +530,7 @@ void EffectsMonitorWidget::Draw(IDirect3DDevice9*)
                     ImGui::PopFont();
                     ImGui::End();
                     ImGui::PopStyleVar(2);
+                    return;
                 }
             }
             else if (effect.skill_id == GW::Constants::SkillID::Hard_mode) {


### PR DESCRIPTION
When cached_effects was invalidated, and two effects expired simultaneously in the same frame, ImGui::PopFont was called twice, leading to a fatal assertion. Based on the comment, it looks like it's just a missing return statement needed.