### PR TITLE
Add quest line color setting

### DIFF
--- a/GWToolboxdll/Modules/QuestModule.cpp
+++ b/GWToolboxdll/Modules/QuestModule.cpp
@@ -151,7 +151,7 @@ namespace {
                 l->draw_on_minimap = draw_quest_path_on_minimap;
                 l->draw_on_mission_map = draw_quest_path_on_mission_map;
                 l->created_by_toolbox = true;
-                l->color = QuestModule::GetQuestColor(quest_id);
+                l->color = QuestModule::GetQuestLineColor(quest_id);
                 minimap_lines.push_back(l);
             }
             GameWorldRenderer::TriggerSyncAllMarkers();
@@ -563,6 +563,14 @@ ImU32& QuestModule::GetQuestColor(GW::Constants::QuestID quest_id)
 {
     if (GW::QuestMgr::GetActiveQuestId() == quest_id) {
         return Minimap::Instance().symbols_renderer.color_quest;
+    }
+    return Minimap::Instance().symbols_renderer.color_other_quests;
+}
+
+ImU32& QuestModule::GetQuestLineColor(GW::Constants::QuestID quest_id)
+{
+    if (GW::QuestMgr::GetActiveQuestId() == quest_id) {
+        return Minimap::Instance().symbols_renderer.color_quest_line;
     }
     return Minimap::Instance().symbols_renderer.color_other_quests;
 }

--- a/GWToolboxdll/Modules/QuestModule.h
+++ b/GWToolboxdll/Modules/QuestModule.h
@@ -70,5 +70,6 @@ public:
     static void EmulateQuestSelected(GW::Constants::QuestID);
 
     static ImU32& GetQuestColor(GW::Constants::QuestID);
+    static ImU32& GetQuestLineColor(GW::Constants::QuestID);
     static std::vector<QuestObjective> ParseQuestObjectives(GW::Constants::QuestID quest_id);
 };

--- a/GWToolboxdll/Widgets/Minimap/SymbolsRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/SymbolsRenderer.cpp
@@ -40,6 +40,7 @@ namespace {
 void SymbolsRenderer::LoadSettings(const ToolboxIni* ini, const char* section)
 {
     color_quest = Colors::Load(ini, section, "color_quest", 0xFF22EF22);
+    color_quest_line = Colors::Load(ini, section, "color_quest_line", 0xFF22EF22);
     color_other_quests = Colors::Load(ini, section, "color_other_quests", 0x00006400);
     color_north = Colors::Load(ini, section, "color_north", 0xFFFF8000);
     color_modifier = Colors::Load(ini, section, "color_symbols_modifier", 0x001E1E1E);
@@ -50,6 +51,7 @@ void SymbolsRenderer::LoadSettings(const ToolboxIni* ini, const char* section)
 void SymbolsRenderer::SaveSettings(ToolboxIni* ini, const char* section) const
 {
     Colors::Save(ini, section, "color_quest", color_quest);
+    Colors::Save(ini, section, "color_quest_line", color_quest_line);
     Colors::Save(ini, section, "color_other_quests", color_other_quests);
     Colors::Save(ini, section, "color_north", color_north);
     Colors::Save(ini, section, "color_symbols_modifier", color_modifier);
@@ -60,6 +62,7 @@ void SymbolsRenderer::DrawSettings()
     ImGui::SmallConfirmButton("Restore Defaults", "Are you sure?", [&](const bool result, void*) {
         if (result) {
             color_quest = 0xFF22EF22;
+            color_quest_line = 0xFF22EF22;
             color_other_quests = 0x00006400;
             color_north = 0xFFFF8000;
             color_modifier = 0x001E1E1E;
@@ -67,6 +70,9 @@ void SymbolsRenderer::DrawSettings()
         }
     });
     if (Colors::DrawSettingHueWheel("Active quest marker", &color_quest)) {
+        Invalidate();
+    }
+    if (Colors::DrawSettingHueWheel("Quest line color", &color_quest_line)) {
         Invalidate();
     }
     if (Colors::DrawSettingHueWheel("Other quest markers", &color_other_quests)) {

--- a/GWToolboxdll/Widgets/Minimap/SymbolsRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/SymbolsRenderer.h
@@ -17,6 +17,7 @@ public:
 private:
     void Initialize(IDirect3DDevice9* device) override;
     Color color_quest = 0;
+    Color color_quest_line = 0;
     Color color_other_quests = 0;
     Color color_north = 0;
     Color color_modifier = 0;


### PR DESCRIPTION
Create a new setting to change only the quest line color, so it is not managed by the same setting as the quest marker color. This allows user to keep the native quest marker while still using the quest line module from toolbox.

<img width="2808" height="1462" alt="pic" src="https://github.com/user-attachments/assets/db394ec0-d90f-42ad-bdbe-736263e641c3" />
