### PR TITLE
Add tracked enemy count to vanquish widget chat message

### DIFF
--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -1088,3 +1088,14 @@ void MissionMapWidget::Terminate()
         buffer->Terminate();
     }
 }
+
+void MissionMapWidget::GetTrackedEnemyCounts(int& alive, int& stale)
+{
+    alive = 0;
+    stale = 0;
+    for (size_t i = 0, len = highest_trackable_agent_id; i <= len && i < tracked_enemies_by_agent_id.size(); i++) {
+        const auto& enemy = tracked_enemies_by_agent_id[i];
+        if (enemy.state == EnemyState::Alive) alive++;
+        else if (enemy.state == EnemyState::Stale) stale++;
+    }
+}

--- a/GWToolboxdll/Widgets/MissionMapWidget.h
+++ b/GWToolboxdll/Widgets/MissionMapWidget.h
@@ -30,4 +30,6 @@ public:
     void DrawSettingsInternal() override;
     void Terminate() override;
     bool WndProc(UINT Message, WPARAM, LPARAM lParam) override;
+
+    static void GetTrackedEnemyCounts(int& alive, int& stale);
 };

--- a/GWToolboxdll/Widgets/VanquishWidget.cpp
+++ b/GWToolboxdll/Widgets/VanquishWidget.cpp
@@ -7,6 +7,7 @@
 #include <GWCA/Managers/PartyMgr.h>
 
 #include <Widgets/VanquishWidget.h>
+#include <Widgets/MissionMapWidget.h>
 
 #include "Utils/FontLoader.h"
 
@@ -55,13 +56,22 @@ void VanquishWidget::Draw(IDirect3DDevice9*)
         const ImVec2 min = ImGui::GetWindowPos();
         const ImVec2 max(min.x + size.x, min.y + size.y);
         if (ctrl_pressed && ImGui::IsMouseReleased(0) && ImGui::IsMouseHoveringRect(min, max)) {
+            int alive = 0, stale = 0;
+            MissionMapWidget::GetTrackedEnemyCounts(alive, stale);
+            const int located = alive + stale;
             char buffer[256];
-            snprintf(buffer, sizeof(buffer),
-                     "We have vanquished %lu %s! %lu %s remaining.",
-                     killed,
-                     killed == 1 ? "foe" : "foes",
-                     tokill,
-                     tokill == 1 ? "foe" : "foes");
+            if (located > 0) {
+                snprintf(buffer, sizeof(buffer),
+                         "We have vanquished %lu %s! %lu %s remaining, %d located.",
+                         killed, killed == 1 ? "foe" : "foes",
+                         tokill, tokill == 1 ? "foe" : "foes",
+                         located);
+            } else {
+                snprintf(buffer, sizeof(buffer),
+                         "We have vanquished %lu %s! %lu %s remaining.",
+                         killed, killed == 1 ? "foe" : "foes",
+                         tokill, tokill == 1 ? "foe" : "foes");
+            }
             GW::Chat::SendChat('#', buffer);
         }
     }


### PR DESCRIPTION
Ctrl-click on the vanquish widget now includes the number of located enemies from the mission map overlay, e.g. "5 foes remaining, 3 located."