### PR TITLE
fix: replace <> with [] in error messages

### DIFF
--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -661,13 +661,13 @@ namespace {
     }
 
 
-    constexpr auto withdraw_syntax = "'/withdraw <quantity (1-65535)> [model_id1 model_id2 ...]' tops up your inventory "
+    constexpr auto withdraw_syntax = "'/withdraw [quantity (1-65535)] [model_id1 model_id2 ...]' tops up your inventory "
         "with a minimum quantity of 1 or more items, identified by model_id\n"
-        "If no model_ids are passed, withdraws <quantity>[k] gold from storage\n"
+        "If no model_ids are passed, withdraws [quantity][k] gold from storage\n"
         "If quantity is 'all' and you do not pass model_ids, withdraws all gold you have or can hold.";
-    constexpr auto deposit_syntax = "'/deposit <quantity (1-65535)> [model_id1 model_id2 ...]' deposits <quantity> items, "
+    constexpr auto deposit_syntax = "'/deposit [quantity (1-65535)] [model_id1 model_id2 ...]' deposits [quantity] items, "
         "identified by model ids, from your inventory to your storage.\n"
-        "If no model_ids are passed, deposits <quantity>[k] gold from your inventory\n"
+        "If no model_ids are passed, deposits [quantity][k] gold from your inventory\n"
         "If quantity is 'all' and you do not pass model_ids, deposits all gold [platinum] from your inventory to your storage.";
 
     struct CmdAlias {
@@ -1169,10 +1169,10 @@ namespace {
         clock_t skill_timer = clock();
         void Update();
     } skill_to_use;
-    const char* useskill_syntax = "'/useskill <skill>' starts using the skill on recharge.\n"
-                                  "Use the skill number instead of <skill> (e.g. '/useskill 5').\n"
+    const char* useskill_syntax = "'/useskill [skill]' starts using the skill on recharge.\n"
+                                  "Use the skill number instead of [skill] (e.g. '/useskill 5').\n"
                                   "Use empty '/useskill' or '/useskill stop' to stop all.\n"
-                                  "Use '/useskill <skill>' to stop the skill.";
+                                  "Use '/useskill [skill]' to stop the skill.";
     void CHAT_CMD_FUNC(CmdUseSkill)
     {
         if (!IsMapReady() || argc < 2) {

--- a/GWToolboxdll/Windows/TradeWindow.cpp
+++ b/GWToolboxdll/Windows/TradeWindow.cpp
@@ -144,7 +144,7 @@ namespace {
     void CHAT_CMD_FUNC(CmdPricecheck)
     {
         if (argc < 2) {
-            return Log::Error("Try '/pc <item>'");
+            return Log::Error("Try '/pc [item]'");
         }
 
         std::string item_to_search;


### PR DESCRIPTION
I'm not really sure what is causing it, but it seems that using the `<arg>` syntax in these messages is causing GW to interpret it in some special way. I know the convention is `<>` for required arguments, but switching to `[]` fixes the issue, even though it usually means the argument is optional. Maybe the problem can be fixed differently I don't know.

Before with `/useskill` (no arg):

<details>
<img width="681" height="431" alt="useskill_error_1" src="https://github.com/user-attachments/assets/592b02f2-bea4-40d2-bfbe-358e3811d975" />
</details>

After with `/useskill`, `/pc`, `/withdraw` (no arg):

<details>
<img width="690" height="264" alt="useskill_error_2" src="https://github.com/user-attachments/assets/f09eaff8-5745-41e3-9079-3ba61616b675" />
</details>