### PR TITLE
feat/minimap: marked targets inherit custom size/shape

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.cpp
@@ -207,6 +207,7 @@ void AgentRenderer::LoadSettings(const ToolboxIni* ini, const char* section)
     LoadDefaultSizes();
     
     LOAD_FLOAT(size_marked_target);
+    LOAD_BOOL(marked_target_inherit_custom_agents);
     LOAD_FLOAT(size_default);
     LOAD_FLOAT(size_player);
     LOAD_FLOAT(size_signpost);
@@ -287,6 +288,7 @@ void AgentRenderer::SaveSettings(ToolboxIni* ini, const char* section) const
     SAVE_FLOAT(size_boss);
     SAVE_FLOAT(size_minion);
     SAVE_FLOAT(size_marked_target);
+    SAVE_BOOL(marked_target_inherit_custom_agents);
     SAVE_UINT(default_shape);
     SAVE_UINT(shape_player);
     SAVE_UINT(shape_players);
@@ -413,6 +415,10 @@ void AgentRenderer::DrawSettings()
         ImGui::DragFloat("Minion Size", &size_minion, 1.0f, 1.0f, 0.0f, "%.0f");
         ImGui::DragFloat("Marked Target Size", &size_marked_target, 1.0f, 1.0f, 0.0f, "%.0f");
         ImGui::ShowHelp("Agents highlighted as marked target via /marktarget command");
+        // Right-align the checkbox
+        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ImGui::CalcItemWidth() - ImGui::GetFrameHeight());
+        ImGui::Checkbox("Marked Targets Inherit Custom Size/Shape", &marked_target_inherit_custom_agents);
+        ImGui::ShowHelp("When enabled, agents highlighted via /marktarget use their custom agent size and shape if one is defined");
         static std::array items = {"Tear", "Circle", "Square", "Big Circle"};
         ImGui::Combo("Default Shape", reinterpret_cast<int*>(&default_shape), items.data(), items.size());
         ImGui::Combo("Player Shape", reinterpret_cast<int*>(&shape_player), items.data(), items.size());
@@ -883,7 +889,12 @@ void AgentRenderer::Render(IDirect3DDevice9* device)
         if (!agent->GetIsAlive()) {
             continue;
         }
-        Enqueue(default_shape, agent, size_marked_target, color_marked_target);
+        // Apply custom size/shape if defined && marked_target_inherit_custom_agents == true
+        const auto* cas = GetCustomAgentsToDraw(agent);
+        const auto* ca = cas && !cas->empty() ? cas->front() : nullptr;
+        const auto size = marked_target_inherit_custom_agents && ca && ca->size_active && ca->size >= 0 ? ca->size : size_marked_target;
+        const auto shape = marked_target_inherit_custom_agents && ca && ca->shape_active ? ca->shape : default_shape;
+        Enqueue(shape, agent, size, color_marked_target);
     }
 
     // 4. target if it's a non-player
@@ -896,7 +907,11 @@ void AgentRenderer::Render(IDirect3DDevice9* device)
             }
         }
         if (marked) {
-            Enqueue(default_shape, target, size_marked_target, color_marked_target);
+            // Apply custom size/shape if defined && marked_target_inherit_custom_agents == true
+            const auto* ca = custom_agents_for_this_agent && !custom_agents_for_this_agent->empty() ? custom_agents_for_this_agent->front() : nullptr;
+            const auto size = marked_target_inherit_custom_agents && ca && ca->size_active && ca->size >= 0 ? ca->size : size_marked_target;
+            const auto shape = marked_target_inherit_custom_agents && ca && ca->shape_active ? ca->shape : default_shape;
+            Enqueue(shape, target, size, color_marked_target);
         }
 
         if (!marked && !custom_agents_for_this_agent) {

--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
@@ -190,6 +190,7 @@ private:
     float size_boss = 125.f;
     float size_minion = 50.f;
     float size_marked_target = 75.f;
+    bool marked_target_inherit_custom_agents = false;
     Shape_e default_shape = Tear;
     Shape_e shape_player = Tear;
     Shape_e shape_players = Tear;


### PR DESCRIPTION
### Use-case

1. I defined custom color/size agents for Skeletons in UW (size: `120.0`), and Coldfires (size: `default`).
2. I use `/marktarget` command on a patrolling Skeleton to keep track of it. Now it has the default marked size (`75.0`) and is actually *less* visible. I wanted its size to remain at `120.0`, just update its color to distinguish it from other skeles.
3. If I update "marked agents size" to `120.0` to fix that, then when I mark a Coldfire it will now be of size `120.0` too (I wanted it to remain at `default`, and only update its color).

### Solution

We introduce a new checkbox setting which makes marked targets inherit the custom size/shape of custom agents if any is defined. I believe this is more aligned with what users would want out of the `/marktarget` feature, but for backwards-compatibility the setting is disabled by default.

### Alternative

An alternative would be to always inherit custom agent sizes when `marked_agent_size == default_size`. And if a user updated the `marked_agent_size` to something other than `default_size`, we could assume they chose to override the marked agent size, and use it instead. 

Since this behavior is not backwards-compatible, I did not implement it.