### PR TITLE
Adds support for self-hosted Kokoro TTS

### DIFF
--- a/GWToolboxdll/Modules/TextToSpeechModule.cpp
+++ b/GWToolboxdll/Modules/TextToSpeechModule.cpp
@@ -119,6 +119,7 @@ namespace {
     std::string GenerateVoiceGoogle(PendingNPCAudio*);
     std::string GenerateVoicePlayHT(PendingNPCAudio* );
     std::string GenerateVoiceGWDevHub(PendingNPCAudio*);
+    std::string GenerateVoiceKokoro(PendingNPCAudio*);
 
     // Static API configurations
     APIConfig api_configs[] = {
@@ -127,6 +128,7 @@ namespace {
         {GenerateVoiceOpenAI ,"OpenAI", "https://platform.openai.com/api-keys"},
         {GenerateVoiceGoogle ,"Google Cloud", "https://console.cloud.google.com/apis/credentials", "Note: Make sure to enable the Text-to-Speech API in your Google Cloud project"},
         {GenerateVoicePlayHT ,"Play.ht", "https://elevenlabs.io/app/settings/api-keys", "Note: Play.ht requires both an API Key and User ID", true},
+        {GenerateVoiceKokoro, "Kokoro (Self-Hosted)", "https://github.com/remsky/Kokoro-FastAPI", "Enter your Kokoro-FastAPI server URL in the API Key field (default: http://localhost:8880)"},
     };
 
     // TTS Provider settings
@@ -1238,6 +1240,54 @@ namespace {
 
         if (!audio_data.empty()) {
             VoiceLog("GWDevHub voice generation successful, received %zu bytes", audio_data.size());
+        }
+        return audio_data;
+    }
+
+    std::string GenerateVoiceKokoro(PendingNPCAudio* audio)
+    {
+        if (!(audio && audio->profile)) {
+            return VoiceLog("No Audio Profile"), "";
+        }
+        const auto api_config = GetCurrentAPIConfig();
+        if (!api_config) {
+            return VoiceLog("No API config"), "";
+        }
+
+        // Uses the api_key field for the URL since none of the others have a customizable url
+        std::string base_url = *api_config->api_key ? api_config->api_key : "http://localhost:8880";
+
+        if (!base_url.empty() && base_url.back() == '/') {
+            base_url.pop_back();
+        }
+
+        nlohmann::json request_body;
+        request_body["model"] = "kokoro";
+        request_body["input"] = TextUtils::WStringToString(audio->decoded_message);
+        
+        std::string voice_name = (audio->gender == Gender::Female) ? "af_bella" : "am_adam";
+        request_body["voice"] = voice_name;
+        request_body["response_format"] = "mp3";
+        request_body["speed"] = audio->profile->speaking_rate;
+
+        // Kokoro uses single-letter language codes:
+        // a=American English, b=British English, e=Spanish, f=French, i=Italian, j=Japanese, z=Mandarin Chinese
+        std::string lang_code;
+        switch (audio->language) {
+            case GW::Constants::Language::English:            lang_code = "a"; break;
+            case GW::Constants::Language::Spanish:            lang_code = "e"; break;
+            case GW::Constants::Language::French:             lang_code = "f"; break;
+            case GW::Constants::Language::Italian:            lang_code = "i"; break;
+            case GW::Constants::Language::Japanese:           lang_code = "j"; break;
+            case GW::Constants::Language::TraditionalChinese: lang_code = "z"; break;
+            default:                                          lang_code = "a"; break;
+        }
+        request_body["lang_code"] = lang_code;
+
+        RestClient client;
+        const auto audio_data = PostJson(client, base_url + "/v1/audio/speech", request_body, api_config->name);
+        if (!audio_data.empty()) {
+            VoiceLog("Kokoro voice generation successful, received %zu bytes", audio_data.size());
         }
         return audio_data;
     }


### PR DESCRIPTION
Kokoro Docs - https://github.com/remsky/Kokoro-FastAPI
Nvidia Container toolkit (needed if you run in compose/docker) -  https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
Example voices - https://github.com/remsky/Kokoro-FastAPI/tree/master/examples/voice_samples

Steps for setup:
1. Install nvidia container toolkit
2. Follow Kokoro compose instructions(or others, how you run this doesn't matter)
    a. git clone https://github.com/remsky/Kokoro-FastAPI.git
    b. cd docker/gpu or cd docker/cpu
    c. docker compose up --build (This step takes a while as it also has to download the model - if this fails update the permissions of the directory so docker can access it)
3. Add the URL / ip with port to toolbox after switching to kokoro (goes in the 'api key' field)

Voices can be swapped to other examples, I just picked 2 randomly - I did not test the others. The voice quality is much better than the previous test I had ran(Qwen) as well as the speed of generation (pretty much instant). I think this would likely work well to generate all voices in the back-end when credits aren't available (assuming someone has a spare gpu / system to run it) as well given how well it seems to be running.