### PR TITLE
Resources export(GetMapName & DecodeStringId)

### DIFF
--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -207,6 +207,16 @@ extern "C" __declspec(dllexport) IDirect3DTexture9** __cdecl GetSkillImage(GW::C
     return Resources::GetSkillImage(skill_id);
 }
 
+extern "C" __declspec(dllexport) const char* __cdecl GetMapNameString(GW::Constants::MapID map_id)
+{
+    return Resources::GetMapName(map_id)->string().c_str();
+}
+
+extern "C" __declspec(dllexport) const char* __cdecl DecodeStringIdToString(uint32_t enc_str_id)
+{
+    return Resources::DecodeStringId(enc_str_id)->string().c_str();
+}
+
 Resources::Resources()
 {
     InitCurl();


### PR DESCRIPTION
Hey, 
I'm asking to export 2 more functions, mainly to being able to decode Map Name on the game.

This is related to https://github.com/gwdevhub/GWToolboxpp/pull/1407
