### PR TITLE
Add healing tracking to damage meter

### DIFF
--- a/GWToolboxdll/Widgets/PartyDamage.cpp
+++ b/GWToolboxdll/Widgets/PartyDamage.cpp
@@ -29,6 +29,7 @@ namespace {
 
 
     uint32_t total = 0;
+    uint32_t total_healing = 0;
 
     std::map<DWORD, uint32_t> hp_map{};
     
@@ -43,6 +44,7 @@ namespace {
     Color color_background = Colors::ARGB(76, 0, 0, 0);
     Color color_damage = Colors::ARGB(76, 0, 0, 0);
     Color color_recent = Colors::ARGB(205, 102, 153, 230);
+    Color color_healing = Colors::ARGB(205, 102, 230, 102);
     float width = 100.0f;
     bool bars_left = true;
     int recent_max_time = 7000;
@@ -62,8 +64,17 @@ namespace {
         }
         return static_cast<float>(dmg) / total;
     }
-    float GetPercentageOfTotal(const uint32_t dmg) { 
-        return GetPartOfTotal(dmg) * 100.0f; 
+    float GetPercentageOfTotal(const uint32_t dmg) {
+        return GetPartOfTotal(dmg) * 100.0f;
+    }
+    float GetPartOfTotalHealing(uint32_t heal) {
+        if (total_healing == 0) {
+            return 0;
+        }
+        return static_cast<float>(heal) / total_healing;
+    }
+    float GetPercentageOfTotalHealing(const uint32_t heal) {
+        return GetPartOfTotalHealing(heal) * 100.0f;
     }
 }
 
@@ -71,6 +82,9 @@ struct PartyDamage::PlayerDamage {
     uint32_t damage = 0;
     uint32_t recent_damage = 0;
     clock_t last_damage = 0;
+    uint32_t healing = 0;
+    uint32_t recent_healing = 0;
+    clock_t last_healing = 0;
     uint32_t agent_id = 0;
     GW::Constants::Profession primary = GW::Constants::Profession::None;
     GW::Constants::Profession secondary = GW::Constants::Profession::None;
@@ -79,6 +93,8 @@ struct PartyDamage::PlayerDamage {
     {
         damage = 0;
         recent_damage = 0;
+        healing = 0;
+        recent_healing = 0;
         agent_id = 0;
         primary = GW::Constants::Profession::None;
         secondary = GW::Constants::Profession::None;
@@ -91,7 +107,7 @@ void PartyDamage::WriteDamageOf(size_t index, uint32_t rank) {
     if (index >= damage.size()) {
         return;
     }
-    if (damage[index].damage <= 0) {
+    if (damage[index].damage <= 0 && damage[index].healing <= 0) {
         return;
     }
 
@@ -110,15 +126,44 @@ void PartyDamage::WriteDamageOf(size_t index, uint32_t rank) {
         }
     }
 
-    constexpr size_t buffer_size = 130;
+    constexpr size_t buffer_size = 200;
     wchar_t buffer[buffer_size];
-    swprintf_s(buffer, buffer_size, L"#%2d ~ %3.2f %% ~ %ls/%ls %ls ~ %d",
-        rank,
-        GetPercentageOfTotal(damage[index].damage),
-        GetWProfessionAcronym(damage[index].primary),
-        GetWProfessionAcronym(damage[index].secondary),
-        party_names_by_index[index]->wstring().c_str(),
-        damage[index].damage);
+
+    const bool has_damage = damage[index].damage > 0;
+    const bool has_healing = damage[index].healing > 0;
+
+    if (has_damage && has_healing) {
+        swprintf_s(buffer, buffer_size, L"#%2d ~ %ls/%ls %ls ~ Dmg: %3.2f%% (%d) ~ Heal: %3.2f%% (%d)",
+            rank,
+            GetWProfessionAcronym(damage[index].primary),
+            GetWProfessionAcronym(damage[index].secondary),
+            party_names_by_index[index]->wstring().c_str(),
+            GetPercentageOfTotal(damage[index].damage),
+            damage[index].damage,
+            GetPercentageOfTotalHealing(damage[index].healing),
+            damage[index].healing);
+    }
+    else if (has_damage) {
+        swprintf_s(buffer, buffer_size, L"#%2d ~ %ls/%ls %ls ~ Dmg: %3.2f%% (%d)",
+            rank,
+            GetWProfessionAcronym(damage[index].primary),
+            GetWProfessionAcronym(damage[index].secondary),
+            party_names_by_index[index]->wstring().c_str(),
+            GetPercentageOfTotal(damage[index].damage),
+            damage[index].damage);
+    }
+    else if (has_healing) {
+        swprintf_s(buffer, buffer_size, L"#%2d ~ %ls/%ls %ls ~ Heal: %3.2f%% (%d)",
+            rank,
+            GetWProfessionAcronym(damage[index].primary),
+            GetWProfessionAcronym(damage[index].secondary),
+            party_names_by_index[index]->wstring().c_str(),
+            GetPercentageOfTotalHealing(damage[index].healing),
+            damage[index].healing);
+    }
+    else {
+        return; // Nothing to report
+    }
 
     send_queue.push(buffer);
 }
@@ -134,7 +179,7 @@ void PartyDamage::WritePartyDamage() {
     for (size_t i = 0; i < idx.size(); ++i) {
         WriteDamageOf(idx[i], i + 1);
     }
-    send_queue.push(L"Total ~ 100 % ~ " + std::to_wstring(total));
+    send_queue.push(L"Total ~ Dmg: " + std::to_wstring(total) + L" ~ Heal: " + std::to_wstring(total_healing));
 }
 
 void PartyDamage::MapLoadedCallback(GW::HookStatus*, const GW::Packet::StoC::MapLoaded*)
@@ -157,7 +202,7 @@ void PartyDamage::MapLoadedCallback(GW::HookStatus*, const GW::Packet::StoC::Map
 
 void PartyDamage::DamagePacketCallback(GW::HookStatus*, const GW::Packet::StoC::GenericModifier* packet)
 {
-    // ignore non-damage packets
+    // ignore non-damage/heal packets
     switch (packet->type) {
     case GW::Packet::StoC::P156_Type::damage:
     case GW::Packet::StoC::P156_Type::critical:
@@ -167,15 +212,16 @@ void PartyDamage::DamagePacketCallback(GW::HookStatus*, const GW::Packet::StoC::
         return;
     }
 
-    // ignore heals
-    if (packet->value >= 0) {
+    const bool is_heal = packet->value > 0;
+    const bool is_damage = packet->value < 0;
+    if (!is_heal && !is_damage)
         return;
-    }
+
     const auto cause = static_cast<GW::AgentLiving*>(GW::Agents::GetAgentByID(packet->cause_id));
     if (!(cause && cause->GetIsLivingType()))
-        return; // Ignore damage caused by non-living agents
+        return; // Ignore damage/heals caused by non-living agents
     if (cause->allegiance != GW::Constants::Allegiance::Ally_NonAttackable)
-        return; // Ignore damage caused by non-allied NPCs
+        return; // Ignore damage/heals caused by non-allied NPCs
 
     auto entry = GetDamageByAgentId(cause->agent_id);
     if (!entry)
@@ -183,51 +229,73 @@ void PartyDamage::DamagePacketCallback(GW::HookStatus*, const GW::Packet::StoC::
 
     const auto target = static_cast<GW::AgentLiving*>(GW::Agents::GetAgentByID(packet->target_id));
     if (!(target && target->GetIsLivingType()))
-        return; // Ignore damage inflicted on non-living agents
-    if (target->login_number != 0)
-        return; // Ignore damage inflicted on other players such as Life bond or sacrifice
-    switch (target->allegiance) {
-    case GW::Constants::Allegiance::Ally_NonAttackable:
-    case GW::Constants::Allegiance::Spirit_Pet:
-    case GW::Constants::Allegiance::Minion:
-        return; // ignore damage inflicted to allies in general
+        return; // Ignore damage/heals on non-living agents
+
+    if (is_damage) {
+        // For damage: target must be enemy
+        if (target->login_number != 0)
+            return; // Ignore damage inflicted on other players such as Life bond or sacrifice
+        switch (target->allegiance) {
+        case GW::Constants::Allegiance::Ally_NonAttackable:
+        case GW::Constants::Allegiance::Spirit_Pet:
+        case GW::Constants::Allegiance::Minion:
+            return; // ignore damage inflicted to allies in general
+        }
+    }
+    else {
+        // For healing: target must be ally
+        switch (target->allegiance) {
+        case GW::Constants::Allegiance::Ally_NonAttackable:
+        case GW::Constants::Allegiance::Spirit_Pet:
+        case GW::Constants::Allegiance::Minion:
+            break; // allow healing to allies
+        default:
+            return; // ignore healing to enemies
+        }
     }
 
-    long ldmg;
+    long lvalue;
     if (target->max_hp > 0 && target->max_hp < 100000) {
-        ldmg = std::lround(-packet->value * target->max_hp);
+        lvalue = std::lround(std::abs(packet->value) * target->max_hp);
         hp_map[target->player_number] = target->max_hp;
     }
     else {
         const auto it = hp_map.find(target->player_number);
         if (it == hp_map.end()) {
             // max hp not found, approximate with hp/lvl formula
-            ldmg = std::lround(-packet->value * (target->level * 20 + 100));
+            lvalue = std::lround(std::abs(packet->value) * (target->level * 20 + 100));
         }
         else {
-            // size_t maxhp = it->second;
-            ldmg = std::lround(-packet->value * it->second);
+            lvalue = std::lround(std::abs(packet->value) * it->second);
         }
     }
 
-    const uint32_t dmg = static_cast<uint32_t>(ldmg);
+    const uint32_t amount = static_cast<uint32_t>(lvalue);
 
-    if (entry->damage == 0) {
+    if (entry->damage == 0 && entry->healing == 0) {
         entry->agent_id = packet->cause_id;
         entry->primary = static_cast<GW::Constants::Profession>(cause->primary);
         entry->secondary = static_cast<GW::Constants::Profession>(cause->secondary);
     }
 
-    entry->damage += dmg;
-    total += dmg;
-
-    entry->recent_damage += dmg;
-    entry->last_damage = TIMER_INIT();
+    if (is_damage) {
+        entry->damage += amount;
+        total += amount;
+        entry->recent_damage += amount;
+        entry->last_damage = TIMER_INIT();
+    }
+    else {
+        entry->healing += amount;
+        total_healing += amount;
+        entry->recent_healing += amount;
+        entry->last_healing = TIMER_INIT();
+    }
 }
 
 void PartyDamage::ResetDamage()
 {
     total = 0;
+    total_healing = 0;
     for (auto& entry : damage) {
         entry.Reset();
     }
@@ -328,6 +396,9 @@ void PartyDamage::Update(const float)
         if (TIMER_DIFF(entry.last_damage) > recent_max_time) {
             entry.recent_damage = 0;
         }
+        if (TIMER_DIFF(entry.last_healing) > recent_max_time) {
+            entry.recent_healing = 0;
+        }
     }
     FetchPartyInfo();
 }
@@ -354,13 +425,20 @@ void PartyDamage::Draw(IDirect3DDevice9* )
 
     uint32_t max_recent = 0;
     uint32_t max = 0;
+    uint32_t max_recent_healing = 0;
+    uint32_t max_healing = 0;
     for (const auto& i : damage) {
         if (max_recent < i.recent_damage) {
             max_recent = i.recent_damage;
         }
-
         if (max < i.damage) {
             max = i.damage;
+        }
+        if (max_recent_healing < i.recent_healing) {
+            max_recent_healing = i.recent_healing;
+        }
+        if (max_healing < i.healing) {
+            max_healing = i.healing;
         }
     }
 
@@ -368,6 +446,8 @@ void PartyDamage::Draw(IDirect3DDevice9* )
     const Color damage_col_to = Colors::Sub(color_damage, Colors::ARGB(0, 20, 20, 20));
     const Color damage_recent_from = Colors::Add(color_recent, Colors::ARGB(0, 20, 20, 20));
     const Color damage_recent_to = Colors::Sub(color_recent, Colors::ARGB(0, 20, 20, 20));
+    const Color healing_from = Colors::Add(color_healing, Colors::ARGB(0, 20, 20, 20));
+    const Color healing_to = Colors::Sub(color_healing, Colors::ARGB(0, 20, 20, 20));
 
     const auto user_offset_x = abs(static_cast<float>(user_offset));
     float window_x = .0f;
@@ -428,7 +508,7 @@ void PartyDamage::Draw(IDirect3DDevice9* )
                 );
             }
 
-            // Recent damage as percent of total team's recent damage
+            // Recent damage as percent of total team's recent damage (bottom bar)
             if (entry->recent_damage) {
                 const float part_of_recent = max_recent > 0 ? static_cast<float>(entry->recent_damage) / max_recent : 0;
                 const float recent_left = bars_left ? x + width * (1.0f - part_of_recent) : x;
@@ -442,11 +522,25 @@ void PartyDamage::Draw(IDirect3DDevice9* )
                 );
             }
 
+            // Recent healing as percent of total team's recent healing (top bar)
+            if (entry->recent_healing) {
+                const float part_of_recent_heal = max_recent_healing > 0 ? static_cast<float>(entry->recent_healing) / max_recent_healing : 0;
+                const float heal_left = bars_left ? x + width * (1.0f - part_of_recent_heal) : x;
+                const float heal_right = bars_left ? x + width : x + width * part_of_recent_heal;
+                const auto heal_top_left = ImVec2(heal_left, damage_top_left.y);
+                const auto heal_bottom_right = ImVec2(heal_right, damage_top_left.y + 6);
+                draw_list->AddRectFilledMultiColor(
+                    heal_top_left, heal_bottom_right,
+                    healing_from, healing_from,
+                    healing_to, healing_to
+                );
+            }
+
             const auto row_height = damage_bottom_right.y - damage_top_left.y;
             const auto text_height = ImGui::GetTextLineHeight();
             const auto text_y = damage_top_left.y + (row_height - text_height) / 2;
 
-            // Damage text - float
+            // Damage text
             if (damage_float < 1000.f) {
                 snprintf(buffer, buffer_size, "%.0f", damage_float);
             }
@@ -464,12 +558,24 @@ void PartyDamage::Draw(IDirect3DDevice9* )
                 ImVec2(x + ImGui::GetStyle().ItemSpacing.x, text_y),
                 IM_COL32(255, 255, 255, 255), buffer);
 
-            // Damage text - percentage
-            const float perc_of_total = GetPercentageOfTotal(entry->damage);
-            snprintf(buffer, buffer_size, "%.1f %%", perc_of_total);
+            // Healing text
+            const float healing_float = static_cast<float>(entry->healing);
+            if (healing_float < 1000.f) {
+                snprintf(buffer, buffer_size, "%.0f", healing_float);
+            }
+            else if (healing_float < 1000.f * 10) {
+                snprintf(buffer, buffer_size, "%.2f k", healing_float / 1000.f);
+            }
+            else if (healing_float < 1000.f * 1000.f) {
+                snprintf(buffer, buffer_size, "%.1f k", healing_float / 1000.f);
+            }
+            else {
+                snprintf(buffer, buffer_size, "%.2f m", healing_float / (1000.f * 1000.f));
+            }
+
             draw_list->AddText(
                 ImVec2(x + width / 2, text_y),
-                IM_COL32(255, 255, 255, 255), buffer
+                color_healing, buffer
             );
 
             if (print_by_click
@@ -496,6 +602,7 @@ void PartyDamage::LoadSettings(ToolboxIni* ini)
     LOAD_COLOR(color_background);
     LOAD_COLOR(color_damage);
     LOAD_COLOR(color_recent);
+    LOAD_COLOR(color_healing);
     LOAD_BOOL(hide_in_outpost);
     LOAD_BOOL(print_by_click);
     LOAD_UINT(user_offset);
@@ -533,6 +640,7 @@ void PartyDamage::SaveSettings(ToolboxIni* ini)
     SAVE_COLOR(color_background);
     SAVE_COLOR(color_damage);
     SAVE_COLOR(color_recent);
+    SAVE_COLOR(color_healing);
     SAVE_BOOL(hide_in_outpost);
     SAVE_BOOL(print_by_click);
     SAVE_UINT(user_offset);
@@ -575,8 +683,9 @@ void PartyDamage::DrawSettingsInternal()
     if (recent_max_time < 0) {
         recent_max_time = 0;
     }
-    ImGui::ShowHelp("After this amount of time, each player recent damage (blue bar) will be reset");
+    ImGui::ShowHelp("After this amount of time, each player's recent damage/healing bars will be reset");
     Colors::DrawSettingHueWheel("Background", &color_background);
     Colors::DrawSettingHueWheel("Damage", &color_damage);
-    Colors::DrawSettingHueWheel("Recent", &color_recent);
+    Colors::DrawSettingHueWheel("Recent Damage", &color_recent);
+    Colors::DrawSettingHueWheel("Healing", &color_healing);
 }


### PR DESCRIPTION
This adds healing stats to `/damage` and the damage widget. Like damage stats this does not account for indirect "healing", e.g. through regeneration or damage mitigation.

<img width="698" height="528" alt="image" src="https://github.com/user-attachments/assets/87fc9c86-c00e-4022-9074-d901e3dbb6d8" />

<img width="848" height="228" alt="image" src="https://github.com/user-attachments/assets/b49dae39-73b0-4f10-9da9-d519a9d9f008" />
