### PR TITLE
Fix unconditional hiding of plugins in MainWindow

### DIFF
--- a/GWToolboxdll/Windows/MainWindow.cpp
+++ b/GWToolboxdll/Windows/MainWindow.cpp
@@ -104,11 +104,11 @@ void MainWindow::Draw(IDirect3DDevice9*)
                         }
                         module->visible = false;
                     }
-                }
-                for (const auto plugin : PluginModule::GetPlugins() | std::views::filter([](ToolboxPlugin* p) {
-                    return p && p->GetVisiblePtr() && p->ShowInMainMenu();
-                })) {
-                    *plugin->GetVisiblePtr() = false;
+                    for (const auto plugin : PluginModule::GetPlugins() | std::views::filter([](ToolboxPlugin* p) {
+                        return p && p->GetVisiblePtr() && p->ShowInMainMenu();
+                    })) {
+                        *plugin->GetVisiblePtr() = false;
+                    }
                 }
             }
             ImGui::PopID();


### PR DESCRIPTION
Currently, when any module button is clicked in the Main Window, all plugins that are set to "Show in main window" are unconditionally hidden. This occurs even when the "Close other windows when opening a new one" setting is disabled. This is inconsistent with how other modules behave and leads to unexpected UI behavior for plugins like `EnemyWindowPlus`.

Solution
This PR moves the plugin hiding logic inside the conditional block that checks for `one_panel_at_time_only`. This ensures that plugins are only hidden when the user has explicitly opted for single-panel visibility.