### PR TITLE
fix: remember the user is in presearing between loading maps

### DIFF
--- a/GWToolboxdll/Windows/TravelWindow.cpp
+++ b/GWToolboxdll/Windows/TravelWindow.cpp
@@ -116,7 +116,13 @@ namespace {
         return TravelWindow::Instance();
     }
 
-    bool ImInPresearing() { return GW::Map::GetIsMapLoaded() && GW::Map::GetCurrentMapInfo()->region == GW::Region_Presearing; }
+    bool ImInPresearing() {
+        static bool isInPresearing = false;
+        if (GW::Map::GetIsMapLoaded()) {
+            isInPresearing = GW::Map::GetCurrentMapInfo()->region == GW::Region::Region_Presearing;
+        }
+        return isInPresearing;
+    }
 
     bool IsInGH()
     {


### PR DESCRIPTION
Before, the travel window would flicker during map loading screens due to 'GetIsMapLoaded` being false, showing the travel window for post. This is only an issue if you have gwtoolbox showing during loading screens.
https://github.com/user-attachments/assets/aaa74668-dff8-412f-b304-057740def5c1

With this change, we "cache" the last map that was loaded and checked, and use that value if the map is loading. This prevents the flicker.
https://github.com/user-attachments/assets/688d69c1-57ca-4be8-803d-1222c8c9d80e

