### PR TITLE
Alert Chat+Warning if Init on a PvP Map

### DIFF
--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -938,6 +938,17 @@ void GWToolbox::Update(GW::HookStatus*)
         if (c && c->player_name) {
             Log::Flash("Hello!");
             greeted = true;
+            
+            // we wants here to alert the player if he inits GWToolbox++ in a PvP area that it's disabled 
+            // check here if the player is in a PvP area
+            if (ShouldDisableToolbox()) {
+                GW::Chat::WriteChat(
+                    GW::Chat::Channel::CHANNEL_GWCA2,
+                    L"<c=#FF0000>GWToolbox++ is disabled in PvP areas. (It includes Guild Halls)</c>", GWTOOLBOX_SENDER, true);
+                GW::Chat::WriteChat(
+                    GW::Chat::Channel::CHANNEL_WARNING,
+                    L"Toolbox is disabled in PvP areas.", nullptr, true);
+            }
         }
     }
 


### PR DESCRIPTION
Aims to display a chat message and an on-screen warning when initializing the Toolbox in a **PvP map**.
**This only occurs during the Toolbox initialization.**

Responds to feedback from players who weren’t aware of this behavior.





![{2F33B719-EEC9-493B-B0E8-56A9C8980C16}](https://github.com/user-attachments/assets/5baed5f8-8b19-4777-b41b-0225b976e303)
