### PR TITLE
Fix VQ overlay rendering in outpost after leaving explorable

### DIFF
--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -907,7 +907,8 @@ namespace {
         dx_device->SetScissorRect(&scissorRect);
 
         // Pass 1: static map geometry + dynamic VQ (game coords via world matrix + ortho)
-        if (static_map_geo.Any() || fog_geo.vert_count || vb.fog_count) {
+        const bool in_explorable = GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable;
+        if ((static_map_geo.Any() || fog_geo.vert_count || vb.fog_count) && show_vq_overlay && in_explorable) {
             D3DVIEWPORT9 vp;
             dx_device->GetViewport(&vp);
             const D3DMATRIX ortho = MakeOrthoProjection(static_cast<float>(vp.Width), static_cast<float>(vp.Height));


### PR DESCRIPTION
Guard pass 1 draw with explorable and show_vq_overlay checks so stale static geometry doesn't render after returning to outpost.

Steps to reproduce:

1. Enter explorable, turn on VQ overlay.
2. Set a quest market anywhere.
3. /resign
4. Back in the outpost the VQ overlay is still active.