### PR TITLE
Feature(#1684): Add a widget to display number of exploitable corpses around player

### DIFF
--- a/Dependencies/GWCA/include/GWCA/GameEntities/Agent.h
+++ b/Dependencies/GWCA/include/GWCA/GameEntities/Agent.h
@@ -291,6 +291,7 @@ namespace GW {
         // Health Bar Effect Bitmasks.
         inline bool GetIsBleeding()        const { return (effects & 0x0001) != 0; }
         inline bool GetIsConditioned()     const { return (effects & 0x0002) != 0; }
+        inline bool GetIsUsedCorpse()      const { return (effects & 0x0004) != 0; }
         inline bool GetIsCrippled()        const { return (effects & 0x000A) == 0xA; }
         inline bool GetIsDead()            const { return (effects & 0x0010) != 0; }
         inline bool GetIsDeepWounded()     const { return (effects & 0x0020) != 0; }

--- a/Dependencies/GWCA/include/GWCA/GameEntities/NPC.h
+++ b/Dependencies/GWCA/include/GWCA/GameEntities/NPC.h
@@ -36,6 +36,7 @@ namespace GW {
         inline bool IsSpirit() { return (npc_flags & 0x4000) != 0; }
         inline bool IsMinion() { return (npc_flags & 0x100) != 0; }
         inline bool IsPet() { return (npc_flags & 0xD) != 0; }
+        inline bool IsFleshy() const { return (npc_flags & 0x8) != 0; }
     };
     static_assert(sizeof(NPC) == 0x30, "struct NPC has incorrect size");
 

--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -83,6 +83,7 @@
 #include <Widgets/BondsWidget.h>
 #include <Widgets/ClockWidget.h>
 #include <Widgets/VanquishWidget.h>
+#include <Widgets/ExploitableCorpseWidget.h>
 #include <Widgets/AlcoholWidget.h>
 #include <Widgets/SkillbarWidget.h>
 #include <Widgets/SkillMonitorWidget.h>
@@ -179,6 +180,7 @@ namespace {
         BondsWidget::Instance(), 
         ClockWidget::Instance(),
         VanquishWidget::Instance(),
+        ExploitableCorpseWidget::Instance(),
         AlcoholWidget::Instance(),
         WorldMapWidget::Instance(),
         EffectsMonitorWidget::Instance(),

--- a/GWToolboxdll/Widgets/ExploitableCorpseWidget.cpp
+++ b/GWToolboxdll/Widgets/ExploitableCorpseWidget.cpp
@@ -1,0 +1,87 @@
+#include "stdafx.h"
+
+#include <GWCA/Constants/Constants.h>
+
+#include <GWCA/GameEntities/Agent.h>
+#include <GWCA/GameEntities/NPC.h>
+
+#include <GWCA/Managers/AgentMgr.h>
+#include <GWCA/Managers/MapMgr.h>
+
+#include <Defines.h>
+
+#include "Utils/FontLoader.h"
+
+#include <Widgets/ExploitableCorpseWidget.h>
+
+namespace {
+    float range = GW::Constants::Range::Spellcast;
+}
+
+void ExploitableCorpseWidget::Draw(IDirect3DDevice9*)
+{
+    if (!visible || GW::Map::GetInstanceType() == GW::Constants::InstanceType::Outpost) {
+        return;
+    }
+
+    const GW::AgentArray* agents = GW::Agents::GetAgentArray();
+    const GW::Agent* player = agents ? GW::Agents::GetObservingAgent() : nullptr;
+
+    if (!agents || !player) {
+        return;
+    }
+
+    unsigned int corpses_found = 0;
+
+    for (auto* agent : *agents) {
+        const GW::AgentLiving* living = agent ? agent->GetAsAgentLiving() : nullptr;
+
+        if (!living || living->GetIsAlive() || living->GetIsUsedCorpse() || (GW::GetSquareDistance(player->pos, living->pos) > range * range)) {
+            continue;
+        }
+
+        if (living->IsPlayer()) {
+            corpses_found++;
+        }
+        else {
+            const GW::NPC* npc = GW::Agents::GetNPCByID(living->player_number);
+            if (npc && npc->IsFleshy()) {
+                corpses_found++;
+            }
+        }
+    }
+
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0, 0, 0, 0));
+    ImGui::SetNextWindowSize(ImVec2(250.0f, 90.0f), ImGuiCond_FirstUseEver);
+    if (ImGui::Begin(Name(), nullptr, GetWinFlags())) {
+        static char corpses_count[32];
+        snprintf(corpses_count, sizeof(corpses_count), "%u exploitable corpse%c", corpses_found, corpses_found > 1 ? 's' : '\0');
+
+        ImGui::PushFont(FontLoader::GetFont(FontLoader::FontSize::header1));
+        ImVec2 cur = ImGui::GetCursorPos();
+        ImGui::SetCursorPos(ImVec2(cur.x + 1, cur.y + 1));
+        ImGui::TextColored(ImColor(0, 0, 0), corpses_count);
+        ImGui::SetCursorPos(cur);
+        ImGui::Text(corpses_count);
+        ImGui::PopFont();
+    }
+    ImGui::End();
+    ImGui::PopStyleColor();
+}
+
+void ExploitableCorpseWidget::DrawSettingsInternal()
+{
+    ImGui::DragFloat("Range", &range, 50.f, 0, 5000.f);
+}
+
+void ExploitableCorpseWidget::LoadSettings(ToolboxIni* ini)
+{
+    ToolboxWidget::LoadSettings(ini);
+    LOAD_FLOAT(range);
+}
+
+void ExploitableCorpseWidget::SaveSettings(ToolboxIni* ini)
+{
+    ToolboxWidget::SaveSettings(ini);
+    SAVE_FLOAT(range);
+}

--- a/GWToolboxdll/Widgets/ExploitableCorpseWidget.h
+++ b/GWToolboxdll/Widgets/ExploitableCorpseWidget.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <ToolboxWidget.h>
+
+class ExploitableCorpseWidget : public ToolboxWidget {
+    ExploitableCorpseWidget() = default;
+    ~ExploitableCorpseWidget() override = default;
+
+public:
+    static ExploitableCorpseWidget& Instance()
+    {
+        static ExploitableCorpseWidget instance;
+        return instance;
+    }
+
+    [[nodiscard]] const char* Name() const override { return "Exploitable Corpses"; }
+
+    [[nodiscard]] const char* Icon() const override { return ICON_FA_SKULL; }
+
+    void Draw(IDirect3DDevice9* pDevice) override;
+
+    void DrawSettingsInternal() override;
+
+    void LoadSettings(ToolboxIni* ini) override;
+    void SaveSettings(ToolboxIni* ini) override;
+};


### PR DESCRIPTION
Based on an idea from user Mumblecrustt (https://github.com/gwdevhub/GWToolboxpp/issues/1684), this PR creates a new widget to display the number of exploitable corpses around the player (spellcast range by default).

I chose to go with a widget similar to the Vanquish one, as it is discreet and easy to integrate into the UI, but could very well go into an existing window aswell (e.g. Enemy Window as suggested in the issue). Open to any suggestion on the matter!

As this is my first contribution to this repo, please do let me know if anything is missing.