### PR TITLE
Minimap extensibility

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-FILE(GLOB SOURCES
+FILE(GLOB SOURCES CONFIGURE_DEPENDS
     "*.h"
     "*.cpp")
 

--- a/GWToolbox/CMakeLists.txt
+++ b/GWToolbox/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-FILE(GLOB SOURCES
+FILE(GLOB SOURCES CONFIGURE_DEPENDS
     "*.h"
     "*.cpp"
     "GWToolbox.rc")

--- a/GWToolboxdll/CMakeLists.txt
+++ b/GWToolboxdll/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(GWToolboxdll SHARED)
 
-file(GLOB SOURCES
+file(GLOB SOURCES CONFIGURE_DEPENDS
     "*.h"
     "*.cpp"
     "GWToolbox.rc"
@@ -105,10 +105,10 @@ if(NOT FXC)
     message(SEND_ERROR "unable to find Fxc.exe for HLSL compilation")
 endif(NOT FXC)
 
-file(GLOB HLSL_VERTEX_SHADER_FILES
+file(GLOB HLSL_VERTEX_SHADER_FILES CONFIGURE_DEPENDS
     Widgets/Minimap/Shaders/*_vs.hlsl
 )
-file(GLOB HLSL_PIXEL_SHADER_FILES
+file(GLOB HLSL_PIXEL_SHADER_FILES CONFIGURE_DEPENDS
     Widgets/Minimap/Shaders/*_ps.hlsl
 )
 

--- a/GWToolboxdll/CMakeLists.txt
+++ b/GWToolboxdll/CMakeLists.txt
@@ -24,8 +24,18 @@ file(GLOB SOURCES
      
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${SOURCES})
 target_sources(GWToolboxdll PRIVATE ${SOURCES})
- 
+
+# auto-generated files - export header & pch 
+include(GenerateExportHeader)
+generate_export_header(GWToolboxdll)
+#target_sources(GWToolboxdll PRIVATE FILE_SET generated_header TYPE HEADERS BASE_DIRS ${CMAKE_CURRENT_BINARY_DIR} FILES ${CMAKE_CURRENT_BINARY_DIR}/gwtoolboxdll_export.h)
+target_sources(GWToolboxdll PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/gwtoolboxdll_export.h)
+target_include_directories(GWToolboxdll PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+source_group(Generated FILES ${CMAKE_CURRENT_BINARY_DIR}/gwtoolboxdll_export.h)
+
 target_precompile_headers(GWToolboxdll PRIVATE "stdafx.h")
+source_group(Generated REGULAR_EXPRESSION cmake_pch)
+
 target_compile_definitions(GWToolboxdll PRIVATE
     "_USRDLL"
     "GWCA_IMPORT"
@@ -88,7 +98,7 @@ target_link_libraries(GWToolboxdll PRIVATE
     Dbghelp.lib # for MiniDump
 	delayimp # for delay loading gwca
     )
-      
+
 file(GLOB FXC_PATHS "C:/Program Files (x86)/Windows Kits/10/bin/*/x86")
 find_program(FXC fxc DOC "hlsl compiler" PATHS ${FXC_PATHS})
 if(NOT FXC)

--- a/GWToolboxdll/Logger.cpp
+++ b/GWToolboxdll/Logger.cpp
@@ -87,16 +87,14 @@ namespace {
 
     void PrintTimestamp()
     {
-        time_t rawtime{};
-        time(&rawtime);
-
-        tm timeinfo{};
-        localtime_s(&timeinfo, &rawtime);
-
-        char buffer[16];
-        strftime(buffer, sizeof(buffer), "%H:%M:%S", &timeinfo);
-
-        fprintf(logfile, "[%s] ", buffer);
+        // note - why not just use current_zone()->to_local(now()) ?
+        // this has a small but non trivial perf cost - since the time zone conversion can depend on the time point (think daylight saving time starting or ending),
+        // to_local has to do some logic to figure out how to convert every single time point independently
+        // for logging purposes, we don't really care about accurate time zone conversions - in fact, monotonicity of timestamps is more convenient than having an accurate wall-clock time
+        // consider that if DST changes mid session, we'd rather have some timestamps off by an hour than have gaps or non-monotonicity in timestamps
+        // so just cache the timezone offset at first call and use it forever
+        static const auto tzoffset = std::chrono::current_zone()->get_info(std::chrono::system_clock::now()).offset;
+        std::print(logfile, "[{:%T}] ", std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() + tzoffset));
     }
 
 
@@ -250,6 +248,13 @@ void Log::LogW(const wchar_t* msg, ...)
     va_end(args);
     if (msg[wcslen(msg) - 1] != '\n') {
         fprintf(logfile, "\n");
+    }
+}
+
+void Log::FlushFile()
+{
+    if (logfile) {
+        fflush(logfile);
     }
 }
 

--- a/GWToolboxdll/Logger.h
+++ b/GWToolboxdll/Logger.h
@@ -1,7 +1,11 @@
 #pragma once
 
+#include "gwtoolboxdll_export.h"
+
 #define ASSERT(expr) ((void)(!!(expr) || (Log::FatalAssert(#expr, __FILE__, (unsigned)__LINE__), 0)))
+#ifndef IM_ASSERT
 #define IM_ASSERT(expr) ASSERT(expr)
+#endif
 #include <GWCA/Managers/ChatMgr.h>
 
 constexpr auto GWTOOLBOX_CHAN = GW::Chat::Channel::CHANNEL_GWCA2;
@@ -22,34 +26,34 @@ namespace Log {
 
     // === File/console logging ===
     // printf-style log
-    void Log(const char* msg, ...);
+    GWTOOLBOXDLL_EXPORT void Log(const char* msg, ...);
 
     // printf-style wide-string log
-    void LogW(const wchar_t* msg, ...);
+    GWTOOLBOXDLL_EXPORT void LogW(const wchar_t* msg, ...);
 
     // flushes log file.
-    //static void FlushFile() { fflush(logfile); }
+    GWTOOLBOXDLL_EXPORT void FlushFile();
 
     // === Game chat logging ===
     // Shows a message in chat in the form of a white chat message from toolbox
-    void Info(const char* format, ...);
+    GWTOOLBOXDLL_EXPORT void Info(const char* format, ...);
     // Shows a message in chat in the form of a white chat message from toolbox
-    void InfoW(const wchar_t* format, ...);
+    GWTOOLBOXDLL_EXPORT void InfoW(const wchar_t* format, ...);
 
     // Shows a temporary message in chat in the form of a white chat message from toolbox. This message will disappear on map change.
-    void Flash(const char* format, ...);
+    GWTOOLBOXDLL_EXPORT void Flash(const char* format, ...);
     // Shows a temporary message in chat in the form of a white chat message from toolbox. This message will disappear on map change.
-    void FlashW(const wchar_t* format, ...);
+    GWTOOLBOXDLL_EXPORT void FlashW(const wchar_t* format, ...);
 
     // Shows a temporary message in chat in the form of a red chat message from toolbox. This message will disappear on map change.
-    void Error(const char* format, ...);
+    GWTOOLBOXDLL_EXPORT void Error(const char* format, ...);
     // Shows a temporary message in chat in the form of a red chat message from toolbox. This message will disappear on map change.
-    void ErrorW(const wchar_t* format, ...);
+    GWTOOLBOXDLL_EXPORT void ErrorW(const wchar_t* format, ...);
 
     // Shows a temporary message in chat in the form of a yellow chat message from toolbox. This message will disappear on map change.
-    void Warning(const char* format, ...);
+    GWTOOLBOXDLL_EXPORT void Warning(const char* format, ...);
     // Shows a temporary message in chat in the form of a yellow chat message from toolbox. This message will disappear on map change.
-    void WarningW(const wchar_t* format, ...);
+    GWTOOLBOXDLL_EXPORT void WarningW(const wchar_t* format, ...);
 
-    void FatalAssert(const char* expr, const char* file, const unsigned line);
+    GWTOOLBOXDLL_EXPORT void FatalAssert(const char* expr, const char* file, const unsigned line);
 }

--- a/GWToolboxdll/ToolboxModule.h
+++ b/GWToolboxdll/ToolboxModule.h
@@ -2,6 +2,7 @@
 
 using SectionDrawCallback = std::function<void(const std::string& section, bool is_showing)>;
 class ToolboxModule;
+class ToolboxIni;
 
 struct SectionDrawCallbackInfo {
     float weighting{};

--- a/GWToolboxdll/Widgets/Minimap/CustomRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/CustomRenderer.h
@@ -10,38 +10,6 @@ namespace GW::Constants {
 
 using Color = uint32_t;
 
-namespace mapbox::util {
-    template <>
-    struct nth<0, GW::GamePos> {
-        static auto get(const GW::GamePos& t) { return t.x; }
-    };
-
-    template <>
-    struct nth<1, GW::GamePos> {
-        static auto get(const GW::GamePos& t) { return t.y; }
-    };
-
-    template <>
-    struct nth<0, GW::Vec2f> {
-        static auto get(const GW::Vec2f& t) { return t.x; }
-    };
-
-    template <>
-    struct nth<1, GW::Vec2f> {
-        static auto get(const GW::Vec2f& t) { return t.y; }
-    };
-
-    template <>
-    struct nth<0, GW::Vec3f> {
-        static auto get(const GW::Vec3f& t) { return t.x; }
-    };
-
-    template <>
-    struct nth<1, GW::Vec3f> {
-        static auto get(const GW::Vec3f& t) { return t.y; }
-    };
-}
-
 class CustomRenderer : public VBuffer {
     friend class AgentRenderer;
     friend class GameWorldRenderer;

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -1444,6 +1444,22 @@ void Minimap::Draw(IDirect3DDevice9* device)
     }
 }
 
+void Minimap::RegisterRenderer(MinimapRenderer* renderer)
+{
+    auto& inst = Instance();
+    ASSERT(std::ranges::find(inst.registered_renderers, renderer) == inst.registered_renderers.end());
+    inst.registered_renderers.push_back(renderer);
+}
+
+void Minimap::UnregisterRenderer(MinimapRenderer* renderer)
+{
+    auto& inst = Instance();
+    auto it = std::ranges::find(inst.registered_renderers, renderer);
+    if (it != inst.registered_renderers.end()) {
+        inst.registered_renderers.erase(it);
+    }
+}
+
 bool Minimap::ShouldMarkersDrawOnMap()
 {
     const auto map_has_outpost_and_explorable = [](const GW::Constants::MapID map_id) {
@@ -1602,6 +1618,8 @@ void Minimap::Render(IDirect3DDevice9* device, const MinimapRenderContext& conte
     instance.agent_renderer.Render(device);
     instance.effect_renderer.Render(device);
     instance.pingslines_renderer.Render(device);
+    for (auto renderer : instance.registered_renderers)
+        renderer->RenderMinimap(device, context);
     
     DrawNSEW(context);
 

--- a/GWToolboxdll/Widgets/Minimap/Minimap.h
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.h
@@ -5,6 +5,7 @@
 #include <ToolboxWidget.h>
 
 #include "Defines.h"
+#include "gwtoolboxdll_export.h"
 
 #include <Utils/GuiUtils.h>
 
@@ -43,6 +44,24 @@ struct MinimapRenderContext : RectF {
     {
         return {static_cast<LONG>(top_left.x), static_cast<LONG>(top_left.y), static_cast<LONG>(bottom_right.x), static_cast<LONG>(bottom_right.y)};
     }
+};
+
+// subclass this structure and register an instance to have plugins draw extra stuff on a minimap
+class GWTOOLBOXDLL_EXPORT MinimapRenderer {
+public:
+    MinimapRenderer() = default;
+    virtual ~MinimapRenderer() = default;
+
+    // minimap holds pointers to registered renderers, so move is forbidden
+    MinimapRenderer(const MinimapRenderer&) = delete;
+    MinimapRenderer(MinimapRenderer&&) = delete;
+    MinimapRenderer& operator=(const MinimapRenderer&) = delete;
+    MinimapRenderer& operator=(MinimapRenderer&&) = delete;
+
+    // implement this to draw your data on the minimap
+    // the view matrix is set up to transform game world positions to minimap appropriately, make sure to restore it if you touch it
+    // the world matrix is undefined and can be left in any state
+    virtual void RenderMinimap(IDirect3DDevice9* device, const MinimapRenderContext& context) = 0;
 };
 
 class Minimap final : public ToolboxWidget {
@@ -86,6 +105,9 @@ public:
     // Setup projection matrix for a given context
     static void RenderSetupProjection(IDirect3DDevice9* device, const MinimapRenderContext& context);
 
+    GWTOOLBOXDLL_EXPORT static void RegisterRenderer(MinimapRenderer* renderer);
+    GWTOOLBOXDLL_EXPORT static void UnregisterRenderer(MinimapRenderer* renderer);
+
     bool FlagHeros(LPARAM lParam);
     bool OnMouseDown(UINT Message, WPARAM wParam, LPARAM lParam);
     [[nodiscard]] bool OnMouseDblClick(UINT Message, WPARAM wParam, LPARAM lParam) const;
@@ -112,6 +134,7 @@ public:
     SymbolsRenderer symbols_renderer;
     CustomRenderer custom_renderer;
     EffectRenderer effect_renderer;
+    std::vector<MinimapRenderer*> registered_renderers;
 
     static bool ShouldMarkersDrawOnMap();
     static bool ShouldDrawAllQuests();

--- a/GWToolboxdll/mapbox_earcut.h
+++ b/GWToolboxdll/mapbox_earcut.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <mapbox/earcut.hpp>
+#include <GWCA/GameContainers/GamePos.h>
+
+namespace mapbox::util {
+    template <>
+    struct nth<0, GW::GamePos> {
+        static auto get(const GW::GamePos& t) { return t.x; }
+    };
+
+    template <>
+    struct nth<1, GW::GamePos> {
+        static auto get(const GW::GamePos& t) { return t.y; }
+    };
+
+    template <>
+    struct nth<0, GW::Vec2f> {
+        static auto get(const GW::Vec2f& t) { return t.x; }
+    };
+
+    template <>
+    struct nth<1, GW::Vec2f> {
+        static auto get(const GW::Vec2f& t) { return t.y; }
+    };
+
+    template <>
+    struct nth<0, GW::Vec3f> {
+        static auto get(const GW::Vec3f& t) { return t.x; }
+    };
+
+    template <>
+    struct nth<1, GW::Vec3f> {
+        static auto get(const GW::Vec3f& t) { return t.y; }
+    };
+} // namespace mapbox::util

--- a/GWToolboxdll/stdafx.h
+++ b/GWToolboxdll/stdafx.h
@@ -75,7 +75,7 @@
 #include <easywsclient.hpp>
 #include <mp3.h>
 #include <IconsFontAwesome5.h>
-#include <mapbox/earcut.hpp>
+#include <mapbox_earcut.h>
 
 #define __forceinline
 #include <ctre.hpp>

--- a/RestClient/CMakeLists.txt
+++ b/RestClient/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(CURL REQUIRED)
 
-FILE(GLOB SOURCES
+FILE(GLOB SOURCES CONFIGURE_DEPENDS
     "*.h"
     "*.cpp")
 

--- a/cmake/gwtoolboxdll_plugins.cmake
+++ b/cmake/gwtoolboxdll_plugins.cmake
@@ -24,7 +24,7 @@ target_compile_definitions(plugin_base INTERFACE BUILD_DLL)
 
 macro(add_tb_plugin PLUGIN)
     add_library(${PLUGIN} SHARED)
-    file(GLOB SOURCES
+    file(GLOB SOURCES CONFIGURE_DEPENDS
         "${PROJECT_SOURCE_DIR}/plugins/${PLUGIN}/*.h"
         "${PROJECT_SOURCE_DIR}/plugins/${PLUGIN}/*.cpp")
     target_sources(${PLUGIN} PRIVATE ${SOURCES})

--- a/cmake/imgui.cmake
+++ b/cmake/imgui.cmake
@@ -48,4 +48,4 @@ target_include_directories(imgui PUBLIC
 target_compile_definitions(imgui PUBLIC 
     IMGUI_USER_CONFIG="${CMAKE_CURRENT_LIST_DIR}/../GWToolboxdll/imconfig.h")
 
-set_target_properties(imgui PROPERTIES FOLDER "${CMAKE_CURRENT_LIST_DIR}/../Dependencies/")
+set_target_properties(imgui PROPERTIES FOLDER "Dependencies/")

--- a/cmake/imgui.cmake
+++ b/cmake/imgui.cmake
@@ -5,6 +5,10 @@ FetchContent_Declare(
     imgui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
     GIT_TAG v1.90.9-docking
+    PATCH_COMMAND ${CMAKE_CURRENT_LIST_DIR}/patches/apply_patch.bat imgui_transparent_viewports.patch
+    LOG_PATCH true
+    LOG_MERGED_STDOUTERR true
+    LOG_OUTPUT_ON_FAILURE true
     )
 FetchContent_GetProperties(imgui)
 if (imgui_POPULATED)
@@ -12,20 +16,6 @@ if (imgui_POPULATED)
 endif()
 
 FetchContent_MakeAvailable(imgui)
-
-# Apply the patch without halting the build on failure, in case it's already applied
-execute_process(
-    COMMAND git apply "${CMAKE_CURRENT_LIST_DIR}/../cmake/patches/imgui_transparent_viewports.patch"
-    WORKING_DIRECTORY ${imgui_SOURCE_DIR}
-    RESULT_VARIABLE patch_result
-    ERROR_VARIABLE patch_error
-    OUTPUT_VARIABLE patch_output
-)
-
-if (NOT patch_result EQUAL 0)
-    message(WARNING "Failed to apply patch: ${patch_error}")
-    message(WARNING "Patch output: ${patch_output}")
-endif()
 
 add_library(imgui)
 set(SOURCES

--- a/cmake/imgui_fonts.cmake
+++ b/cmake/imgui_fonts.cmake
@@ -8,3 +8,5 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/HasKha/imgui-fonts.git
     GIT_TAG 51e143ae864d141d919194af74ff916d5e6d383a)
 FetchContent_MakeAvailable(imgui_fonts)
+
+set_target_properties(fonts PROPERTIES FOLDER "Dependencies/")

--- a/cmake/patches/apply_patch.bat
+++ b/cmake/patches/apply_patch.bat
@@ -1,0 +1,5 @@
+echo Checking if patch is already applied...
+git apply --reverse --check %~dp0%1
+if NOT ERRORLEVEL 1 echo Already applied, nothing to do && exit /b 0
+echo Applying patch
+git apply %~dp0%1


### PR DESCRIPTION
A bunch of changes to support extending minimap from plugins.

Note that this PR includes some more changes - I've tried to split them into separate commits with reasonable descriptions. Technically only last commit implements minimap extensibility - the rest is optional; the only thing last commit relies on is dllexport machinery introduced in 'Logging improvements' commit.

If desired, I can split that logging commit further into two (dllexport and logger markup). Or I can move some changes out into separate PRs (or even remove them if they are not desired)...