### PR TITLE
Fix VQ overlay flicker when mission map pans

### DIFF
--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -111,6 +111,7 @@ namespace {
         bool valid = false;
         clock_t last_rebuild = TIMER_INIT();
 
+        float cached_basis_zoom = 0.f;
         void Rebuild(); // defined after namespace variables
 
         void Project(float gx, float gy, float& sx, float& sy) const
@@ -564,38 +565,42 @@ namespace {
     {
         valid = false;
 
+        const auto* mm_ctx = GW::Map::GetMissionMapContext();
+        if (!mm_ctx || !mm_ctx->h003c) return;
+
         const auto player_pos = GW::PlayerMgr::GetPlayerPosition();
         if (!player_pos) return;
-        auto px = player_pos->x;
-        auto py = player_pos->y;
+        const float px = player_pos->x;
+        const float py = player_pos->y;
 
-        // Derive basis vectors by sampling two nearby points.
-        // GamePosToMissionMapScreenPos goes through world map coords, and the
-        // differences cancel out any constant offset errors (e.g. underground
-        // maps where pan_offset is not in world map coordinates).
-        constexpr float STEP = 1000.f;
-        GW::Vec2f s00, s10, s01;
-        if (!GamePosToMissionMapScreenPos({px, py, 0}, s00) ||
-            !GamePosToMissionMapScreenPos({px + STEP, py, 0}, s10) ||
-            !GamePosToMissionMapScreenPos({px, py + STEP, 0}, s01)) return;
+        // Only recompute basis vectors when zoom changes — they're stable
+        // across panning. Recomputing every frame causes floating-point jitter.
+        if (mission_map_zoom != cached_basis_zoom || !valid) {
+            cached_basis_zoom = mission_map_zoom;
 
-        ax = (s10.x - s00.x) / STEP;
-        ay = (s10.y - s00.y) / STEP;
-        bx = (s01.x - s00.x) / STEP;
-        by = (s01.y - s00.y) / STEP;
+            constexpr float STEP = 1000.f;
+            GW::Vec2f s00, s10, s01;
+            if (!GamePosToMissionMapScreenPos({px, py, 0}, s00) ||
+                !GamePosToMissionMapScreenPos({px + STEP, py, 0}, s10) ||
+                !GamePosToMissionMapScreenPos({px, py + STEP, 0}, s01)) return;
+
+            ax = (s10.x - s00.x) / STEP;
+            ay = (s10.y - s00.y) / STEP;
+            bx = (s01.x - s00.x) / STEP;
+            by = (s01.y - s00.y) / STEP;
+        }
 
         // Compute origin from the player's known mission map position,
         // not from the world-map-based s00 which is wrong for underground maps.
-        const auto* mm_ctx = GW::Map::GetMissionMapContext();
-        if (!mm_ctx || !mm_ctx->h003c) return;
         const GW::Vec2f mm_pos = mm_ctx->h003c->player_mission_map_pos;
         const GW::Vec2f mm_offset = mm_pos - current_pan_offset;
         const GW::Vec2f mm_scaled = {mm_offset.x * mission_map_scale.x, mm_offset.y * mission_map_scale.y};
         const GW::Vec2f player_screen = {mm_scaled.x * mission_map_zoom + mission_map_screen_pos.x,
                                          mm_scaled.y * mission_map_zoom + mission_map_screen_pos.y};
 
-        ox = player_screen.x - px * ax - py * bx;
-        oy = player_screen.y - px * ay - py * by;
+        // Snap origin to nearest pixel to reduce sub-pixel flicker on thin lines
+        ox = roundf(player_screen.x - px * ax - py * bx);
+        oy = roundf(player_screen.y - px * ay - py * by);
         valid = true;
     }
 
@@ -805,8 +810,8 @@ namespace {
             if (!compass_circle.empty()) {
                 if (const auto* player = GW::Agents::GetControlledCharacter()) {
                     D3DMATRIX compassMatrix = gameToScreen;
-                    compassMatrix._41 = g2s.ox + player->pos.x * g2s.ax + player->pos.y * g2s.bx;
-                    compassMatrix._42 = g2s.oy + player->pos.x * g2s.ay + player->pos.y * g2s.by;
+                    compassMatrix._41 = roundf(g2s.ox + player->pos.x * g2s.ax + player->pos.y * g2s.bx);
+                    compassMatrix._42 = roundf(g2s.oy + player->pos.x * g2s.ay + player->pos.y * g2s.by);
                     dx_device->SetTransform(D3DTS_WORLD, &compassMatrix);
                     compass_circle.Render(dx_device);
                     dx_device->SetTransform(D3DTS_WORLD, &gameToScreen);

--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -69,7 +69,7 @@ namespace {
     // Used to easily terminate hanging buffers later
     D3DVertexBuffer* vertex_buffers[] = {&unexplored_area, &frontier_border, &minimap_lines, &inaccessible_area_and_borders, &enemy_vertex_buffer, &compass_circle};
 
-    constexpr float EXPLORE_CELL_SIZE = GW::Constants::Range::Adjacent;
+    constexpr float EXPLORE_CELL_SIZE = GW::Constants::Range::Adjacent / 2.f;
     constexpr size_t MAX_MAP_WIDTH = 50000;
     constexpr size_t MAX_CELLS_PER_AXIS = (size_t)(MAX_MAP_WIDTH / EXPLORE_CELL_SIZE);
 


### PR DESCRIPTION
When moving around both the radar circle and the map boundary outline would "wobble". This should fix that (or at least noticeably reduce the problem).

Also, it makes the exploration cells a bit smaller and re-introduces smoothing so the map boundary is less jagged:

Before:
<img width="812" height="805" alt="image" src="https://github.com/user-attachments/assets/11b68474-4c73-407d-8789-e6ce223ac823" />

After:
<img width="811" height="804" alt="image" src="https://github.com/user-attachments/assets/a0051ffd-050c-44db-a84a-6f38d7132cec" />
