### PR TITLE
Fix VQ overlay enemy count off by one

### DIFF
--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -719,7 +719,7 @@ namespace {
         if (!show_vq_overlay) return;
 
         int alive_count = 0, stale_count = 0;
-        for (size_t i = 0, len = highest_trackable_agent_id; i < len;i++) {
+        for (size_t i = 0, len = highest_trackable_agent_id; i <= len; i++) {
             const auto& enemy = tracked_enemies_by_agent_id[i];
             if (enemy.state == EnemyState::Alive)
                 alive_count++;


### PR DESCRIPTION
The count loop used < instead of <= for highest_trackable_agent_id, missing the last tracked enemy. The marker was drawn but not counted.