### PR TITLE
Fixes gold value multiplying by itself in the drop tracker gold total

### DIFF
--- a/GWToolboxdll/Modules/ItemDrops.cpp
+++ b/GWToolboxdll/Modules/ItemDrops.cpp
@@ -653,7 +653,11 @@ int ItemDrops::GetTotalGoldValue()
 {
     int value = 0;
     for (auto drop : drop_history) {
-        value += drop->value * drop->quantity;  
+        if (drop->type == GW::Constants::ItemType::Gold_Coin) {
+            value += drop->value;
+        }else {
+            value += drop->value * drop->quantity;  
+        }
     }
     return value;
 }


### PR DESCRIPTION
Previously if you had a 100g drop it'd show up in the total as 100x100 instead of just the +100 as expected