### PR TITLE
Fix VQ overlay tracking pets and allegiance-changed NPCs

### DIFF
--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -496,7 +496,11 @@ namespace {
             if (!agent) continue;
             const auto living = agent->GetAsAgentLiving();
             if (!living) continue;
-            if (living->allegiance != GW::Constants::Allegiance::Enemy) continue;
+            if (living->allegiance != GW::Constants::Allegiance::Enemy) {
+                // Allegiance changed — stop tracking
+                tracked_enemies.erase(agent->agent_id);
+                continue;
+            }
             const auto npc = GW::Agents::GetNPCByID(living->player_number);
             if (npc && (npc->IsSpirit() || npc->IsMinion())) continue;
 


### PR DESCRIPTION
Remove tracked enemies when their allegiance changes away from enemy. Also exclude pets from enemy tracking.

Fixes #1785