### PR TITLE
Improve /armory functionality

### DIFF
--- a/GWToolboxdll/Windows/ArmoryWindow.cpp
+++ b/GWToolboxdll/Windows/ArmoryWindow.cpp
@@ -484,9 +484,24 @@ namespace GWArmory {
         const auto lower_name = TextUtils::ToLower(item_name.data());
         for (size_t i = 0; i < armor_cnt && armors; i++) {
             const auto& armor = armors[i];
-            if (TextUtils::ToLower(armor.label).starts_with(lower_name)) return &armor;
+            if (TextUtils::ToLower(armor.label) == lower_name) return &armor;
         }
-        // TODO: Costumes
+        for (size_t i = 0; i < _countof(costumes); i++) {
+            const auto& armor = costumes[i];
+            if (TextUtils::ToLower(armor.label) == lower_name) return &armor;
+        }
+        for (size_t i = 0; i < _countof(costume_heads); i++) {
+            const auto& armor = costume_heads[i];
+            if (TextUtils::ToLower(armor.label) == lower_name) return &armor;
+        }
+        for (size_t i = 0; i < _countof(weapons); i++) {
+            const auto& weapon = weapons[i];
+            if (TextUtils::ToLower(weapon.label) == lower_name) return &weapon;
+        }
+        for (size_t i = 0; i < _countof(unequipped_armors); i++) {
+            const auto& armor = unequipped_armors[i];
+            if (TextUtils::ToLower(armor.label) == lower_name) return &armor;
+        }
         return nullptr;
     }
 
@@ -713,6 +728,18 @@ namespace GWArmory {
         return true;
     }
 
+    const std::map<ItemSlot, std::string_view> empty_slot_names = std::map<ItemSlot, std::string_view> {
+        { ItemSlot::Headpiece, "NoHead" },
+        { ItemSlot::Chestpiece, "NoChest" },
+        { ItemSlot::Gloves, "NoGloves" },
+        { ItemSlot::Leggings, "NoLegs" },
+        { ItemSlot::Boots, "NoBoots" },
+        { ItemSlot::CostumeHead, "NoCostumeHead" },
+        { ItemSlot::CostumeBody, "NoCostume" },
+        { ItemSlot::LeftHand, "NoLeftHand" },
+        { ItemSlot::RightHand, "NoRightHand" }
+    };
+
     bool DrawArmorPieceNew(ItemSlot slot) {
         ImGui::PushID(slot);
         const auto state = &combo_list_states[slot];
@@ -759,9 +786,14 @@ namespace GWArmory {
             player_piece->model_file_id = 0;
             value_changed = true;
         }
-        ImGui::PopID();
-        
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip([slot]() {
+                ImGui::TextUnformatted("Empty Slot");
+                ImGui::TextDisabled("/armory %s", empty_slot_names.at(slot).data());
+            });
+        }
 
+        ImGui::PopID();
         
         constexpr ImVec4 tint(1, 1, 1, 1);
         constexpr auto uv0 = ImVec2(0, 0);
@@ -1088,7 +1120,7 @@ namespace GWArmory {
             if (slot == ItemSlot::CostumeHead && GetFileIdForFestivalHat(drawn_pieces[slot].model_file_id, current_profession)) {
                 ClearArmorItem(ItemSlot::Headpiece);
             }
-            if (slot == ItemSlot::CostumeBody) {
+            if (slot == ItemSlot::CostumeBody || slot == ItemSlot::Chestpiece || slot == ItemSlot::Gloves || slot == ItemSlot::Leggings || slot == ItemSlot::Boots) {
                 RevertCostumePieces();
             }
             ClearArmorItem(slot);

--- a/GWToolboxdll/Windows/ArmoryWindow_Constants.h
+++ b/GWToolboxdll/Windows/ArmoryWindow_Constants.h
@@ -70,6 +70,19 @@ namespace GWArmory {
         Armor* current_piece = nullptr;
     };
 
+    Armor unequipped_armors[] = {
+        // Empty slots
+        { "NoHead", 0, Profession::None, ItemType::Headpiece, Campaign::Core, 0 },
+        { "NoChest", 0, Profession::None, ItemType::Chestpiece, Campaign::Core, 0 },
+        { "NoGloves", 0, Profession::None, ItemType::Gloves, Campaign::Core, 0 },
+        { "NoLegs", 0, Profession::None, ItemType::Leggings, Campaign::Core, 0 },
+        { "NoBoots", 0, Profession::None, ItemType::Boots, Campaign::Core, 0 },
+        { "NoCostumeHead", 0, Profession::None, ItemType::Costume_Headpiece, Campaign::Core, 0 },
+        { "NoCostume", 0, Profession::None, ItemType::Costume, Campaign::Core, 0 },
+        { "NoLeftHand", 0, Profession::None, ItemType::Offhand, Campaign::Core, 0 },
+        { "NoRightHand", 0, Profession::None, ItemType::Axe, Campaign::Core, 0 },
+    };
+
     Armor warrior_armors[] = {
         // Core
         {"Obsidian Helm", 0x20D, Profession::Warrior, ItemType::Headpiece, Campaign::Core, 3},
@@ -1606,7 +1619,6 @@ namespace GWArmory {
         {"Wintergreen Scythe", 0x40E5D, Profession::None, ItemType::Scythe, Campaign::BonusMissionPack, 0, 0x2A331601},
 
         // Shields
-        {"Aegis of Terror", 0x3870B, Profession::None, ItemType::Shield, Campaign::BonusMissionPack, 3, 0x2000C611},
         {"Amber Aegis", 0x2AFC6, Profession::None, ItemType::Shield, Campaign::BonusMissionPack, 3, 0x20020041},
         {"Amethyst Aegis", 0x49B23, Profession::None, ItemType::Shield, Campaign::BonusMissionPack, 3, 0x2C120441},
         {"Aureate Aegis", 0x386F2, Profession::None, ItemType::Shield, Campaign::BonusMissionPack, 3, 0x20000000},


### PR DESCRIPTION
Adds costumes, weapons and unequipping to /armory.  As a consequence, the search is now stricter and must match the name exactly rather than just the beginning of it.

Unequips costumes when you (un)equip any conflicting armor piece

Removes Aegis of Terror from shield list as it is a duplicate skin

Closes #1508 and #1548