### PR TITLE
Add rudimentary autosplitter support

### DIFF
--- a/GWToolboxdll/CMakeLists.txt
+++ b/GWToolboxdll/CMakeLists.txt
@@ -61,6 +61,8 @@ include(imgui_fonts)
 
 find_package(minhook CONFIG REQUIRED)
 
+find_package(unofficial-uwebsockets CONFIG REQUIRED)
+
 target_link_libraries(GWToolboxdll PRIVATE
     # cmake targets:
     RestClient
@@ -79,6 +81,7 @@ target_link_libraries(GWToolboxdll PRIVATE
     wolfssl::wolfssl
 	minhook::minhook
 	ctre::ctre
+    unofficial::uwebsockets::uwebsockets
 
     # libs:
     Dbghelp.lib # for MiniDump

--- a/GWToolboxdll/Windows/ObjectiveTimerWindow.h
+++ b/GWToolboxdll/Windows/ObjectiveTimerWindow.h
@@ -5,7 +5,10 @@
 #include <GWCA/Packets/StoC.h>
 
 #include <ToolboxWindow.h>
+#include <thread>
 #include <vector>
+
+#include <uWebsockets/App.h>
 
 /*
 each objective can have a duration (start and end) or a single timestamp
@@ -44,6 +47,8 @@ public:
 
 private:
     std::thread run_loader;
+    std::thread websocket_server;
+    uWS::App* websocket_app = nullptr;
     bool loading = false;
 
     bool map_load_pending = false;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -13,6 +13,7 @@
     "minhook",
     "nlohmann-json",
     "simpleini",
+    "uwebsockets",
     "wolfssl"
   ],
   "overrides": [


### PR DESCRIPTION
The ObjectiveTimerWindow now also creates a websocket server that informs all clients if a run starts, ends or if an objective is completed.

This is simply a suggestion for #887 and implements integration into LiveSplit One and any autosplitter that can use or forward the websocket commands. This unfortunately requires a new dependency on a websocket implementation. An alternative would be to write these events to a file, but that adds delay and would require additional work from the user to parse these events for LiveSplit.

If we can't bind a socket on that port the uwebsocket implementation already does "nothing" and we can skip any error handling for the simplest of cases. Let me know if an implementation like this would be acceptable and I can add extra config and maybe a button to restart the webserver. The server listens on 0.0.0.0 by default, which could be useful for remote LiveSplit deployments in the same network, but I'm not opposed to hardcode this to localhost.