### PR TITLE
Add silent flag to /hero command

### DIFF
--- a/GWToolboxdll/Constants/EncStrings.h
+++ b/GWToolboxdll/Constants/EncStrings.h
@@ -311,6 +311,12 @@ namespace GW {
             static const wchar_t* TheLastHeirophant = L"\x8102\x10b5\xbc2f\xb47f\x30a7";
         }
 
+        namespace HeroBehavior {
+            static const wchar_t* Fight = L"\x8101\x5E27";
+            static const wchar_t* Guard = L"\x8101\x5E28";
+            static const wchar_t* Avoid = L"\x8101\x5E29";
+        }
+
         // General settings
         static const uint32_t TextLanguage = 0x561;
         static const uint32_t AudioLanguage = 0xdbe2;

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -45,6 +45,7 @@
 #include <Keys.h>
 #include <Logger.h>
 
+#include <Constants/EncStrings.h>
 #include <Modules/ChatCommands.h>
 #include <Modules/GameSettings.h>
 #include <Modules/ChatSettings.h>
@@ -3175,7 +3176,7 @@ void GetFlaggableHeroNames(std::function<void(std::map<uint32_t, std::wstring>*)
 
 void CHAT_CMD_FUNC(ChatCommands::CmdHeroBehaviour)
 {
-    const wchar_t* syntax = L"Syntax: /hero [avoid|guard|attack|target] [hero_name|hero_index]";
+    const wchar_t* syntax = L"Syntax: /hero [avoid|guard|attack|target] [hero_name|hero_index] [silent]";
 
     GW::WorldContext* w = GW::GetWorldContext();
     GW::HeroFlagArray* flags = w ? &w->hero_flags : nullptr;
@@ -3184,6 +3185,17 @@ void CHAT_CMD_FUNC(ChatCommands::CmdHeroBehaviour)
     if (argc < 2) {
         return Log::ErrorW(syntax);
     }
+
+    // Check if last argument is "silent" - suppress hero behavior chat messages
+    int effective_argc = argc;
+    if (argc >= 2 && wcscmp(argv[argc - 1], L"silent") == 0) {
+        constexpr DWORD SUPPRESS_MS = 1000;
+        ChatSettings::SuppressChatMessageForMs(GW::EncStrings::HeroBehavior::Fight, 2, SUPPRESS_MS);
+        ChatSettings::SuppressChatMessageForMs(GW::EncStrings::HeroBehavior::Guard, 2, SUPPRESS_MS);
+        ChatSettings::SuppressChatMessageForMs(GW::EncStrings::HeroBehavior::Avoid, 2, SUPPRESS_MS);
+        effective_argc--;
+    }
+
     // set behavior based on command message
     auto behaviour = 0xff;
     const std::wstring arg1 = TextUtils::ToLower(argv[1]);
@@ -3211,8 +3223,7 @@ void CHAT_CMD_FUNC(ChatCommands::CmdHeroBehaviour)
         return GW::PartyMgr::SetHeroBehavior(agent_id, (GW::HeroBehavior)behaviour);
     };
 
-
-    if (argc < 3) {
+    if (effective_argc < 3) {
         for (const auto& flag : *flags) {
             flag_hero(flag.agent_id);
         }

--- a/GWToolboxdll/Modules/ChatSettings.cpp
+++ b/GWToolboxdll/Modules/ChatSettings.cpp
@@ -23,6 +23,28 @@
 #include <GWCA/Utilities/Hooker.h>
 
 namespace {
+    struct SuppressedMessage {
+        std::wstring substring;
+        DWORD expires_at;
+    };
+    std::vector<SuppressedMessage> suppressed_messages;
+
+    bool ShouldSuppressChatMessage(const wchar_t* message)
+    {
+        if (!message || suppressed_messages.empty()) return false;
+        const DWORD now = GetTickCount();
+        for (auto it = suppressed_messages.begin(); it != suppressed_messages.end();) {
+            if (now > it->expires_at) {
+                it = suppressed_messages.erase(it);
+                continue;
+            }
+            if (wcsstr(message, it->substring.c_str())) {
+                return true;
+            }
+            ++it;
+        }
+        return false;
+    }
     // Settings
     bool show_timestamps = false;
     bool hide_player_speech_bubbles = false;
@@ -401,6 +423,18 @@ namespace {
                 if (param->channel == GW::Chat::Channel::CHANNEL_GROUP || param->channel == GW::Chat::Channel::CHANNEL_ALLIES)
                     param->channel = GW::Chat::Channel::CHANNEL_EMOTE;
             } break;
+            case GW::UI::UIMessage::kPrintChatMessage: {
+                const auto param = static_cast<GW::UI::UIPacket::kPrintChatMessage*>(wParam);
+                if (ShouldSuppressChatMessage(param->message)) {
+                    status->blocked = true;
+                }
+            } break;
+            case GW::UI::UIMessage::kLogChatMessage: {
+                const auto param = static_cast<GW::UI::UIPacket::kLogChatMessage*>(wParam);
+                if (ShouldSuppressChatMessage(param->message)) {
+                    status->blocked = true;
+                }
+            } break;
             case GW::UI::UIMessage::kStartWhisper: {
                 OnStartWhisper(status, message_id, wParam, lParam);
             } break;
@@ -426,7 +460,8 @@ void ChatSettings::Initialize()
 
     constexpr GW::UI::UIMessage ui_messages[] = {GW::UI::UIMessage::kAgentSpeechBubble, GW::UI::UIMessage::kDialogueMessage, GW::UI::UIMessage::kPreferenceFlagChanged,    GW::UI::UIMessage::kPreferenceValueChanged,
                                                  GW::UI::UIMessage::kPlayerChatMessage, GW::UI::UIMessage::kWriteToChatLog,  GW::UI::UIMessage::kWriteToChatLogWithSender, GW::UI::UIMessage::kRecvWhisper,
-                                                 GW::UI::UIMessage::kStartWhisper,      GW::UI::UIMessage::kSendChatMessage, GW::UI::UIMessage::kAgentSpeechBubble};
+                                                 GW::UI::UIMessage::kStartWhisper,      GW::UI::UIMessage::kSendChatMessage, GW::UI::UIMessage::kAgentSpeechBubble,
+                                                 GW::UI::UIMessage::kPrintChatMessage,  GW::UI::UIMessage::kLogChatMessage};
     for (const auto message_id : ui_messages) {
         GW::UI::RegisterUIMessageCallback(&OnUIMessage_Entry, message_id, OnUIMessage);
     }
@@ -659,4 +694,10 @@ void ChatSettings::SetAfkMessage(std::wstring&& message)
     else {
         Log::Error("Afk message must be under 80 characters. (Yours is %zu)", message.size());
     }
+}
+
+void ChatSettings::SuppressChatMessageForMs(const wchar_t* encoded_substring, const size_t len, const DWORD ms)
+{
+    const DWORD expires_at = GetTickCount() + ms;
+    suppressed_messages.push_back({std::wstring(encoded_substring, len), expires_at});
 }

--- a/GWToolboxdll/Modules/ChatSettings.h
+++ b/GWToolboxdll/Modules/ChatSettings.h
@@ -84,4 +84,7 @@ public:
 
     static void AddPendingMessage(PendingChatMessage* pending_chat_message);
     static void SetAfkMessage(std::wstring&& message);
+
+    // Temporarily suppress chat messages containing the given encoded substring.
+    static void SuppressChatMessageForMs(const wchar_t* encoded_substring, size_t len, DWORD ms);
 };


### PR DESCRIPTION
`/hero guard silent`, `/hero attack Koss silent`, etc. suppress the hero behavior chat messages for 1 second after the command is issued.