### PR TITLE
Fix ambiguous auto declarations to allow build completion

### DIFF
--- a/GWToolboxdll/Modules/ChatSettings.cpp
+++ b/GWToolboxdll/Modules/ChatSettings.cpp
@@ -415,7 +415,7 @@ void ChatSettings::Initialize()
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::SpeechBubble>(&SpeechBubble_Entry, OnSpeechBubble);
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::DisplayDialogue>(&DisplayDialogue_Entry, OnSpeechDialogue);
 
-    constexpr auto ui_messages = {
+    constexpr GW::UI::UIMessage ui_messages[] = {
         GW::UI::UIMessage::kAgentSpeechBubble,
         GW::UI::UIMessage::kPreferenceFlagChanged,
         GW::UI::UIMessage::kPlayerChatMessage,

--- a/GWToolboxdll/Modules/QuestModule.cpp
+++ b/GWToolboxdll/Modules/QuestModule.cpp
@@ -632,7 +632,7 @@ void QuestModule::Initialize()
         bypass_custom_quest_assertion_patch.TogglePatch(true);
     }
 
-    constexpr auto ui_messages = {
+    constexpr GW::UI::UIMessage ui_messages[] = {
         GW::UI::UIMessage::kQuestDetailsChanged,
         GW::UI::UIMessage::kQuestAdded,
         GW::UI::UIMessage::kClientActiveQuestChanged,

--- a/GWToolboxdll/Utils/TextUtils.cpp
+++ b/GWToolboxdll/Utils/TextUtils.cpp
@@ -225,7 +225,7 @@ namespace TextUtils {
             return {};
         }
         // NB: GW uses code page 0 (CP_ACP)
-        constexpr auto try_code_pages = {CP_UTF8, CP_ACP};
+        constexpr UINT try_code_pages[] = {CP_UTF8, CP_ACP};
         for (const auto code_page : try_code_pages) {
             const auto size_needed = MultiByteToWideChar(code_page, MB_ERR_INVALID_CHARS, str.data(), static_cast<int>(str.size()), nullptr, 0);
             if (!size_needed)
@@ -246,7 +246,7 @@ namespace TextUtils {
             return "";
         }
         // NB: GW uses code page 0 (CP_ACP)
-        constexpr auto try_code_pages = {CP_UTF8, CP_ACP};
+        constexpr UINT try_code_pages[] = {CP_UTF8, CP_ACP};
         for (const auto code_page : try_code_pages) {
             const auto size_needed = WideCharToMultiByte(code_page, WC_ERR_INVALID_CHARS, str.data(), static_cast<int>(str.size()), nullptr, 0, nullptr, nullptr);
             if (!size_needed)

--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -1587,7 +1587,7 @@ void CompletionWindow::Initialize()
     skills.push_back(new PvESkill(SkillID::Vow_of_Revolution));
     skills.push_back(new PvESkill(SkillID::Heroic_Refrain));
 
-    constexpr auto message_ids = {
+    constexpr GW::UI::UIMessage message_ids[] = {
         GW::UI::UIMessage::kMapLoaded,
         GW::UI::UIMessage::kSendDialog,
         GW::UI::UIMessage::kDialogButton,


### PR DESCRIPTION
This pull request replaces several ambiguous auto declarations with explicit types to resolve build errors. Specifically:

    Replaced auto with GW::UI::UIMessage[] for ui_messages

    Replaced auto with UINT[] for try_code_pages

    Replaced auto with uint32_t[] for message_ids
    
The project failed to build in my environment (MSVC) due to these auto usages being too ambiguous for the compiler to deduce the correct type. These changes allow the build to complete successfully.

    No functional changes were made

    Changes are limited to type clarifications

    Let me know if there’s an alternative or further conventions I should follow