### PR TITLE
Extract VQ overlay from MissionMapWidget into VanquishOverlayModule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ if(MSVC_TOOLSET_VERSION LESS 143)
     message(FATAL_ERROR "Build using Visual Studio 2022 toolset (v143) or higher. Run cmake with `-T143`. You're currently using ${MSVC_TOOLSET_VERSION}")
 endif()
 
+# Increase constexpr depth for CTRE compile-time regex library
+add_compile_options(/constexpr:depth2048 /constexpr:steps10000000)
+
 if(NOT(CMAKE_SIZEOF_VOID_P EQUAL 4))
     message(FATAL_ERROR "You are configuring a non 32-bit build, this is not supported. Run cmake with `-A Win32`")
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,7 +3,7 @@
   "configurePresets": [
     {
       "name": "vcpkg",
-      "generator": "Visual Studio 17 2022",
+      "generator": "Visual Studio 18 2026",
       "architecture": "Win32",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {

--- a/GWToolbox/Settings.cpp
+++ b/GWToolbox/Settings.cpp
@@ -24,6 +24,7 @@ void PrintUsage(const bool terminate)
             "    /localdll                  Check launcher directory for toolbox dll, won't try to install or update\n\n"
 
             "    /pid <process id>          Process id of the target in which to inject\n"
+            "    /hotreload <dll path>      Signal running toolbox to unload, copy DLL, and re-inject\n"
     );
 
     if (terminate) {
@@ -102,6 +103,15 @@ void ParseCommandLine()
         }
         else if (wcscmp(arg, L"/localdll") == 0) {
             settings.localdll = true;
+            settings.noupdate = true;
+            settings.noinstall = true;
+        }
+        else if (wcscmp(arg, L"/hotreload") == 0) {
+            if (++i == argc) {
+                fprintf(stderr, "'/hotreload' must be followed by a DLL path\n");
+                PrintUsage(true);
+            }
+            settings.hotreload_dll = argv[i];
             settings.noupdate = true;
             settings.noinstall = true;
         }

--- a/GWToolbox/Settings.h
+++ b/GWToolbox/Settings.h
@@ -13,7 +13,8 @@ struct Settings {
     bool noupdate = false;
     bool noinstall = false;
     bool localdll = false;
-    uint32_t pid;
+    uint32_t pid = 0;
+    std::wstring hotreload_dll; // path to DLL to hot-reload
 };
 
 extern Settings settings;

--- a/GWToolbox/main.cpp
+++ b/GWToolbox/main.cpp
@@ -37,6 +37,94 @@ static bool RestartAsAdminForInjection(const uint32_t target_pid)
     return RestartAsAdmin(args);
 }
 
+static bool HotReloadDll(const std::wstring& new_dll_path)
+{
+    // Find all GW processes with toolbox loaded
+    std::vector<Process> gw_processes;
+    GetProcessesByWindowClass(gw_processes, L"ArenaNet_Dx_Window_Class");
+
+    std::vector<DWORD> target_pids;
+    for (auto& proc : gw_processes) {
+        ProcessModule module;
+        if (proc.GetModule(&module, L"GWToolboxdll.dll")) {
+            target_pids.push_back(proc.GetProcessId());
+        }
+    }
+    gw_processes.clear(); // Close handles so DLL can unload
+
+    if (!target_pids.empty()) {
+        // Signal all instances to unload (manual-reset event, all instances see it)
+        HANDLE event = OpenEventA(EVENT_MODIFY_STATE, FALSE, "GWToolboxHotReload");
+        if (!event) {
+            fprintf(stderr, "Could not open GWToolboxHotReload event (error %lu)\n", GetLastError());
+            return false;
+        }
+        if (!SetEvent(event)) {
+            fprintf(stderr, "SetEvent failed (error %lu)\n", GetLastError());
+            CloseHandle(event);
+            return false;
+        }
+
+        // Wait for all instances to unload
+        bool unloaded = false;
+        for (int i = 0; i < 300; i++) { // up to 30 seconds
+            Sleep(100);
+            bool all_unloaded = true;
+            for (const auto pid : target_pids) {
+                Process proc;
+                if (!proc.Open(pid, PROCESS_QUERY_INFORMATION | PROCESS_VM_READ)) continue;
+                ProcessModule check;
+                if (proc.GetModule(&check, L"GWToolboxdll.dll")) {
+                    all_unloaded = false;
+                    break;
+                }
+            }
+            if (all_unloaded) { unloaded = true; break; }
+        }
+        ResetEvent(event);
+        CloseHandle(event);
+        if (!unloaded) {
+            fprintf(stderr, "Timeout waiting for DLLs to unload\n");
+            return false;
+        }
+        Sleep(200); // Brief pause to ensure file handles are released
+    }
+
+    // Determine install path and copy the new DLL
+    std::filesystem::path install_dll = GetInstallationDir();
+    if (install_dll.empty()) {
+        fprintf(stderr, "GetInstallationDir failed\n");
+        return false;
+    }
+    install_dll = install_dll.parent_path() / L"GWToolboxdll.dll";
+
+    std::error_code ec;
+    std::filesystem::copy_file(new_dll_path, install_dll,
+        std::filesystem::copy_options::overwrite_existing, ec);
+    if (ec) {
+        fprintf(stderr, "Failed to copy DLL: %s\n", ec.message().c_str());
+        return false;
+    }
+
+    // Re-inject into all processes
+    bool any_failed = false;
+    for (const auto pid : target_pids) {
+        Process proc;
+        if (!proc.Open(pid)) {
+            any_failed = true;
+            continue;
+        }
+        DWORD exit_code;
+        if (!InjectRemoteThread(&proc, install_dll.wstring().c_str(), &exit_code)) {
+            fprintf(stderr, "Re-injection into process %lu failed\n", pid);
+            any_failed = true;
+            continue;
+        }
+    }
+
+    return !any_failed;
+}
+
 static bool InjectInstalledDllInProcess(const Process* process, std::wstring& error)
 {
     std::wstring exe_filename;
@@ -156,6 +244,13 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int n
     AsyncRestScopeInit RestInitializer;
 
     Process proc;
+    if (!settings.hotreload_dll.empty()) {
+        if (!HotReloadDll(settings.hotreload_dll)) {
+            fprintf(stderr, "Hot reload failed\n");
+            return 1;
+        }
+        return 0;
+    }
     if (settings.install) {
         Install(settings.quiet, error);
         return 0;

--- a/GWToolboxdll/D3DContainers.cpp
+++ b/GWToolboxdll/D3DContainers.cpp
@@ -315,3 +315,14 @@ void D3DLineCircle::SetRadius(float r)
     vertices[n] = vertices[0];
     dirty = true;
 }
+
+D3DMATRIX MakeOrthoProjection(float w, float h)
+{
+    D3DMATRIX m = {{
+         2.f/w,   0.f,  0.f, 0.f,
+          0.f,  -2.f/h, 0.f, 0.f,
+          0.f,   0.f,  1.f, 0.f,
+         -1.f,   1.f,  0.f, 1.f
+    }};
+    return m;
+}

--- a/GWToolboxdll/D3DContainers.h
+++ b/GWToolboxdll/D3DContainers.h
@@ -134,6 +134,22 @@ public:
     void SetCenterColor(DWORD c);
     void SetRadius(float r);
 };
+struct D3DStateGuard {
+    IDirect3DStateBlock9* block = nullptr;
+    explicit D3DStateGuard(IDirect3DDevice9* dev) { dev->CreateStateBlock(D3DSBT_ALL, &block); }
+    ~D3DStateGuard()
+    {
+        if (block) {
+            block->Apply();
+            block->Release();
+        }
+    }
+    D3DStateGuard(const D3DStateGuard&) = delete;
+    D3DStateGuard& operator=(const D3DStateGuard&) = delete;
+};
+
+D3DMATRIX MakeOrthoProjection(float w, float h);
+
 class D3DLineCircle : public D3DVertexBuffer {
 public:
     D3DLineCircle(float radius = 10.f, DWORD color = 0xffffffff, int segments = 64);

--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -64,6 +64,8 @@ namespace {
     bool must_self_destruct = false; // is true when toolbox should quit
     GW::HookEntry Update_Entry;
 
+    HANDLE hot_reload_event = nullptr;
+
     std::recursive_mutex module_management_mutex;
 
 
@@ -728,6 +730,11 @@ DWORD __stdcall GWToolbox::MainLoop(LPVOID module) noexcept
         Sleep(160);
 
         UnloadGWCADll();
+
+        if (hot_reload_event) {
+            CloseHandle(hot_reload_event);
+            hot_reload_event = nullptr;
+        }
     } __except (EXCEPT_EXPRESSION_ENTRY) {
         Log::Log("SafeThreadEntry __except body\n");
     }
@@ -761,6 +768,10 @@ void GWToolbox::Initialize(LPVOID module)
     UpdateInitialising(.0f);
     AttachGameLoopCallback();
     pending_detach_dll = false;
+
+    if (!hot_reload_event) {
+        hot_reload_event = CreateEventA(nullptr, TRUE, FALSE, "GWToolboxHotReload");
+    }
 }
 
 std::filesystem::path GWToolbox::LoadSettings()
@@ -934,6 +945,13 @@ void GWToolbox::Update(GW::HookStatus*)
             break;
         default:
             return;
+    }
+
+    // Check for hot reload signal
+    if (hot_reload_event && WaitForSingleObject(hot_reload_event, 0) == WAIT_OBJECT_0) {
+        Log::Info("Hot reload requested, unloading...");
+        SignalTerminate();
+        return;
     }
 
     UpdateModulesTerminating(delta_f);

--- a/GWToolboxdll/Modules/QuestModule.cpp
+++ b/GWToolboxdll/Modules/QuestModule.cpp
@@ -588,6 +588,11 @@ void QuestModule::SetCustomQuestMarker(const GW::Vec2f& world_pos, bool set_acti
     RefreshQuestPath(custom_quest_id);
 }
 
+void QuestModule::ClearCustomQuestMarker()
+{
+    SetCustomQuestMarker({0, 0});
+}
+
 std::vector<QuestObjective> QuestModule::ParseQuestObjectives(GW::Constants::QuestID quest_id)
 {
     const auto quest = GW::QuestMgr::GetQuest(quest_id);

--- a/GWToolboxdll/Modules/QuestModule.cpp
+++ b/GWToolboxdll/Modules/QuestModule.cpp
@@ -39,6 +39,8 @@ namespace {
 
     bool fetch_missing_quest_info_queued = false;
 
+    std::vector<QuestModule::CustomMarkerChangedCallback> custom_marker_callbacks;
+
     GW::HookEntry pre_ui_message_entry;
     GW::HookEntry post_ui_message_entry;
     bool initialised = false;
@@ -528,8 +530,10 @@ void QuestModule::SetCustomQuestMarker(const GW::Vec2f& world_pos, bool set_acti
         GW::StoC::EmulatePacket(&quest_remove_packet);
         memset(&custom_quest_marker, 0, sizeof(custom_quest_marker));
     }
-    if (custom_quest_marker_world_pos.x == 0 && custom_quest_marker_world_pos.y == 0)
+    if (custom_quest_marker_world_pos.x == 0 && custom_quest_marker_world_pos.y == 0) {
+        for (const auto& cb : custom_marker_callbacks) cb();
         return;
+    }
 
     setting_custom_quest_marker = true;
 
@@ -586,12 +590,16 @@ void QuestModule::SetCustomQuestMarker(const GW::Vec2f& world_pos, bool set_acti
     if (set_active)
         GW::QuestMgr::SetActiveQuestId(custom_quest_id);
     RefreshQuestPath(custom_quest_id);
+    for (const auto& cb : custom_marker_callbacks) cb();
 }
 
 void QuestModule::ClearCustomQuestMarker()
 {
     SetCustomQuestMarker({0, 0});
 }
+
+void QuestModule::AddCustomMarkerChangedCallback(CustomMarkerChangedCallback cb) { custom_marker_callbacks.push_back(cb); }
+void QuestModule::RemoveCustomMarkerChangedCallback(CustomMarkerChangedCallback cb) { std::erase(custom_marker_callbacks, cb); }
 
 std::vector<QuestObjective> QuestModule::ParseQuestObjectives(GW::Constants::QuestID quest_id)
 {

--- a/GWToolboxdll/Modules/QuestModule.h
+++ b/GWToolboxdll/Modules/QuestModule.h
@@ -66,6 +66,7 @@ public:
     static const GW::Quest* GetCustomQuestMarker();
 
     static void SetCustomQuestMarker(const GW::Vec2f& world_pos, bool set_active = false);
+    static void ClearCustomQuestMarker();
     // Fake an action of the user selecting an active quest, without making any server request.
     static bool SetActiveQuestId(GW::Constants::QuestID quest_id, bool notify_server = true);
 

--- a/GWToolboxdll/Modules/QuestModule.h
+++ b/GWToolboxdll/Modules/QuestModule.h
@@ -67,6 +67,11 @@ public:
 
     static void SetCustomQuestMarker(const GW::Vec2f& world_pos, bool set_active = false);
     static void ClearCustomQuestMarker();
+
+    // Callback fired when the custom quest marker is set or cleared.
+    using CustomMarkerChangedCallback = void(*)();
+    static void AddCustomMarkerChangedCallback(CustomMarkerChangedCallback cb);
+    static void RemoveCustomMarkerChangedCallback(CustomMarkerChangedCallback cb);
     // Fake an action of the user selecting an active quest, without making any server request.
     static bool SetActiveQuestId(GW::Constants::QuestID quest_id, bool notify_server = true);
 

--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -40,6 +40,7 @@
 #include <Modules/GamepadModule.h>
 #include <Modules/CameraUnlockModule.h>
 #include <Modules/LoginModule.h>
+#include <Widgets/VanquishMapOverlayWidget.h>
 
 #include <Windows/PconsWindow.h>
 #include <Windows/HotkeysWindow.h>
@@ -161,6 +162,7 @@ namespace {
         ItemTooltipModule::Instance(),
         ResignLogModule::Instance(),
         QuestModule::Instance(),
+        VanquishMapOverlayWidget::Instance(),
         PartyBroadcast::Instance(),
         CodeOptimiserModule::Instance(),
 #if 0

--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -22,6 +22,8 @@ namespace {
     bool draw_all_terrain_lines = false;
     bool draw_all_minimap_lines = true;
 
+    std::vector<MissionMapWidget::DrawCallback> draw_callbacks;
+
     // Pixel-to-game-unit scale — converts pixel thickness to game units
     float cached_px_to_game = 1.f;
 
@@ -243,6 +245,10 @@ namespace {
         dx_device->SetTransform(D3DTS_PROJECTION, &ortho);
 
         minimap_lines.Render(dx_device);
+
+        for (const auto& cb : draw_callbacks) {
+            cb(dx_device);
+        }
     }
 
     void EnqueueMinimapLines(GW::Constants::MapID map_id)
@@ -347,3 +353,6 @@ GW::Vec2f MissionMapWidget::GetBottomRight() { return mission_map_bottom_right; 
 GW::UI::Frame* MissionMapWidget::GetFrame() { return mission_map_frame; }
 float MissionMapWidget::GetPxToGame() { return cached_px_to_game; }
 float MissionMapWidget::GetZoom() { return mission_map_zoom; }
+
+void MissionMapWidget::AddDrawCallback(DrawCallback cb) { draw_callbacks.push_back(cb); }
+void MissionMapWidget::RemoveDrawCallback(DrawCallback cb) { std::erase(draw_callbacks, cb); }

--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -10,7 +10,6 @@
 
 #include <ImGuiAddons.h>
 #include <Modules/QuestModule.h>
-#include <Widgets/VanquishMapOverlayWidget.h>
 #include <Widgets/Minimap/Minimap.h>
 #include <Widgets/MissionMapWidget.h>
 #include <Widgets/WorldMapWidget.h>
@@ -23,6 +22,7 @@ namespace {
     bool draw_all_minimap_lines = true;
 
     std::vector<MissionMapWidget::DrawCallback> draw_callbacks;
+    std::vector<MissionMapWidget::ContextMenuCallback> context_menu_callbacks;
 
     // Pixel-to-game-unit scale — converts pixel thickness to game units
     float cached_px_to_game = 1.f;
@@ -199,19 +199,20 @@ namespace {
         }
 #endif
         if (ImGui::Button("Place Marker")) {
-            VanquishMapOverlayWidget::StopNavigating();
             GW::GameThread::Enqueue([] {
                 QuestModule::SetCustomQuestMarker(world_map_click_pos, true);
             });
             return false;
         }
-        if (QuestModule::GetCustomQuestMarker() && !VanquishMapOverlayWidget::IsNavigating()) {
+        if (QuestModule::GetCustomQuestMarker()) {
             if (ImGui::Button("Remove Marker")) {
                 GW::GameThread::Enqueue([] { QuestModule::ClearCustomQuestMarker(); });
                 return false;
             }
         }
-        if (!VanquishMapOverlayWidget::ContextMenuItems()) return false;
+        for (const auto& cb : context_menu_callbacks) {
+            if (!cb()) return false;
+        }
 
         return true;
     }
@@ -356,3 +357,5 @@ float MissionMapWidget::GetZoom() { return mission_map_zoom; }
 
 void MissionMapWidget::AddDrawCallback(DrawCallback cb) { draw_callbacks.push_back(cb); }
 void MissionMapWidget::RemoveDrawCallback(DrawCallback cb) { std::erase(draw_callbacks, cb); }
+void MissionMapWidget::AddContextMenuCallback(ContextMenuCallback cb) { context_menu_callbacks.push_back(cb); }
+void MissionMapWidget::RemoveContextMenuCallback(ContextMenuCallback cb) { std::erase(context_menu_callbacks, cb); }

--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -2,8 +2,6 @@
 
 #include <GWCA/Context/GameplayContext.h>
 #include <GWCA/GameEntities/Agent.h>
-#include <GWCA/GameEntities/NPC.h>
-#include <GWCA/GameEntities/Pathing.h>
 #include <GWCA/Managers/AgentMgr.h>
 #include <GWCA/Managers/GameThreadMgr.h>
 #include <GWCA/Managers/MapMgr.h>
@@ -12,6 +10,7 @@
 
 #include <ImGuiAddons.h>
 #include <Modules/QuestModule.h>
+#include <Widgets/VanquishMapOverlayWidget.h>
 #include <Widgets/Minimap/Minimap.h>
 #include <Widgets/MissionMapWidget.h>
 #include <Widgets/WorldMapWidget.h>
@@ -19,126 +18,17 @@
 #include <GWCA/Context/WorldContext.h>
 #include <D3DContainers.h>
 
-
-
 namespace {
     bool draw_all_terrain_lines = false;
     bool draw_all_minimap_lines = true;
-    bool show_vq_overlay = false; // master toggle for all VQ features on mission map
-    bool show_vq_toggle_button = true;
-
-    // VQ overlay colours — configurable via settings
-    Color vq_color_inaccessible = IM_COL32(0, 0, 0, 190);
-    Color vq_color_fog_unexplored = IM_COL32(0, 0, 0, 140);
-    Color vq_color_border = IM_COL32(200, 220, 255, 160);
-    Color vq_color_frontier = IM_COL32(255, 200, 50, 200);
-    Color vq_color_compass = IM_COL32(180, 220, 255, 100);
-    Color vq_color_enemy_alive = IM_COL32(70, 130, 255, 255);
-    Color vq_color_enemy_stale = IM_COL32(255, 180, 50, 180);
-    Color vq_color_enemy_outline = IM_COL32(0, 0, 0, 200);
-    float vq_enemy_marker_size = 9.0f;
-
-    // Enemy tracking for VQ assistance
-
-    enum class EnemyState { NotApplicable, Alive, Stale };
-    struct TrackedEnemy {
-        GW::Vec2f pos;
-        float rotation = 0.f; // last known movement direction
-        EnemyState state = EnemyState::NotApplicable;
-    };
-    std::vector<TrackedEnemy> tracked_enemies_by_agent_id; // agent_id -> tracked enemy
-    size_t highest_trackable_agent_id = 0;
-
-    GW::Constants::MapID tracked_enemies_map_id = static_cast<GW::Constants::MapID>(0);
-    GW::Constants::InstanceType tracked_enemies_instance_type = GW::Constants::InstanceType::Loading;
-
-    constexpr float TWO_PI = 6.2831853f;
-    constexpr float COMPASS_RANGE = GW::Constants::Range::Compass;
-    constexpr float STALE_CHECK_RANGE = COMPASS_RANGE * 0.9f;
-
-    bool should_draw_vq_overlay = false;
 
     // Pixel-to-game-unit scale — converts pixel thickness to game units
     float cached_px_to_game = 1.f;
 
-class D3DFogBuffer : public D3DTriangleBuffer {
-    public:
-        static constexpr size_t VERTS_PER_CELL = sizeof(D3DQuad) / sizeof(D3DVertex);
+    bool render_ready = false;
+    D3DMATRIX cached_game_to_screen = {};
 
-        std::vector<int> walkable_cell_index; // flat grid index → sequential walkable index, or -1
-
-        void Build(int grid_w, int grid_h, const bool* walkable)
-        {
-            clear();
-            walkable_cell_index.assign(grid_w * grid_h, -1);
-            int walkable_count = 0;
-            for (int i = 0; i < grid_w * grid_h; i++) {
-                if (!walkable[i]) continue;
-                walkable_cell_index[i] = walkable_count++;
-            }
-            vertices.reserve(walkable_count * VERTS_PER_CELL);
-            dirty = true;
-        }
-
-        // grid_idx is the flat grid index (ly * grid_w + lx)
-        void SetCellColor(int grid_idx, DWORD color)
-        {
-            if (grid_idx < 0 || grid_idx >= static_cast<int>(walkable_cell_index.size())) return;
-            const int wi = walkable_cell_index[grid_idx];
-            if (wi < 0) return;
-            const size_t off = static_cast<size_t>(wi) * VERTS_PER_CELL;
-            if (vertices[off].color == color) return;
-            for (size_t v = 0; v < VERTS_PER_CELL; v++)
-                vertices[off + v].color = color;
-            dirty = true;
-        }
-    };
-
-
-
-    D3DFogBuffer fog_buffer;
-    D3DTriangleBuffer frontier_border;
     D3DTriangleBuffer minimap_lines;
-    D3DTriangleBuffer inaccessible_area_and_borders;
-    D3DTriangleBuffer enemy_vertex_buffer;
-    D3DCircle compass_circle;
-    D3DVertexBuffer* vertex_buffers[] = {&fog_buffer, &frontier_border, &minimap_lines, &inaccessible_area_and_borders, &enemy_vertex_buffer, &compass_circle};
-
-    constexpr float EXPLORE_CELL_SIZE = GW::Constants::Range::Adjacent / 2.f;
-    constexpr size_t MAX_MAP_WIDTH = 50000;
-    constexpr size_t MAX_CELLS_PER_AXIS = (size_t)(MAX_MAP_WIDTH / EXPLORE_CELL_SIZE);
-
-    // Exploration tracking (fog of war)
-    
-    bool* explored_cells = nullptr; // parallel to cached_walkable_grid, same dimensions
-    GW::Constants::MapID explored_map_id = static_cast<GW::Constants::MapID>(0);
-    GW::Constants::InstanceType explored_instance_type = GW::Constants::InstanceType::Loading;
-
-    struct BorderSegment {
-        GW::Vec2f p1, p2;
-    };
-
-    std::vector<BorderSegment> cached_border_segments;
-
-    // Static cached circle — built once per map/zoom change, centred on game origin
-    constexpr int COMPASS_CIRCLE_SEGMENTS = 64;
-    constexpr float COMPASS_CIRCLE_THICKNESS_PX = 0.5f;
-
-
-    bool* cached_walkable_grid = nullptr;
-    int cached_walkable_grid_size = 0;
-
-    int cached_grid_x0 = 0, cached_grid_y0 = 0, cached_grid_w = 0, cached_grid_h = 0;
-    GW::Constants::MapID border_map_id = static_cast<GW::Constants::MapID>(0);
-    float border_cached_zoom = 0.0f; // zoom level used when static geometry was last built
-
-        // Returns true if the cell at flat local grid index `idx` is walkable and explored,
-    // making the shared edge a frontier border. Caller is responsible for bounds checking.
-    bool IsFrontierEdge(int idx)
-    {
-        if (!explored_cells) return false;
-        return explored_cells[idx];
-    }
 
     const D3DMATRIX IDENTITY_MATRIX = {{1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f}};
 
@@ -152,7 +42,7 @@ class D3DFogBuffer : public D3DTriangleBuffer {
         clock_t last_rebuild = TIMER_INIT();
 
         float cached_basis_zoom = 0.f;
-        void Rebuild(); // defined after namespace variables
+        void Rebuild();
 
         void Project(float gx, float gy, float& sx, float& sy) const
         {
@@ -160,510 +50,6 @@ class D3DFogBuffer : public D3DTriangleBuffer {
             sy = oy + gx * ay + gy * by;
         }
     } g2s;
-
-
-    // Returns the flat index into cached_walkable_grid / explored_cells for
-    // a given absolute grid coord, or -1 if out of bounds.
-    int GetCellIndex(int gx, int gy)
-    {
-        const int lx = gx - cached_grid_x0;
-        const int ly = gy - cached_grid_y0;
-        if (lx < 0 || lx >= cached_grid_w || ly < 0 || ly >= cached_grid_h) return -1;
-        return ly * cached_grid_w + lx;
-    }
-
-    bool IsCellExplored(int gx, int gy)
-    {
-        if (!explored_cells) return false;
-        const int idx = GetCellIndex(gx, gy);
-        return idx >= 0 && explored_cells[idx];
-    }
-
-    bool UpdateExploration(const GW::GamePos* player_pos)
-    {
-        static GW::GamePos last_check = {};
-        if (!player_pos || GW::GetSquareDistance(last_check, *player_pos) < GW::Constants::SqrRange::Adjacent) return false;
-        last_check = *player_pos;
-
-        const auto map_id = GW::Map::GetMapID();
-        const auto instance_type = GW::Map::GetInstanceType();
-        if (map_id != explored_map_id || instance_type != explored_instance_type) {
-            delete[] explored_cells;
-            explored_cells = nullptr;
-            explored_map_id = map_id;
-            explored_instance_type = instance_type;
-        }
-
-        if (!explored_cells && cached_walkable_grid_size > 0) explored_cells = new bool[cached_walkable_grid_size]();
-        if (!explored_cells) return false;
-
-        bool any_new = false;
-        constexpr int range_cells = static_cast<int>(COMPASS_RANGE / EXPLORE_CELL_SIZE) + 1;
-        const int player_cx = static_cast<int>(floorf(player_pos->x / EXPLORE_CELL_SIZE));
-        const int player_cy = static_cast<int>(floorf(player_pos->y / EXPLORE_CELL_SIZE));
-        constexpr float range_sq = COMPASS_RANGE * COMPASS_RANGE;
-
-        for (int dy = -range_cells; dy <= range_cells; dy++) {
-            for (int dx = -range_cells; dx <= range_cells; dx++) {
-                const int gx = player_cx + dx;
-                const int gy = player_cy + dy;
-                const float cell_center_x = (gx + 0.5f) * EXPLORE_CELL_SIZE;
-                const float cell_center_y = (gy + 0.5f) * EXPLORE_CELL_SIZE;
-                const float ddx = cell_center_x - player_pos->x;
-                const float ddy = cell_center_y - player_pos->y;
-                if (ddx * ddx + ddy * ddy > range_sq) continue;
-                const int idx = GetCellIndex(gx, gy);
-                if (idx >= 0 && !explored_cells[idx]) {
-                    explored_cells[idx] = true;
-                    fog_buffer.SetCellColor(idx, 0x00000000);
-                    any_new = true;
-                }
-            }
-        }
-        return any_new;
-    }
-
-    void InitFogBuffer()
-    {
-        frontier_border.clear();
-        fog_buffer.clear();
-        if (!cached_walkable_grid || cached_walkable_grid_size <= 0) return;
-
-        const float grid_origin_x = cached_grid_x0 * EXPLORE_CELL_SIZE;
-        const float grid_origin_y = cached_grid_y0 * EXPLORE_CELL_SIZE;
-
-        fog_buffer.Build(cached_grid_w, cached_grid_h, cached_walkable_grid);
-
-        for (int ly = 0; ly < cached_grid_h; ly++) {
-            for (int lx = 0; lx < cached_grid_w; lx++) {
-                const int idx = ly * cached_grid_w + lx;
-                if (!cached_walkable_grid[idx]) continue;
-                const float x0 = grid_origin_x + lx * EXPLORE_CELL_SIZE;
-                const float y0 = grid_origin_y + ly * EXPLORE_CELL_SIZE;
-                fog_buffer.push_back(D3DQuad({x0, y0}, {x0 + EXPLORE_CELL_SIZE, y0 + EXPLORE_CELL_SIZE}, vq_color_fog_unexplored));
-            }
-        }
-    }
-
-    void UpdateFogBuffer(const GW::GamePos* player_pos)
-    {
-        if (!explored_cells || !cached_walkable_grid || !player_pos) return;
-        if (fog_buffer.walkable_cell_index.empty()) return;
-
-        const float FRONTIER_HALF_THICKNESS = cached_px_to_game;
-        const float grid_origin_x = cached_grid_x0 * EXPLORE_CELL_SIZE;
-        const float grid_origin_y = cached_grid_y0 * EXPLORE_CELL_SIZE;
-
-        // Patch fog quads within dirty window only
-        constexpr int RANGE_CELLS = static_cast<int>(COMPASS_RANGE / EXPLORE_CELL_SIZE) + 1;
-        const int pcx = static_cast<int>(floorf(player_pos->x / EXPLORE_CELL_SIZE)) - cached_grid_x0;
-        const int pcy = static_cast<int>(floorf(player_pos->y / EXPLORE_CELL_SIZE)) - cached_grid_y0;
-        const int lx0 = std::max(0, pcx - RANGE_CELLS);
-        const int lx1 = std::min(cached_grid_w, pcx + RANGE_CELLS + 1);
-        const int ly0 = std::max(0, pcy - RANGE_CELLS);
-        const int ly1 = std::min(cached_grid_h, pcy + RANGE_CELLS + 1);
-
-        for (int ly = ly0; ly < ly1; ly++) {
-            const int row_base = ly * cached_grid_w;
-            for (int lx = lx0; lx < lx1; lx++) {
-                const int idx = row_base + lx;
-                if (!cached_walkable_grid[idx]) continue;
-                if (explored_cells[idx]) fog_buffer.SetCellColor(idx, 0x00000000);
-            }
-        }
-
-        // Frontier border — full rebuild, explored edges can be anywhere on the map
-        frontier_border.clear();
-        for (int ly = 0; ly < cached_grid_h; ly++) {
-            const float wy0 = grid_origin_y + (cached_grid_y0 + ly) * EXPLORE_CELL_SIZE;
-            const float wy1 = wy0 + EXPLORE_CELL_SIZE;
-            const int row_base = ly * cached_grid_w;
-            for (int lx = 0; lx < cached_grid_w; lx++) {
-                const int idx = row_base + lx;
-                if (!cached_walkable_grid[idx] || explored_cells[idx]) continue;
-                const float wx0 = grid_origin_x + (cached_grid_x0 + lx) * EXPLORE_CELL_SIZE;
-                const float wx1 = wx0 + EXPLORE_CELL_SIZE;
-                const auto edge = [&](bool cond, int neighbour_idx, float ax, float ay, float bx, float by) {
-                    if (cond && IsFrontierEdge(neighbour_idx)) frontier_border.push_back(D3DLine({ax, ay}, {bx, by}, FRONTIER_HALF_THICKNESS, vq_color_frontier));
-                };
-                edge(ly > 0, idx - cached_grid_w, wx0, wy0, wx1, wy0);
-                edge(ly < cached_grid_h - 1, idx + cached_grid_w, wx0, wy1, wx1, wy1);
-                edge(lx > 0, idx - 1, wx0, wy0, wx0, wy1);
-                edge(lx < cached_grid_w - 1, idx + 1, wx1, wy0, wx1, wy1);
-            }
-        }
-    }
-
-    void RebuildFrontierBorder()
-    {
-        frontier_border.clear();
-        if (!explored_cells || !cached_walkable_grid) return;
-
-        const float FRONTIER_HALF_THICKNESS = cached_px_to_game;
-        const float grid_origin_x = cached_grid_x0 * EXPLORE_CELL_SIZE;
-        const float grid_origin_y = cached_grid_y0 * EXPLORE_CELL_SIZE;
-
-
-        for (int ly = 0; ly < cached_grid_h; ly++) {
-            const float wy0 = grid_origin_y + ly * EXPLORE_CELL_SIZE;
-            const float wy1 = wy0 + EXPLORE_CELL_SIZE;
-            const int row_base = ly * cached_grid_w;
-            for (int lx = 0; lx < cached_grid_w; lx++) {
-                const int idx = row_base + lx;
-                if (!cached_walkable_grid[idx] || explored_cells[idx]) continue;
-                const float wx0 = grid_origin_x + lx * EXPLORE_CELL_SIZE;
-                const float wx1 = wx0 + EXPLORE_CELL_SIZE;
-                const auto edge = [&](bool cond, int neighbour_idx, float ax, float ay, float bx, float by) {
-                    if (cond && IsFrontierEdge(neighbour_idx)) frontier_border.push_back(D3DLine({ax, ay}, {bx, by}, FRONTIER_HALF_THICKNESS, vq_color_frontier));
-                };
-                edge(ly > 0, idx - cached_grid_w, wx0, wy0, wx1, wy0);
-                edge(ly < cached_grid_h - 1, idx + cached_grid_w, wx0, wy1, wx1, wy1);
-                edge(lx > 0, idx - 1, wx0, wy0, wx0, wy1);
-                edge(lx < cached_grid_w - 1, idx + 1, wx1, wy0, wx1, wy1);
-            }
-        }
-    }
-
-    bool IsGridCellWalkable(int gx, int gy)
-    {
-        const int idx = GetCellIndex(gx, gy);
-        return idx >= 0 && cached_walkable_grid[idx];
-    }
-
-    bool IsCellWalkableInTrapezoid(int gx, int gy, const GW::PathingTrapezoid& trap)
-    {
-        const float cx0 = gx * EXPLORE_CELL_SIZE;
-        const float cy0 = gy * EXPLORE_CELL_SIZE;
-        const float cx1 = cx0 + EXPLORE_CELL_SIZE;
-        const float cy1 = cy0 + EXPLORE_CELL_SIZE;
-
-        if (cy1 <= trap.YB || cy0 >= trap.YT) return false;
-        const float y_lo = std::max(cy0, trap.YB);
-        const float y_hi = std::min(cy1, trap.YT);
-        const float height = trap.YT - trap.YB;
-        if (height < 0.001f) return cx1 > std::min(trap.XBL, trap.XTL) && cx0 < std::max(trap.XBR, trap.XTR);
-
-        const float t_lo = (y_lo - trap.YB) / height;
-        const float t_hi = (y_hi - trap.YB) / height;
-        const float left = std::min(trap.XBL + t_lo * (trap.XTL - trap.XBL), trap.XBL + t_hi * (trap.XTL - trap.XBL));
-        const float right = std::max(trap.XBR + t_lo * (trap.XTR - trap.XBR), trap.XBR + t_hi * (trap.XTR - trap.XBR));
-        return cx1 > left && cx0 < right;
-    }
-
-    void OnMinimapZoomChanged() {
-        
-    }
-
-    void BuildStaticMapGeometry()
-    {
-        const float border_thickness_game = cached_px_to_game;
-        const float gx0 = cached_grid_x0 * EXPLORE_CELL_SIZE;
-        const float gy0 = cached_grid_y0 * EXPLORE_CELL_SIZE;
-        const float gx1 = (cached_grid_x0 + cached_grid_w) * EXPLORE_CELL_SIZE;
-        const float gy1 = (cached_grid_y0 + cached_grid_h) * EXPLORE_CELL_SIZE;
-        const float ext = std::max(gx1 - gx0, gy1 - gy0) * 5.0f;
-
-        inaccessible_area_and_borders.clear();
-
-        // 4 strips covering everything outside the grid
-        inaccessible_area_and_borders.push_back(D3DQuad({gx0 - ext, gy0 - ext}, {gx1 + ext, gy0}, vq_color_inaccessible));
-        inaccessible_area_and_borders.push_back(D3DQuad({gx0 - ext, gy1}, {gx1 + ext, gy1 + ext}, vq_color_inaccessible));
-        inaccessible_area_and_borders.push_back(D3DQuad({gx0 - ext, gy0}, {gx0, gy1}, vq_color_inaccessible));
-        inaccessible_area_and_borders.push_back(D3DQuad({gx1, gy0}, {gx1 + ext, gy1}, vq_color_inaccessible));
-
-        // merge horizontally-adjacent inaccessible cells into single quads per row
-        for (int gy = cached_grid_y0; gy < cached_grid_y0 + cached_grid_h; gy++) {
-            const float y0 = gy * EXPLORE_CELL_SIZE;
-            const float y1 = y0 + EXPLORE_CELL_SIZE;
-            int run_start = -1;
-            for (int gx = cached_grid_x0; gx < cached_grid_x0 + cached_grid_w; gx++) {
-                if (!IsGridCellWalkable(gx, gy)) {
-                    if (run_start == -1) run_start = gx; // start a new run
-                }
-                else {
-                    if (run_start != -1) {
-                        // flush run
-                        inaccessible_area_and_borders.push_back(D3DQuad({run_start * EXPLORE_CELL_SIZE, y0}, {gx * EXPLORE_CELL_SIZE, y1}, vq_color_inaccessible));
-                        run_start = -1;
-                    }
-                }
-            }
-            if (run_start != -1) {
-                // flush run at end of row
-                inaccessible_area_and_borders.push_back(D3DQuad({run_start * EXPLORE_CELL_SIZE, y0}, {(cached_grid_x0 + cached_grid_w) * EXPLORE_CELL_SIZE, y1}, vq_color_inaccessible));
-            }
-        }
-
-        for (const auto& seg : cached_border_segments)
-            inaccessible_area_and_borders.push_back(D3DLine(seg.p1, seg.p2, border_thickness_game, vq_color_border));
-
-
-    }
-
-    void RebuildMapBorder()
-    {
-        cached_border_segments.clear();
-        delete[] cached_walkable_grid;
-        cached_walkable_grid = nullptr;
-        cached_walkable_grid_size = 0;
-        delete[] explored_cells;
-        explored_cells = nullptr;
-        explored_map_id = static_cast<GW::Constants::MapID>(0);
-
-        const auto pathing_map = GW::Map::GetPathingMap();
-        if (!pathing_map) return;
-
-        std::vector<const GW::PathingTrapezoid*> traps;
-        float min_x = FLT_MAX, min_y = FLT_MAX, max_x = -FLT_MAX, max_y = -FLT_MAX;
-        for (size_t p = 0; p < pathing_map->size(); p++) {
-            const auto& plane = pathing_map->at(p);
-            for (uint32_t t = 0; t < plane.trapezoid_count; t++) {
-                const auto& trap = plane.trapezoids[t];
-                traps.push_back(&trap);
-                min_x = std::min({min_x, trap.XTL, trap.XTR, trap.XBL, trap.XBR});
-                max_x = std::max({max_x, trap.XTL, trap.XTR, trap.XBL, trap.XBR});
-                min_y = std::min(min_y, trap.YB);
-                max_y = std::max(max_y, trap.YT);
-            }
-        }
-        if (traps.empty()) return;
-
-        cached_grid_x0 = static_cast<int>(floorf(min_x / EXPLORE_CELL_SIZE)) - 1;
-        cached_grid_y0 = static_cast<int>(floorf(min_y / EXPLORE_CELL_SIZE)) - 1;
-        cached_grid_w = static_cast<int>(ceilf(max_x / EXPLORE_CELL_SIZE)) + 1 - cached_grid_x0;
-        cached_grid_h = static_cast<int>(ceilf(max_y / EXPLORE_CELL_SIZE)) + 1 - cached_grid_y0;
-
-        cached_walkable_grid_size = cached_grid_w * cached_grid_h;
-        cached_walkable_grid = new bool[cached_walkable_grid_size]();
-
-        for (const auto* trap : traps) {
-            const int ty0 = std::max(0, static_cast<int>(floorf(trap->YB / EXPLORE_CELL_SIZE)) - cached_grid_y0);
-            const int ty1 = std::min(cached_grid_h - 1, static_cast<int>(ceilf(trap->YT / EXPLORE_CELL_SIZE)) - cached_grid_y0);
-            const int tx0 = std::max(0, static_cast<int>(floorf(std::min({trap->XTL, trap->XBL}) / EXPLORE_CELL_SIZE)) - cached_grid_x0);
-            const int tx1 = std::min(cached_grid_w - 1, static_cast<int>(ceilf(std::max({trap->XTR, trap->XBR}) / EXPLORE_CELL_SIZE)) - cached_grid_x0);
-            for (int cy = ty0; cy <= ty1; cy++) {
-                for (int cx = tx0; cx <= tx1; cx++) {
-                    const int abs_gx = cached_grid_x0 + cx;
-                    const int abs_gy = cached_grid_y0 + cy;
-                    const int idx = GetCellIndex(abs_gx, abs_gy);
-                    if (idx < 0 || cached_walkable_grid[idx]) continue;
-                    if (IsCellWalkableInTrapezoid(abs_gx, abs_gy, *trap)) 
-                        cached_walkable_grid[idx] = true;
-                }
-            }
-        }
-
-        for (int cy = 0; cy < cached_grid_h; cy++) {
-            for (int cx = 0; cx < cached_grid_w; cx++) {
-                const int idx = GetCellIndex(cached_grid_x0 + cx, cached_grid_y0 + cy);
-                if (idx < 0 || !cached_walkable_grid[idx]) continue;
-
-                const float x0 = (cached_grid_x0 + cx) * EXPLORE_CELL_SIZE;
-                const float y0 = (cached_grid_y0 + cy) * EXPLORE_CELL_SIZE;
-                const float x1 = x0 + EXPLORE_CELL_SIZE;
-                const float y1 = y0 + EXPLORE_CELL_SIZE;
-
-                if (!IsGridCellWalkable(cached_grid_x0 + cx, cached_grid_y0 + cy - 1)) cached_border_segments.push_back({{x0, y0}, {x1, y0}});
-                if (!IsGridCellWalkable(cached_grid_x0 + cx, cached_grid_y0 + cy + 1)) cached_border_segments.push_back({{x0, y1}, {x1, y1}});
-                if (!IsGridCellWalkable(cached_grid_x0 + cx - 1, cached_grid_y0 + cy)) cached_border_segments.push_back({{x0, y0}, {x0, y1}});
-                if (!IsGridCellWalkable(cached_grid_x0 + cx + 1, cached_grid_y0 + cy)) cached_border_segments.push_back({{x1, y0}, {x1, y1}});
-            }
-        }
-        BuildStaticMapGeometry();
-        InitFogBuffer();
-    }
-
-    void ClearQuestMarker()
-    {
-        GW::GameThread::Enqueue([] {
-            QuestModule::SetCustomQuestMarker({0, 0});
-        });
-    }
-
-    bool nav_active = false;
-    GW::Vec2f nav_target_pos;
-    GW::Vec2f nav_marker_pos;
-    bool nav_marker_set = false;
-    bool nav_marker_hidden = false;
-
-    constexpr float MARKER_UPDATE_DIST = 500.0f * 500.f;
-
-    void StopNavigating()
-    {
-        nav_active = false;
-        nav_target_pos = {};
-        nav_marker_pos = {};
-        nav_marker_set = false;
-        nav_marker_hidden = false;
-        ClearQuestMarker();
-    }
-
-    void SetNavTarget(const GW::Vec2f& target)
-    {
-        nav_active = true;
-        nav_target_pos = target;
-
-        const auto player = GW::Agents::GetControlledCharacter();
-        if (player) {
-            constexpr float HIDE_RANGE_SQ = (COMPASS_RANGE * 0.5f) * (COMPASS_RANGE * 0.5f);
-            const bool in_compass = GW::GetSquareDistance(target, player->pos) < HIDE_RANGE_SQ;
-
-            if (in_compass && !nav_marker_hidden) {
-                nav_marker_hidden = true;
-                ClearQuestMarker();
-                return;
-            }
-            if (in_compass) return;
-
-            if (nav_marker_hidden) {
-                nav_marker_hidden = false;
-                nav_marker_set = false;
-            }
-        }
-
-        if (nav_marker_set && GW::GetSquareDistance(target,nav_marker_pos) < MARKER_UPDATE_DIST) return;
-
-        nav_marker_pos = target;
-        nav_marker_set = true;
-        GW::Vec2f world_pos;
-        if (WorldMapWidget::GamePosToWorldMap(target, world_pos)) {
-            GW::GameThread::Enqueue([world_pos] {
-                QuestModule::SetCustomQuestMarker(world_pos, true);
-            });
-        }
-    }
-
-    void NavigateToClosestEnemy()
-    {
-        const auto player = GW::Agents::GetControlledCharacter();
-        if (!player) return;
-
-        const auto& player_pos = player->pos;
-        float best_dist_sq = FLT_MAX;
-        GW::GamePos best_pos = {};
-        bool found = false;
-
-        for (size_t agent_id = 0, len = std::min(tracked_enemies_by_agent_id.size(), highest_trackable_agent_id + 1); agent_id < len; agent_id++) {
-            const auto& enemy = tracked_enemies_by_agent_id[agent_id];
-            if (enemy.state == EnemyState::NotApplicable) continue;
-            const float dist_sq = GW::GetDistance(enemy.pos, player_pos);
-            if (dist_sq < best_dist_sq) {
-                best_dist_sq = dist_sq;
-                best_pos = enemy.pos;
-                found = true;
-            }
-        }
-
-        if (!found) {
-            if (!nav_marker_hidden) {
-                nav_marker_hidden = true;
-                ClearQuestMarker();
-            }
-            return;
-        }
-
-        SetNavTarget(best_pos);
-    }
-
-    constexpr float stale_range_sq = STALE_CHECK_RANGE * STALE_CHECK_RANGE;
-    D3DTeardrop teardrop_outline;
-    D3DTeardrop teardrop_fill;
-
-    void UpdateEnemyTracking()
-    {
-        const auto map_id = GW::Map::GetMapID();
-        const auto instance_type = GW::Map::GetInstanceType();
-        if (map_id != tracked_enemies_map_id || instance_type != tracked_enemies_instance_type) {
-            tracked_enemies_by_agent_id.assign(tracked_enemies_by_agent_id.size(), {});
-            tracked_enemies_map_id = map_id;
-            highest_trackable_agent_id = 0;
-            tracked_enemies_instance_type = instance_type;
-        }
-
-        const auto* player = GW::Agents::GetControlledCharacter();
-        const auto player_pos = GW::PlayerMgr::GetPlayerPosition();
-        const auto* agents = player_pos ? GW::Agents::GetAgentArray() : nullptr;
-        if (!agents) return;
-
-        // Skip stale detection when dead or on the first frame after respawn —
-        // agents near the death location vanish from the array during teleport
-        static bool was_dead = false;
-        const auto* player_living = player ? player->GetAsAgentLiving() : nullptr;
-        const bool is_dead = !player_living || !player_living->GetIsAlive();
-        if (is_dead) { was_dead = true; return; }
-        if (was_dead) { was_dead = false; return; }
-
-        if (tracked_enemies_by_agent_id.size() < agents->size()) tracked_enemies_by_agent_id.resize(agents->size());
-
-        for (size_t agent_id = 0, len = agents->size(); agent_id < len; agent_id++) {
-            const auto agent = agents->at(agent_id);
-            auto& tracked = tracked_enemies_by_agent_id[agent_id];
-            if (!agent) {
-                // Agent not in radar — only mark stale if we're close enough to
-                // their last known position that we should be able to see them
-                if (tracked.state == EnemyState::Alive) {
-                    if (GW::GetSquareDistance(*player_pos,tracked.pos) < stale_range_sq) {
-                        tracked.state = EnemyState::Stale;
-                    }
-                }
-                if (tracked.state != EnemyState::NotApplicable) {
-                    highest_trackable_agent_id = agent_id;
-                }
-                continue;
-            }
-            const auto* living = agent->GetAsAgentLiving();
-
-            if (!living || living->allegiance != GW::Constants::Allegiance::Enemy || !living->GetIsAlive()) {
-                tracked.state = EnemyState::NotApplicable;
-                continue;
-            }
-            auto* npc = GW::Agents::GetNPCByID(living->player_number);
-            if (npc && (npc->IsSpirit() || npc->IsMinion())) {
-                tracked.state = EnemyState::NotApplicable;
-                continue;
-            }
-
-            tracked.pos = {living->pos.x, living->pos.y};
-            tracked.rotation = living->rotation_angle;
-            tracked.state = EnemyState::Alive;
-            highest_trackable_agent_id = agent_id;
-        }
-        // Handle entries beyond current agent array size (previously tracked, now out of range)
-        for (size_t agent_id = agents->size(), len = tracked_enemies_by_agent_id.size(); agent_id < len; agent_id++) {
-            auto& tracked = tracked_enemies_by_agent_id[agent_id];
-            if (tracked.state == EnemyState::Alive) {
-                if (GW::GetSquareDistance(*player_pos, tracked.pos) < stale_range_sq) {
-                    tracked.state = EnemyState::Stale;
-                }
-            }
-            if (tracked.state != EnemyState::NotApplicable) {
-                highest_trackable_agent_id = agent_id;
-            }
-        }
-
-        if (nav_active) NavigateToClosestEnemy();
-        enemy_vertex_buffer.clear();
-
-        const float radius = vq_enemy_marker_size * cached_px_to_game;
-        const float radius_outer = radius + cached_px_to_game;
-        teardrop_fill.SetRadius(radius);
-        teardrop_outline.SetRadius(radius_outer);
-        teardrop_outline.SetColor(vq_color_enemy_outline);
-
-        for (size_t i = 0, len = std::min(tracked_enemies_by_agent_id.size(), highest_trackable_agent_id + 1); i < len; i++) {
-            auto& enemy = tracked_enemies_by_agent_id[i];
-            if (enemy.state == EnemyState::NotApplicable) continue;
-            const DWORD color = enemy.state == EnemyState::Stale ? vq_color_enemy_stale : vq_color_enemy_alive;
-            teardrop_fill.SetColor(color);
-            teardrop_fill.SetCenterColor(color);
-            teardrop_fill.SetPosition(enemy.pos);
-            teardrop_fill.SetRotation(enemy.rotation);
-            teardrop_outline.SetPosition(enemy.pos);
-            teardrop_outline.SetRotation(enemy.rotation);
-            enemy_vertex_buffer.push_back(teardrop_outline);
-            enemy_vertex_buffer.push_back(teardrop_fill);
-        }
-    }
 
     GW::Vec2f mission_map_top_left;
     GW::Vec2f mission_map_bottom_right;
@@ -676,8 +62,6 @@ class D3DFogBuffer : public D3DTriangleBuffer {
 
     GW::Vec2f mission_map_screen_pos;
     GW::Vec2f world_map_click_pos;
-
-    MinimapRenderContext mission_map_render_context;
 
     bool right_clicking = false;
 
@@ -709,7 +93,6 @@ class D3DFogBuffer : public D3DTriangleBuffer {
         return offset + current_pan_offset;
     }
 
-    // Used for screen-space geometry (lines, enemy markers, viewport culling)
     bool GamePosToMissionMapScreenPos(const GW::GamePos& game_map_position, GW::Vec2f& screen_coords)
     {
         GW::Vec2f world_map_pos;
@@ -728,8 +111,6 @@ class D3DFogBuffer : public D3DTriangleBuffer {
         const float px = player_pos->x;
         const float py = player_pos->y;
 
-        // Only recompute basis vectors when zoom changes — they're stable
-        // across panning. Recomputing every frame causes floating-point jitter.
         if (mission_map_zoom != cached_basis_zoom || !valid) {
             cached_basis_zoom = mission_map_zoom;
 
@@ -745,21 +126,16 @@ class D3DFogBuffer : public D3DTriangleBuffer {
             by = (s01.y - s00.y) / STEP;
         }
 
-        // Compute origin from the player's known mission map position,
-        // not from the world-map-based s00 which is wrong for underground maps.
         const GW::Vec2f mm_pos = mm_ctx->h003c->player_mission_map_pos;
         const GW::Vec2f mm_offset = mm_pos - current_pan_offset;
         const GW::Vec2f mm_scaled = {mm_offset.x * mission_map_scale.x, mm_offset.y * mission_map_scale.y};
         const GW::Vec2f player_screen = {mm_scaled.x * mission_map_zoom + mission_map_screen_pos.x,
                                          mm_scaled.y * mission_map_zoom + mission_map_screen_pos.y};
 
-        // Snap origin to nearest pixel to reduce sub-pixel flicker on thin lines
         ox = roundf(player_screen.x - px * ax - py * bx);
         oy = roundf(player_screen.y - px * ay - py * by);
         valid = true;
     }
-
-    void Draw(IDirect3DDevice9*);
 
     std::vector<GW::UI::UIMessage> messages_hit;
     GW::UI::UIInteractionCallback OnMissionMap_UICallback_Func = nullptr, OnMissionMap_UICallback_Ret = nullptr;
@@ -768,6 +144,7 @@ class D3DFogBuffer : public D3DTriangleBuffer {
     {
         GW::Hook::EnterHook();
         if (message->message_id == GW::UI::UIMessage::kDestroyFrame) mission_map_frame = nullptr;
+
         OnMissionMap_UICallback_Ret(message, wparam, lparam);
         if (message->message_id == GW::UI::UIMessage::kInitFrame) mission_map_frame = GW::UI::GetFrameById(message->frame_id);
         GW::Hook::LeaveHook();
@@ -820,114 +197,22 @@ class D3DFogBuffer : public D3DTriangleBuffer {
         }
 #endif
         if (ImGui::Button("Place Marker")) {
-            nav_active = false;
-            nav_target_pos = {};
-            nav_marker_pos = {};
+            VanquishMapOverlayWidget::StopNavigating();
             GW::GameThread::Enqueue([] {
                 QuestModule::SetCustomQuestMarker(world_map_click_pos, true);
             });
             return false;
         }
-        if (QuestModule::GetCustomQuestMarker() && !nav_active) {
+        if (QuestModule::GetCustomQuestMarker() && !VanquishMapOverlayWidget::IsNavigating()) {
             if (ImGui::Button("Remove Marker")) {
-                ClearQuestMarker();
+                GW::GameThread::Enqueue([] { QuestModule::ClearCustomQuestMarker(); });
                 return false;
             }
         }
-        if (show_vq_overlay) {
-            if (nav_active) {
-                if (ImGui::Button("Stop navigating")) {
-                    StopNavigating();
-                    return false;
-                }
-            }
-            else {
-                if (ImGui::Button("Navigate to closest enemy")) {
-                    nav_active = true;
-                    NavigateToClosestEnemy();
-                    return false;
-                }
-            }
-        }
+        if (!VanquishMapOverlayWidget::ContextMenuItems()) return false;
 
         return true;
     }
-
-    // ---------------------------------------------------------------------------
-    // Matrix helpers
-    // ---------------------------------------------------------------------------
-
-    // Screen-space ortho: maps pixel coords [0,w]x[0,h] -> NDC [-1,1]x[1,-1]
-    D3DMATRIX MakeOrthoProjection(float w, float h)
-    {
-        // clang-format off
-        D3DMATRIX m = {{
-             2.f/w,   0.f,  0.f, 0.f,
-              0.f,  -2.f/h, 0.f, 0.f,
-              0.f,   0.f,  1.f, 0.f,
-             -1.f,   1.f,  0.f, 1.f
-        }};
-        // clang-format on
-        return m;
-    }
-
-    // -----------------------------------------------------------------------
-    // DrawEnemyCountLabel — ImGui overlay showing VQ kill counts
-    // -----------------------------------------------------------------------
-    void DrawEnemyCountLabel()
-    {
-        if (!show_vq_overlay) return;
-
-        int alive_count = 0, stale_count = 0;
-        for (size_t i = 0, len = std::min(tracked_enemies_by_agent_id.size(), highest_trackable_agent_id + 1); i < len; i++) {
-            const auto& enemy = tracked_enemies_by_agent_id[i];
-            if (enemy.state == EnemyState::Alive)
-                alive_count++;
-            else if (enemy.state == EnemyState::Stale)
-                stale_count++;
-        }
-
-        const uint32_t foes_remaining = GW::Map::GetFoesToKill();
-        const bool has_vq_data = foes_remaining > 0 || GW::Map::GetFoesKilled() > 0;
-
-        if (!alive_count && !stale_count && !(has_vq_data && foes_remaining > 0)) return;
-
-        char label[128];
-        int pos = 0;
-        if (alive_count > 0 || stale_count > 0) {
-            pos += snprintf(label + pos, sizeof(label) - pos, "%d", alive_count);
-            if (stale_count > 0) pos += snprintf(label + pos, sizeof(label) - pos, " (+%d?)", stale_count);
-            if (has_vq_data) pos += snprintf(label + pos, sizeof(label) - pos, " / %u remaining", foes_remaining);
-        }
-        else {
-            pos += snprintf(label + pos, sizeof(label) - pos, "%u remaining", foes_remaining);
-        }
-
-        constexpr float PADDING = 8.0f;
-        const float btn_size = ImGui::GetTextLineHeight() + 12.0f;
-        const ImVec2 text_pos(mission_map_top_left.x + PADDING + btn_size, mission_map_bottom_right.y - ImGui::GetTextLineHeight() - PADDING);
-
-        auto* draw_list = ImGui::GetBackgroundDrawList();
-        draw_list->AddText({text_pos.x + 1, text_pos.y + 1}, IM_COL32(0, 0, 0, 220), label);
-        draw_list->AddText({text_pos.x - 1, text_pos.y - 1}, IM_COL32(0, 0, 0, 220), label);
-        draw_list->AddText({text_pos.x + 1, text_pos.y - 1}, IM_COL32(0, 0, 0, 220), label);
-        draw_list->AddText({text_pos.x - 1, text_pos.y + 1}, IM_COL32(0, 0, 0, 220), label);
-        draw_list->AddText(text_pos, IM_COL32(255, 255, 255, 255), label);
-    }
-
-    struct D3DStateGuard {
-        IDirect3DStateBlock9* block = nullptr;
-
-        explicit D3DStateGuard(IDirect3DDevice9* dev) { dev->CreateStateBlock(D3DSBT_ALL, &block); }
-
-        ~D3DStateGuard()
-        {
-            if (block) {
-                block->Apply();
-                block->Release();
-            }
-        }
-    };
 
     void SubmitVertexBuffers(IDirect3DDevice9* dx_device)
     {
@@ -941,10 +226,10 @@ class D3DFogBuffer : public D3DTriangleBuffer {
         dx_device->SetRenderState(D3DRS_ZENABLE, FALSE);
 
         RECT scissorRect;
-        scissorRect.left = static_cast<LONG>(mission_map_top_left.x);
-        scissorRect.top = static_cast<LONG>(mission_map_top_left.y);
-        scissorRect.right = static_cast<LONG>(mission_map_bottom_right.x);
-        scissorRect.bottom = static_cast<LONG>(mission_map_bottom_right.y);
+        scissorRect.left = static_cast<LONG>(ceilf(mission_map_top_left.x));
+        scissorRect.top = static_cast<LONG>(ceilf(mission_map_top_left.y));
+        scissorRect.right = static_cast<LONG>(floorf(mission_map_bottom_right.x));
+        scissorRect.bottom = static_cast<LONG>(floorf(mission_map_bottom_right.y));
         dx_device->SetScissorRect(&scissorRect);
 
         D3DVIEWPORT9 vp;
@@ -957,51 +242,7 @@ class D3DFogBuffer : public D3DTriangleBuffer {
         dx_device->SetTransform(D3DTS_VIEW, &IDENTITY_MATRIX);
         dx_device->SetTransform(D3DTS_PROJECTION, &ortho);
 
-        if (should_draw_vq_overlay) {
-            inaccessible_area_and_borders.Render(dx_device);
-            fog_buffer.Render(dx_device);
-            frontier_border.Render(dx_device);
-            enemy_vertex_buffer.Render(dx_device);
-
-            if (!compass_circle.empty()) {
-                if (const auto* player = GW::Agents::GetControlledCharacter()) {
-                    D3DMATRIX compassMatrix = gameToScreen;
-                    compassMatrix._41 = roundf(g2s.ox + player->pos.x * g2s.ax + player->pos.y * g2s.bx);
-                    compassMatrix._42 = roundf(g2s.oy + player->pos.x * g2s.ay + player->pos.y * g2s.by);
-                    dx_device->SetTransform(D3DTS_WORLD, &compassMatrix);
-                    compass_circle.Render(dx_device);
-                    dx_device->SetTransform(D3DTS_WORLD, &gameToScreen);
-                }
-            }
-        }
         minimap_lines.Render(dx_device);
-    }
-
-
-
-    void DrawVanquishToggleButton() {
-        constexpr float PADDING = 4.0f;
-        const float btn_size = ImGui::GetTextLineHeight() + PADDING * 2;
-        const ImVec2 btn_pos(mission_map_top_left.x + PADDING, mission_map_bottom_right.y - btn_size - PADDING);
-
-        ImGui::SetNextWindowPos(btn_pos);
-        ImGui::SetNextWindowSize({0, 0});
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {2, 2});
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, {0, 0});
-        if (ImGui::Begin("##vq_toggle", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings)) {
-            if (show_vq_overlay) {
-                if (ImGui::Button(ICON_FA_SKULL "##vq_off")) show_vq_overlay = false;
-                if (ImGui::IsItemHovered()) ImGui::SetTooltip("VQ overlay active. Click to hide.");
-            }
-            else {
-                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-                if (ImGui::Button(ICON_FA_SKULL "##vq_on")) show_vq_overlay = true;
-                ImGui::PopStyleColor();
-                if (ImGui::IsItemHovered()) ImGui::SetTooltip("VQ overlay hidden. Click to show.");
-            }
-        }
-        ImGui::End();
-        ImGui::PopStyleVar(2);
     }
 
     void EnqueueMinimapLines(GW::Constants::MapID map_id)
@@ -1022,12 +263,7 @@ class D3DFogBuffer : public D3DTriangleBuffer {
             else {
                 minimap_lines.push_back(D3DLine(line->p1, line->p2, LINE_HALF_THICKNESS, static_cast<DWORD>(line->color)));
             }
-            
         }
-    }
-
-    void RebuildCompassCircle() {
-        compass_circle = D3DCircle({0.f, 0.f}, COMPASS_RANGE, COMPASS_CIRCLE_THICKNESS_PX * cached_px_to_game, (DWORD)vq_color_compass, COMPASS_CIRCLE_SEGMENTS);
     }
 } // namespace
 
@@ -1036,18 +272,6 @@ void MissionMapWidget::LoadSettings(ToolboxIni* ini)
     ToolboxWidget::LoadSettings(ini);
     LOAD_BOOL(draw_all_terrain_lines);
     LOAD_BOOL(draw_all_minimap_lines);
-    LOAD_BOOL(show_vq_overlay);
-    LOAD_BOOL(show_vq_toggle_button);
-
-    LOAD_COLOR(vq_color_inaccessible);
-    LOAD_COLOR(vq_color_fog_unexplored);
-    LOAD_COLOR(vq_color_border);
-    LOAD_COLOR(vq_color_frontier);
-    LOAD_COLOR(vq_color_compass);
-    LOAD_COLOR(vq_color_enemy_alive);
-    LOAD_COLOR(vq_color_enemy_stale);
-    LOAD_COLOR(vq_color_enemy_outline);
-    LOAD_FLOAT(vq_enemy_marker_size);
 }
 
 void MissionMapWidget::SaveSettings(ToolboxIni* ini)
@@ -1055,18 +279,6 @@ void MissionMapWidget::SaveSettings(ToolboxIni* ini)
     ToolboxWidget::SaveSettings(ini);
     SAVE_BOOL(draw_all_terrain_lines);
     SAVE_BOOL(draw_all_minimap_lines);
-    SAVE_BOOL(show_vq_overlay);
-    SAVE_BOOL(show_vq_toggle_button);
-
-    SAVE_COLOR(vq_color_inaccessible);
-    SAVE_COLOR(vq_color_fog_unexplored);
-    SAVE_COLOR(vq_color_border);
-    SAVE_COLOR(vq_color_frontier);
-    SAVE_COLOR(vq_color_compass);
-    SAVE_COLOR(vq_color_enemy_alive);
-    SAVE_COLOR(vq_color_enemy_stale);
-    SAVE_COLOR(vq_color_enemy_outline);
-    SAVE_FLOAT(vq_enemy_marker_size);
 }
 
 void MissionMapWidget::Draw(IDirect3DDevice9* dx_device)
@@ -1074,123 +286,46 @@ void MissionMapWidget::Draw(IDirect3DDevice9* dx_device)
     if (!visible || !GW::Map::GetIsMapLoaded() || !mission_map_frame || !mission_map_frame->IsVisible()) return;
 
     SubmitVertexBuffers(dx_device);
-    if (should_draw_vq_overlay) 
-        DrawEnemyCountLabel();
-    if (show_vq_toggle_button && ToolboxUtils::IsExplorable())
-        DrawVanquishToggleButton();
+    HookMissionMapFrame();
 }
+
 void MissionMapWidget::Update(float)
 {
     if (!HookMissionMapFrame()) return;
     if (!InitializeMissionMapParameters()) return;
+
     g2s.Rebuild();
-    if (!g2s.valid) return;
-    // Frame rate check
+    if (!g2s.valid) { render_ready = false; return; }
+
+    cached_px_to_game = 1.0f / sqrtf(g2s.ax * g2s.ax + g2s.ay * g2s.ay);
+    cached_game_to_screen = {{g2s.ax, g2s.ay, 0.f, 0.f, g2s.bx, g2s.by, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, g2s.ox, g2s.oy, 0.f, 1.f}};
+    render_ready = true;
+
+    // Frame rate check — only throttle minimap line updates
     static clock_t last_check = TIMER_INIT();
     if (!ToolboxUtils::FrameRateCheck(last_check, 30)) return;
 
-    should_draw_vq_overlay = show_vq_overlay && ToolboxUtils::IsExplorable();
-
-    // -----------------------------------------------------------------------
-    // Custom renderer lines — screen space
-    // -----------------------------------------------------------------------
-
-    const auto map_id = GW::Map::GetMapID();
-
-    const auto instance_type = GW::Map::GetInstanceType();
-    static GW::Constants::InstanceType border_instance_type = GW::Constants::InstanceType::Loading;
-    const bool map_changed = map_id != border_map_id || instance_type != border_instance_type;
-    const bool zoom_changed = mission_map_zoom != border_cached_zoom;
-    const auto player_pos = GW::PlayerMgr::GetPlayerPosition();
-
-    if (map_changed || zoom_changed) {
-        border_cached_zoom = mission_map_zoom;
-        cached_px_to_game = g2s.valid ? 1.0f / sqrtf(g2s.ax * g2s.ax + g2s.ay * g2s.ay) : EXPLORE_CELL_SIZE / 600.0f;
-        BuildStaticMapGeometry();
-        RebuildCompassCircle();
-        if (map_changed) {
-            border_map_id = map_id;
-            border_instance_type = instance_type;
-            RebuildMapBorder(); // calls InitFogBuffer internally
-        }
-        else {
-            RebuildFrontierBorder();
-        }
-
-    }
-
-    EnqueueMinimapLines(map_id);    
-
-    if (ToolboxUtils::IsExplorable()) {
-        UpdateEnemyTracking();
-        if (UpdateExploration(player_pos)) 
-            RebuildFrontierBorder();
-    } else {
-        if (nav_active) StopNavigating();
-        // Reset tracking state so re-entering the same map triggers a fresh start
-        if (tracked_enemies_map_id != GW::Constants::MapID::None) {
-            tracked_enemies_by_agent_id.assign(tracked_enemies_by_agent_id.size(), {});
-            tracked_enemies_map_id = GW::Constants::MapID::None;
-            tracked_enemies_instance_type = GW::Constants::InstanceType::Loading;
-            highest_trackable_agent_id = 0;
-            enemy_vertex_buffer.clear();
-        }
-        // Reset exploration so fog of war restarts on the next explorable instance
-        if (explored_map_id != GW::Constants::MapID::None) {
-            delete[] explored_cells;
-            explored_cells = nullptr;
-            explored_map_id = GW::Constants::MapID::None;
-            explored_instance_type = GW::Constants::InstanceType::Loading;
-        }
-    }
-
+    EnqueueMinimapLines(GW::Map::GetMapID());
 }
 
 void MissionMapWidget::DrawSettingsInternal()
 {
     ImGui::Checkbox("Draw all terrain lines", &draw_all_terrain_lines);
     ImGui::Checkbox("Draw all minimap lines", &draw_all_minimap_lines);
-    ImGui::Checkbox("Show VQ toggle button on mission map", &show_vq_toggle_button);
-    ImGui::Checkbox("Vanquish Overlay", &show_vq_overlay);
-    ImGui::ShowHelp("Tracks enemy positions as they enter compass range.\nBlue = alive, Orange = last known (moved away).\nArrows on orange markers show last movement direction.\nAlso highlights areas you've explored during this session on the mission map.");
-
-    if (show_vq_overlay) {
-        ImGui::Indent();
-        // Flag that triggers a static geometry rebuild if colour changes
-        bool static_changed = false;
-        bool fog_changed = false;
-
-        static_changed |= Colors::DrawSettingHueWheel("Inaccessible area", &vq_color_inaccessible);
-        static_changed |= Colors::DrawSettingHueWheel("Map border", &vq_color_border);
-        fog_changed |= Colors::DrawSettingHueWheel("Unexplored fog", &vq_color_fog_unexplored);
-        fog_changed |= Colors::DrawSettingHueWheel("Frontier edge", &vq_color_frontier);
-        bool rebuild_compass = Colors::DrawSettingHueWheel("Compass range", &vq_color_compass);
-        Colors::DrawSettingHueWheel("Enemy (alive)", &vq_color_enemy_alive);
-        Colors::DrawSettingHueWheel("Enemy (last known position)", &vq_color_enemy_stale);
-        Colors::DrawSettingHueWheel("Enemy outline", &vq_color_enemy_outline);
-        ImGui::SliderFloat("Enemy marker size", &vq_enemy_marker_size, 3.0f, 20.0f, "%.0f");
-        ImGui::Unindent();
-
-        if (static_changed) BuildStaticMapGeometry();
-        if (fog_changed) {
-            InitFogBuffer();
-            RebuildFrontierBorder();
-        }
-        
-        if (rebuild_compass) RebuildCompassCircle();
-    }
 }
 
 bool MissionMapWidget::WndProc(const UINT Message, WPARAM, LPARAM lParam)
 {
+    const GW::Vec2f cursor_pos = {GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+
     switch (Message) {
-        case WM_GW_RBUTTONCLICK:
-            GW::Vec2f cursor_pos = {GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+        case WM_GW_RBUTTONCLICK: {
             if (!IsScreenPosOnMissionMap(cursor_pos)) break;
+            if (!mission_map_frame) break;
             if (GW::UI::GetCurrentTooltip()) break;
             world_map_click_pos = ScreenPosToMissionMapCoords(cursor_pos);
             ImGui::SetContextMenu(MissionMapContextMenu);
-            break;
+        } break;
     }
     return false;
 }
@@ -1200,23 +335,15 @@ void MissionMapWidget::Terminate()
     ToolboxWidget::Terminate();
     if (OnMissionMap_UICallback_Func) GW::Hook::RemoveHook(OnMissionMap_UICallback_Func);
     OnMissionMap_UICallback_Func = nullptr;
-    delete[] cached_walkable_grid;
-    cached_walkable_grid = nullptr;
-    delete[] explored_cells;
-    explored_cells = nullptr;
 
-    for (auto buffer : vertex_buffers) {
-        buffer->Terminate();
-    }
+    minimap_lines.Terminate();
+    render_ready = false;
 }
 
-void MissionMapWidget::GetTrackedEnemyCounts(int& alive, int& stale)
-{
-    alive = 0;
-    stale = 0;
-    for (size_t i = 0, len = std::min(tracked_enemies_by_agent_id.size(), highest_trackable_agent_id + 1); i < len; i++) {
-        const auto& enemy = tracked_enemies_by_agent_id[i];
-        if (enemy.state == EnemyState::Alive) alive++;
-        else if (enemy.state == EnemyState::Stale) stale++;
-    }
-}
+bool MissionMapWidget::IsRenderReady() { return render_ready && GW::Map::GetIsMapLoaded() && mission_map_frame && mission_map_frame->IsVisible(); }
+const D3DMATRIX& MissionMapWidget::GetGameToScreenMatrix() { return cached_game_to_screen; }
+GW::Vec2f MissionMapWidget::GetTopLeft() { return mission_map_top_left; }
+GW::Vec2f MissionMapWidget::GetBottomRight() { return mission_map_bottom_right; }
+GW::UI::Frame* MissionMapWidget::GetFrame() { return mission_map_frame; }
+float MissionMapWidget::GetPxToGame() { return cached_px_to_game; }
+float MissionMapWidget::GetZoom() { return mission_map_zoom; }

--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -167,7 +167,7 @@ namespace {
     {
         const auto gameplay_context = GW::GetGameplayContext();
         const auto mission_map_context = GW::Map::GetMissionMapContext();
-        if (!(gameplay_context && mission_map_frame && mission_map_frame->IsVisible())) return false;
+        if (!(gameplay_context && mission_map_context && mission_map_frame && mission_map_frame->IsVisible())) return false;
 
         const auto root = GW::UI::GetRootFrame();
         mission_map_top_left = mission_map_frame->position.GetContentTopLeft(root);

--- a/GWToolboxdll/Widgets/MissionMapWidget.h
+++ b/GWToolboxdll/Widgets/MissionMapWidget.h
@@ -49,4 +49,10 @@ public:
     using DrawCallback = void(*)(IDirect3DDevice9*);
     static void AddDrawCallback(DrawCallback cb);
     static void RemoveDrawCallback(DrawCallback cb);
+
+    // Context menu callback system — registered callbacks contribute items to the
+    // mission map right-click context menu. Return false to close the menu.
+    using ContextMenuCallback = bool(*)();
+    static void AddContextMenuCallback(ContextMenuCallback cb);
+    static void RemoveContextMenuCallback(ContextMenuCallback cb);
 };

--- a/GWToolboxdll/Widgets/MissionMapWidget.h
+++ b/GWToolboxdll/Widgets/MissionMapWidget.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include <ToolboxWidget.h>
+#include <d3d9types.h>
+#include <GWCA/GameContainers/GamePos.h>
+
+namespace GW::UI { struct Frame; }
 
 class MissionMapWidget : public ToolboxWidget {
     MissionMapWidget()
@@ -31,5 +35,12 @@ public:
     void Terminate() override;
     bool WndProc(UINT Message, WPARAM, LPARAM lParam) override;
 
-    static void GetTrackedEnemyCounts(int& alive, int& stale);
+    // Expose mission map rendering context for overlay widgets
+    static bool IsRenderReady();
+    static const D3DMATRIX& GetGameToScreenMatrix();
+    static GW::Vec2f GetTopLeft();
+    static GW::Vec2f GetBottomRight();
+    static GW::UI::Frame* GetFrame();
+    static float GetPxToGame();
+    static float GetZoom();
 };

--- a/GWToolboxdll/Widgets/MissionMapWidget.h
+++ b/GWToolboxdll/Widgets/MissionMapWidget.h
@@ -43,4 +43,10 @@ public:
     static GW::UI::Frame* GetFrame();
     static float GetPxToGame();
     static float GetZoom();
+
+    // Draw callback system — registered callbacks are invoked with D3D render state
+    // (scissor, blend, transforms) already configured for mission map rendering
+    using DrawCallback = void(*)(IDirect3DDevice9*);
+    static void AddDrawCallback(DrawCallback cb);
+    static void RemoveDrawCallback(DrawCallback cb);
 };

--- a/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
+++ b/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
@@ -364,6 +364,7 @@ namespace {
     GW::Vec2f nav_marker_pos;
     bool nav_marker_set = false;
     bool nav_marker_hidden = false;
+    bool self_changing_marker = false;
 
     constexpr float MARKER_UPDATE_DIST = 500.0f * 500.f;
 
@@ -374,7 +375,11 @@ namespace {
         nav_marker_pos = {};
         nav_marker_set = false;
         nav_marker_hidden = false;
-        GW::GameThread::Enqueue([] { QuestModule::ClearCustomQuestMarker(); });
+        GW::GameThread::Enqueue([] {
+            self_changing_marker = true;
+            QuestModule::ClearCustomQuestMarker();
+            self_changing_marker = false;
+        });
     }
 
     void SetNavTarget(const GW::Vec2f& target)
@@ -389,7 +394,9 @@ namespace {
 
             if (in_compass && !nav_marker_hidden) {
                 nav_marker_hidden = true;
+                self_changing_marker = true;
                 QuestModule::ClearCustomQuestMarker();
+                self_changing_marker = false;
                 return;
             }
             if (in_compass) return;
@@ -407,7 +414,9 @@ namespace {
         GW::Vec2f world_pos;
         if (WorldMapWidget::GamePosToWorldMap(target, world_pos)) {
             GW::GameThread::Enqueue([world_pos] {
+                self_changing_marker = true;
                 QuestModule::SetCustomQuestMarker(world_pos, true);
+                self_changing_marker = false;
             });
         }
     }
@@ -436,7 +445,9 @@ namespace {
         if (!found) {
             if (!nav_marker_hidden) {
                 nav_marker_hidden = true;
+                self_changing_marker = true;
                 QuestModule::ClearCustomQuestMarker();
+                self_changing_marker = false;
             }
             return;
         }
@@ -613,6 +624,18 @@ namespace {
         ImGui::End();
         ImGui::PopStyleVar(2);
     }
+    void OnCustomMarkerChanged()
+    {
+        if (self_changing_marker || !nav_active) return;
+        // Another system changed the custom quest marker — stop navigating
+        // but don't clear the marker (it belongs to whoever set it now)
+        nav_active = false;
+        nav_target_pos = {};
+        nav_marker_pos = {};
+        nav_marker_set = false;
+        nav_marker_hidden = false;
+    }
+
     void OnMissionMapDraw(IDirect3DDevice9* dx_device)
     {
         if (!should_draw) return;
@@ -641,6 +664,8 @@ void VanquishMapOverlayWidget::Initialize()
 {
     ToolboxWidget::Initialize();
     MissionMapWidget::AddDrawCallback(&OnMissionMapDraw);
+    MissionMapWidget::AddContextMenuCallback(&VanquishMapOverlayWidget::ContextMenuItems);
+    QuestModule::AddCustomMarkerChangedCallback(&OnCustomMarkerChanged);
 }
 
 void VanquishMapOverlayWidget::Draw(IDirect3DDevice9*)
@@ -712,6 +737,8 @@ void VanquishMapOverlayWidget::Terminate()
 {
     ToolboxWidget::Terminate();
     MissionMapWidget::RemoveDrawCallback(&OnMissionMapDraw);
+    MissionMapWidget::RemoveContextMenuCallback(&VanquishMapOverlayWidget::ContextMenuItems);
+    QuestModule::RemoveCustomMarkerChangedCallback(&OnCustomMarkerChanged);
 
     delete[] cached_walkable_grid;
     cached_walkable_grid = nullptr;

--- a/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
+++ b/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
@@ -806,7 +806,7 @@ void VanquishMapOverlayWidget::DrawSettingsInternal()
 
 bool VanquishMapOverlayWidget::ContextMenuItems()
 {
-    if (!show_vq_overlay) return true;
+    if (!show_vq_overlay || !ToolboxUtils::IsExplorable()) return true;
     if (nav_active) {
         if (ImGui::Button("Stop navigating")) {
             StopNavigating();

--- a/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
+++ b/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
@@ -486,12 +486,11 @@ namespace {
                 }
                 continue;
             }
-            const auto* living = agent->GetAsAgentLiving();
-
-            if (!living || living->allegiance != GW::Constants::Allegiance::Enemy || !living->GetIsAlive()) {
+            if (!GW::Agents::GetAgentMatchesFlags(agent, GW::TargetFilter::Enemies)) {
                 tracked.state = EnemyState::NotApplicable;
                 continue;
             }
+            const auto* living = agent->GetAsAgentLiving();
             auto* npc = GW::Agents::GetNPCByID(living->player_number);
             if (npc && (npc->IsSpirit() || npc->IsMinion())) {
                 tracked.state = EnemyState::NotApplicable;

--- a/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
+++ b/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
@@ -1,0 +1,839 @@
+#include "stdafx.h"
+
+#include <GWCA/Context/GameplayContext.h>
+#include <GWCA/GameEntities/Agent.h>
+#include <GWCA/GameEntities/NPC.h>
+#include <GWCA/GameEntities/Pathing.h>
+#include <GWCA/Managers/AgentMgr.h>
+#include <GWCA/Managers/GameThreadMgr.h>
+#include <GWCA/Managers/MapMgr.h>
+
+#include <Color.h>
+#include <D3DContainers.h>
+#include <Defines.h>
+#include <ImGuiAddons.h>
+#include <Timer.h>
+#include <Modules/QuestModule.h>
+#include <Utils/ToolboxUtils.h>
+#include <Widgets/MissionMapWidget.h>
+#include <Widgets/VanquishMapOverlayWidget.h>
+#include <Widgets/WorldMapWidget.h>
+
+namespace {
+    bool show_vq_overlay = false;
+
+    // VQ overlay colours
+    Color vq_color_inaccessible = IM_COL32(0, 0, 0, 190);
+    Color vq_color_fog_unexplored = IM_COL32(0, 0, 0, 140);
+    Color vq_color_border = IM_COL32(200, 220, 255, 160);
+    Color vq_color_frontier = IM_COL32(255, 200, 50, 200);
+    Color vq_color_compass = IM_COL32(180, 220, 255, 100);
+    Color vq_color_enemy_alive = IM_COL32(70, 130, 255, 255);
+    Color vq_color_enemy_stale = IM_COL32(255, 180, 50, 180);
+    Color vq_color_enemy_outline = IM_COL32(0, 0, 0, 200);
+    float vq_enemy_marker_size = 9.0f;
+
+    // Enemy tracking
+    enum class EnemyState { NotApplicable, Alive, Stale };
+    struct TrackedEnemy {
+        GW::Vec2f pos;
+        float rotation = 0.f;
+        EnemyState state = EnemyState::NotApplicable;
+    };
+    std::vector<TrackedEnemy> tracked_enemies_by_agent_id;
+    size_t highest_trackable_agent_id = 0;
+
+    GW::Constants::MapID tracked_enemies_map_id = static_cast<GW::Constants::MapID>(0);
+    GW::Constants::InstanceType tracked_enemies_instance_type = GW::Constants::InstanceType::Loading;
+
+    constexpr float COMPASS_RANGE = GW::Constants::Range::Compass;
+    constexpr float STALE_CHECK_RANGE = COMPASS_RANGE * 0.9f;
+
+    bool should_draw = false;
+
+    float cached_px_to_game = 1.f;
+
+    // Fog buffer with pre-allocated quads per walkable cell
+    class D3DFogBuffer : public D3DTriangleBuffer {
+    public:
+        static constexpr size_t VERTS_PER_CELL = sizeof(D3DQuad) / sizeof(D3DVertex);
+        std::vector<int> walkable_cell_index;
+
+        void Build(int grid_w, int grid_h, const bool* walkable)
+        {
+            clear();
+            walkable_cell_index.assign(grid_w * grid_h, -1);
+            int walkable_count = 0;
+            for (int i = 0; i < grid_w * grid_h; i++) {
+                if (!walkable[i]) continue;
+                walkable_cell_index[i] = walkable_count++;
+            }
+            vertices.reserve(walkable_count * VERTS_PER_CELL);
+            dirty = true;
+        }
+
+        void SetCellColor(int grid_idx, DWORD color)
+        {
+            if (grid_idx < 0 || grid_idx >= static_cast<int>(walkable_cell_index.size())) return;
+            const int wi = walkable_cell_index[grid_idx];
+            if (wi < 0) return;
+            const size_t off = static_cast<size_t>(wi) * VERTS_PER_CELL;
+            if (vertices[off].color == color) return;
+            for (size_t v = 0; v < VERTS_PER_CELL; v++)
+                vertices[off + v].color = color;
+            dirty = true;
+        }
+    };
+
+    D3DFogBuffer fog_buffer;
+    D3DTriangleBuffer frontier_border;
+    D3DTriangleBuffer inaccessible_area_and_borders;
+    D3DTriangleBuffer enemy_vertex_buffer;
+    D3DCircle compass_circle;
+    D3DVertexBuffer* vertex_buffers[] = {&fog_buffer, &frontier_border, &inaccessible_area_and_borders, &enemy_vertex_buffer, &compass_circle};
+
+    constexpr float EXPLORE_CELL_SIZE = GW::Constants::Range::Adjacent / 2.f;
+
+    bool* explored_cells = nullptr;
+    GW::Constants::MapID explored_map_id = static_cast<GW::Constants::MapID>(0);
+    GW::Constants::InstanceType explored_instance_type = GW::Constants::InstanceType::Loading;
+
+    struct BorderSegment {
+        GW::Vec2f p1, p2;
+    };
+    std::vector<BorderSegment> cached_border_segments;
+
+    constexpr int COMPASS_CIRCLE_SEGMENTS = 64;
+    constexpr float COMPASS_CIRCLE_THICKNESS_PX = 0.5f;
+
+    bool* cached_walkable_grid = nullptr;
+    int cached_walkable_grid_size = 0;
+    int cached_grid_x0 = 0, cached_grid_y0 = 0, cached_grid_w = 0, cached_grid_h = 0;
+    GW::Constants::MapID border_map_id = static_cast<GW::Constants::MapID>(0);
+    float border_cached_zoom = 0.0f;
+
+    const D3DMATRIX IDENTITY_MATRIX = {{1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f}};
+
+    bool IsFrontierEdge(int idx)
+    {
+        if (!explored_cells) return false;
+        return explored_cells[idx];
+    }
+
+    int GetCellIndex(int gx, int gy)
+    {
+        const int lx = gx - cached_grid_x0;
+        const int ly = gy - cached_grid_y0;
+        if (lx < 0 || lx >= cached_grid_w || ly < 0 || ly >= cached_grid_h) return -1;
+        return ly * cached_grid_w + lx;
+    }
+
+    bool UpdateExploration(const GW::GamePos* player_pos)
+    {
+        static GW::GamePos last_check = {};
+        if (!player_pos || GW::GetSquareDistance(last_check, *player_pos) < GW::Constants::SqrRange::Adjacent) return false;
+        last_check = *player_pos;
+
+        const auto map_id = GW::Map::GetMapID();
+        const auto instance_type = GW::Map::GetInstanceType();
+        if (map_id != explored_map_id || instance_type != explored_instance_type) {
+            delete[] explored_cells;
+            explored_cells = nullptr;
+            explored_map_id = map_id;
+            explored_instance_type = instance_type;
+        }
+
+        if (!explored_cells && cached_walkable_grid_size > 0) explored_cells = new bool[cached_walkable_grid_size]();
+        if (!explored_cells) return false;
+
+        bool any_new = false;
+        constexpr int range_cells = static_cast<int>(COMPASS_RANGE / EXPLORE_CELL_SIZE) + 1;
+        const int player_cx = static_cast<int>(floorf(player_pos->x / EXPLORE_CELL_SIZE));
+        const int player_cy = static_cast<int>(floorf(player_pos->y / EXPLORE_CELL_SIZE));
+        constexpr float range_sq = COMPASS_RANGE * COMPASS_RANGE;
+
+        for (int dy = -range_cells; dy <= range_cells; dy++) {
+            for (int dx = -range_cells; dx <= range_cells; dx++) {
+                const int gx = player_cx + dx;
+                const int gy = player_cy + dy;
+                const float cell_center_x = (gx + 0.5f) * EXPLORE_CELL_SIZE;
+                const float cell_center_y = (gy + 0.5f) * EXPLORE_CELL_SIZE;
+                const float ddx = cell_center_x - player_pos->x;
+                const float ddy = cell_center_y - player_pos->y;
+                if (ddx * ddx + ddy * ddy > range_sq) continue;
+                const int idx = GetCellIndex(gx, gy);
+                if (idx >= 0 && !explored_cells[idx]) {
+                    explored_cells[idx] = true;
+                    fog_buffer.SetCellColor(idx, 0x00000000);
+                    any_new = true;
+                }
+            }
+        }
+        return any_new;
+    }
+
+    void InitFogBuffer()
+    {
+        fog_buffer.clear();
+        if (!cached_walkable_grid || cached_walkable_grid_size <= 0) return;
+
+        const float grid_origin_x = cached_grid_x0 * EXPLORE_CELL_SIZE;
+        const float grid_origin_y = cached_grid_y0 * EXPLORE_CELL_SIZE;
+
+        fog_buffer.Build(cached_grid_w, cached_grid_h, cached_walkable_grid);
+
+        for (int ly = 0; ly < cached_grid_h; ly++) {
+            for (int lx = 0; lx < cached_grid_w; lx++) {
+                const int idx = ly * cached_grid_w + lx;
+                if (!cached_walkable_grid[idx]) continue;
+                const float x0 = grid_origin_x + lx * EXPLORE_CELL_SIZE;
+                const float y0 = grid_origin_y + ly * EXPLORE_CELL_SIZE;
+                fog_buffer.push_back(D3DQuad({x0, y0}, {x0 + EXPLORE_CELL_SIZE, y0 + EXPLORE_CELL_SIZE}, vq_color_fog_unexplored));
+            }
+        }
+    }
+
+    void RebuildFrontierBorder()
+    {
+        frontier_border.clear();
+        if (!explored_cells || !cached_walkable_grid) return;
+
+        const float FRONTIER_HALF_THICKNESS = cached_px_to_game;
+        const float grid_origin_x = cached_grid_x0 * EXPLORE_CELL_SIZE;
+        const float grid_origin_y = cached_grid_y0 * EXPLORE_CELL_SIZE;
+
+        for (int ly = 0; ly < cached_grid_h; ly++) {
+            const float wy0 = grid_origin_y + ly * EXPLORE_CELL_SIZE;
+            const float wy1 = wy0 + EXPLORE_CELL_SIZE;
+            const int row_base = ly * cached_grid_w;
+            for (int lx = 0; lx < cached_grid_w; lx++) {
+                const int idx = row_base + lx;
+                if (!cached_walkable_grid[idx] || explored_cells[idx]) continue;
+                const float wx0 = grid_origin_x + lx * EXPLORE_CELL_SIZE;
+                const float wx1 = wx0 + EXPLORE_CELL_SIZE;
+                const auto edge = [&](bool cond, int neighbour_idx, float ax, float ay, float bx, float by) {
+                    if (cond && IsFrontierEdge(neighbour_idx)) frontier_border.push_back(D3DLine({ax, ay}, {bx, by}, FRONTIER_HALF_THICKNESS, vq_color_frontier));
+                };
+                edge(ly > 0, idx - cached_grid_w, wx0, wy0, wx1, wy0);
+                edge(ly < cached_grid_h - 1, idx + cached_grid_w, wx0, wy1, wx1, wy1);
+                edge(lx > 0, idx - 1, wx0, wy0, wx0, wy1);
+                edge(lx < cached_grid_w - 1, idx + 1, wx1, wy0, wx1, wy1);
+            }
+        }
+    }
+
+    bool IsGridCellWalkable(int gx, int gy)
+    {
+        const int idx = GetCellIndex(gx, gy);
+        return idx >= 0 && cached_walkable_grid[idx];
+    }
+
+    bool IsCellWalkableInTrapezoid(int gx, int gy, const GW::PathingTrapezoid& trap)
+    {
+        const float cx0 = gx * EXPLORE_CELL_SIZE;
+        const float cy0 = gy * EXPLORE_CELL_SIZE;
+        const float cx1 = cx0 + EXPLORE_CELL_SIZE;
+        const float cy1 = cy0 + EXPLORE_CELL_SIZE;
+
+        if (cy1 <= trap.YB || cy0 >= trap.YT) return false;
+        const float y_lo = std::max(cy0, trap.YB);
+        const float y_hi = std::min(cy1, trap.YT);
+        const float height = trap.YT - trap.YB;
+        if (height < 0.001f) return cx1 > std::min(trap.XBL, trap.XTL) && cx0 < std::max(trap.XBR, trap.XTR);
+
+        const float t_lo = (y_lo - trap.YB) / height;
+        const float t_hi = (y_hi - trap.YB) / height;
+        const float left = std::min(trap.XBL + t_lo * (trap.XTL - trap.XBL), trap.XBL + t_hi * (trap.XTL - trap.XBL));
+        const float right = std::max(trap.XBR + t_lo * (trap.XTR - trap.XBR), trap.XBR + t_hi * (trap.XTR - trap.XBR));
+        return cx1 > left && cx0 < right;
+    }
+
+    void BuildStaticMapGeometry()
+    {
+        const float border_thickness_game = cached_px_to_game;
+        const float gx0 = cached_grid_x0 * EXPLORE_CELL_SIZE;
+        const float gy0 = cached_grid_y0 * EXPLORE_CELL_SIZE;
+        const float gx1 = (cached_grid_x0 + cached_grid_w) * EXPLORE_CELL_SIZE;
+        const float gy1 = (cached_grid_y0 + cached_grid_h) * EXPLORE_CELL_SIZE;
+        const float ext = std::max(gx1 - gx0, gy1 - gy0) * 5.0f;
+
+        inaccessible_area_and_borders.clear();
+
+        inaccessible_area_and_borders.push_back(D3DQuad({gx0 - ext, gy0 - ext}, {gx1 + ext, gy0}, vq_color_inaccessible));
+        inaccessible_area_and_borders.push_back(D3DQuad({gx0 - ext, gy1}, {gx1 + ext, gy1 + ext}, vq_color_inaccessible));
+        inaccessible_area_and_borders.push_back(D3DQuad({gx0 - ext, gy0}, {gx0, gy1}, vq_color_inaccessible));
+        inaccessible_area_and_borders.push_back(D3DQuad({gx1, gy0}, {gx1 + ext, gy1}, vq_color_inaccessible));
+
+        for (int gy = cached_grid_y0; gy < cached_grid_y0 + cached_grid_h; gy++) {
+            const float y0 = gy * EXPLORE_CELL_SIZE;
+            const float y1 = y0 + EXPLORE_CELL_SIZE;
+            int run_start = -1;
+            for (int gx = cached_grid_x0; gx < cached_grid_x0 + cached_grid_w; gx++) {
+                if (!IsGridCellWalkable(gx, gy)) {
+                    if (run_start == -1) run_start = gx;
+                }
+                else {
+                    if (run_start != -1) {
+                        inaccessible_area_and_borders.push_back(D3DQuad({run_start * EXPLORE_CELL_SIZE, y0}, {gx * EXPLORE_CELL_SIZE, y1}, vq_color_inaccessible));
+                        run_start = -1;
+                    }
+                }
+            }
+            if (run_start != -1) {
+                inaccessible_area_and_borders.push_back(D3DQuad({run_start * EXPLORE_CELL_SIZE, y0}, {(cached_grid_x0 + cached_grid_w) * EXPLORE_CELL_SIZE, y1}, vq_color_inaccessible));
+            }
+        }
+
+        for (const auto& seg : cached_border_segments)
+            inaccessible_area_and_borders.push_back(D3DLine(seg.p1, seg.p2, border_thickness_game, vq_color_border));
+    }
+
+    void RebuildMapBorder()
+    {
+        cached_border_segments.clear();
+        delete[] cached_walkable_grid;
+        cached_walkable_grid = nullptr;
+        cached_walkable_grid_size = 0;
+        delete[] explored_cells;
+        explored_cells = nullptr;
+        explored_map_id = static_cast<GW::Constants::MapID>(0);
+
+        const auto pathing_map = GW::Map::GetPathingMap();
+        if (!pathing_map) return;
+
+        std::vector<const GW::PathingTrapezoid*> traps;
+        float min_x = FLT_MAX, min_y = FLT_MAX, max_x = -FLT_MAX, max_y = -FLT_MAX;
+        for (size_t p = 0; p < pathing_map->size(); p++) {
+            const auto& plane = pathing_map->at(p);
+            for (uint32_t t = 0; t < plane.trapezoid_count; t++) {
+                const auto& trap = plane.trapezoids[t];
+                traps.push_back(&trap);
+                min_x = std::min({min_x, trap.XTL, trap.XTR, trap.XBL, trap.XBR});
+                max_x = std::max({max_x, trap.XTL, trap.XTR, trap.XBL, trap.XBR});
+                min_y = std::min(min_y, trap.YB);
+                max_y = std::max(max_y, trap.YT);
+            }
+        }
+        if (traps.empty()) return;
+
+        cached_grid_x0 = static_cast<int>(floorf(min_x / EXPLORE_CELL_SIZE)) - 1;
+        cached_grid_y0 = static_cast<int>(floorf(min_y / EXPLORE_CELL_SIZE)) - 1;
+        cached_grid_w = static_cast<int>(ceilf(max_x / EXPLORE_CELL_SIZE)) + 1 - cached_grid_x0;
+        cached_grid_h = static_cast<int>(ceilf(max_y / EXPLORE_CELL_SIZE)) + 1 - cached_grid_y0;
+
+        cached_walkable_grid_size = cached_grid_w * cached_grid_h;
+        cached_walkable_grid = new bool[cached_walkable_grid_size]();
+
+        for (const auto* trap : traps) {
+            const int ty0 = std::max(0, static_cast<int>(floorf(trap->YB / EXPLORE_CELL_SIZE)) - cached_grid_y0);
+            const int ty1 = std::min(cached_grid_h - 1, static_cast<int>(ceilf(trap->YT / EXPLORE_CELL_SIZE)) - cached_grid_y0);
+            const int tx0 = std::max(0, static_cast<int>(floorf(std::min({trap->XTL, trap->XBL}) / EXPLORE_CELL_SIZE)) - cached_grid_x0);
+            const int tx1 = std::min(cached_grid_w - 1, static_cast<int>(ceilf(std::max({trap->XTR, trap->XBR}) / EXPLORE_CELL_SIZE)) - cached_grid_x0);
+            for (int cy = ty0; cy <= ty1; cy++) {
+                for (int cx = tx0; cx <= tx1; cx++) {
+                    const int abs_gx = cached_grid_x0 + cx;
+                    const int abs_gy = cached_grid_y0 + cy;
+                    const int idx = GetCellIndex(abs_gx, abs_gy);
+                    if (idx < 0 || cached_walkable_grid[idx]) continue;
+                    if (IsCellWalkableInTrapezoid(abs_gx, abs_gy, *trap))
+                        cached_walkable_grid[idx] = true;
+                }
+            }
+        }
+
+        for (int cy = 0; cy < cached_grid_h; cy++) {
+            for (int cx = 0; cx < cached_grid_w; cx++) {
+                const int idx = GetCellIndex(cached_grid_x0 + cx, cached_grid_y0 + cy);
+                if (idx < 0 || !cached_walkable_grid[idx]) continue;
+
+                const float x0 = (cached_grid_x0 + cx) * EXPLORE_CELL_SIZE;
+                const float y0 = (cached_grid_y0 + cy) * EXPLORE_CELL_SIZE;
+                const float x1 = x0 + EXPLORE_CELL_SIZE;
+                const float y1 = y0 + EXPLORE_CELL_SIZE;
+
+                if (!IsGridCellWalkable(cached_grid_x0 + cx, cached_grid_y0 + cy - 1)) cached_border_segments.push_back({{x0, y0}, {x1, y0}});
+                if (!IsGridCellWalkable(cached_grid_x0 + cx, cached_grid_y0 + cy + 1)) cached_border_segments.push_back({{x0, y1}, {x1, y1}});
+                if (!IsGridCellWalkable(cached_grid_x0 + cx - 1, cached_grid_y0 + cy)) cached_border_segments.push_back({{x0, y0}, {x0, y1}});
+                if (!IsGridCellWalkable(cached_grid_x0 + cx + 1, cached_grid_y0 + cy)) cached_border_segments.push_back({{x1, y0}, {x1, y1}});
+            }
+        }
+        BuildStaticMapGeometry();
+        InitFogBuffer();
+    }
+
+    bool nav_active = false;
+    GW::Vec2f nav_target_pos;
+    GW::Vec2f nav_marker_pos;
+    bool nav_marker_set = false;
+    bool nav_marker_hidden = false;
+
+    constexpr float MARKER_UPDATE_DIST = 500.0f * 500.f;
+
+    void StopNavigating()
+    {
+        nav_active = false;
+        nav_target_pos = {};
+        nav_marker_pos = {};
+        nav_marker_set = false;
+        nav_marker_hidden = false;
+        GW::GameThread::Enqueue([] { QuestModule::ClearCustomQuestMarker(); });
+    }
+
+    void SetNavTarget(const GW::Vec2f& target)
+    {
+        nav_active = true;
+        nav_target_pos = target;
+
+        const auto player = GW::Agents::GetControlledCharacter();
+        if (player) {
+            constexpr float HIDE_RANGE_SQ = (COMPASS_RANGE * 0.5f) * (COMPASS_RANGE * 0.5f);
+            const bool in_compass = GW::GetSquareDistance(target, player->pos) < HIDE_RANGE_SQ;
+
+            if (in_compass && !nav_marker_hidden) {
+                nav_marker_hidden = true;
+                QuestModule::ClearCustomQuestMarker();
+                return;
+            }
+            if (in_compass) return;
+
+            if (nav_marker_hidden) {
+                nav_marker_hidden = false;
+                nav_marker_set = false;
+            }
+        }
+
+        if (nav_marker_set && GW::GetSquareDistance(target, nav_marker_pos) < MARKER_UPDATE_DIST) return;
+
+        nav_marker_pos = target;
+        nav_marker_set = true;
+        GW::Vec2f world_pos;
+        if (WorldMapWidget::GamePosToWorldMap(target, world_pos)) {
+            GW::GameThread::Enqueue([world_pos] {
+                QuestModule::SetCustomQuestMarker(world_pos, true);
+            });
+        }
+    }
+
+    void NavigateToClosestEnemy()
+    {
+        const auto player = GW::Agents::GetControlledCharacter();
+        if (!player) return;
+
+        const auto& player_pos = player->pos;
+        float best_dist_sq = FLT_MAX;
+        GW::GamePos best_pos = {};
+        bool found = false;
+
+        for (size_t agent_id = 0, len = std::min(tracked_enemies_by_agent_id.size(), highest_trackable_agent_id + 1); agent_id < len; agent_id++) {
+            const auto& enemy = tracked_enemies_by_agent_id[agent_id];
+            if (enemy.state == EnemyState::NotApplicable) continue;
+            const float dist_sq = GW::GetDistance(enemy.pos, player_pos);
+            if (dist_sq < best_dist_sq) {
+                best_dist_sq = dist_sq;
+                best_pos = enemy.pos;
+                found = true;
+            }
+        }
+
+        if (!found) {
+            if (!nav_marker_hidden) {
+                nav_marker_hidden = true;
+                QuestModule::ClearCustomQuestMarker();
+            }
+            return;
+        }
+
+        SetNavTarget(best_pos);
+    }
+
+    constexpr float stale_range_sq = STALE_CHECK_RANGE * STALE_CHECK_RANGE;
+    D3DTeardrop teardrop_outline;
+    D3DTeardrop teardrop_fill;
+
+    void UpdateEnemyTracking()
+    {
+        const auto map_id = GW::Map::GetMapID();
+        const auto instance_type = GW::Map::GetInstanceType();
+        if (map_id != tracked_enemies_map_id || instance_type != tracked_enemies_instance_type) {
+            tracked_enemies_by_agent_id.assign(tracked_enemies_by_agent_id.size(), {});
+            tracked_enemies_map_id = map_id;
+            highest_trackable_agent_id = 0;
+            tracked_enemies_instance_type = instance_type;
+        }
+
+        const auto player_pos = GW::PlayerMgr::GetPlayerPosition();
+        const auto* agents = player_pos ? GW::Agents::GetAgentArray() : nullptr;
+        if (!agents) return;
+
+        static bool was_dead = false;
+        const bool is_dead = !GW::Agents::GetAgentMatchesFlags(GW::Agents::GetControlledCharacter(), GW::TargetFilter::Allies);
+        if (is_dead) { was_dead = true; return; }
+        if (was_dead) { was_dead = false; return; }
+
+        if (tracked_enemies_by_agent_id.size() < agents->size()) tracked_enemies_by_agent_id.resize(agents->size());
+
+        for (size_t agent_id = 0, len = agents->size(); agent_id < len; agent_id++) {
+            const auto agent = agents->at(agent_id);
+            auto& tracked = tracked_enemies_by_agent_id[agent_id];
+            if (!agent) {
+                if (tracked.state == EnemyState::Alive) {
+                    if (GW::GetSquareDistance(*player_pos, tracked.pos) < stale_range_sq) {
+                        tracked.state = EnemyState::Stale;
+                    }
+                }
+                if (tracked.state != EnemyState::NotApplicable) {
+                    highest_trackable_agent_id = agent_id;
+                }
+                continue;
+            }
+            const auto* living = agent->GetAsAgentLiving();
+
+            if (!living || living->allegiance != GW::Constants::Allegiance::Enemy || !living->GetIsAlive()) {
+                tracked.state = EnemyState::NotApplicable;
+                continue;
+            }
+            auto* npc = GW::Agents::GetNPCByID(living->player_number);
+            if (npc && (npc->IsSpirit() || npc->IsMinion())) {
+                tracked.state = EnemyState::NotApplicable;
+                continue;
+            }
+
+            tracked.pos = {living->pos.x, living->pos.y};
+            tracked.rotation = living->rotation_angle;
+            tracked.state = EnemyState::Alive;
+            highest_trackable_agent_id = agent_id;
+        }
+        for (size_t agent_id = agents->size(), len = tracked_enemies_by_agent_id.size(); agent_id < len; agent_id++) {
+            auto& tracked = tracked_enemies_by_agent_id[agent_id];
+            if (tracked.state == EnemyState::Alive) {
+                if (GW::GetSquareDistance(*player_pos, tracked.pos) < stale_range_sq) {
+                    tracked.state = EnemyState::Stale;
+                }
+            }
+            if (tracked.state != EnemyState::NotApplicable) {
+                highest_trackable_agent_id = agent_id;
+            }
+        }
+
+        if (nav_active) NavigateToClosestEnemy();
+        enemy_vertex_buffer.clear();
+
+        const float radius = vq_enemy_marker_size * cached_px_to_game;
+        const float radius_outer = radius + cached_px_to_game;
+        teardrop_fill.SetRadius(radius);
+        teardrop_outline.SetRadius(radius_outer);
+        teardrop_outline.SetColor(vq_color_enemy_outline);
+
+        for (size_t i = 0, len = std::min(tracked_enemies_by_agent_id.size(), highest_trackable_agent_id + 1); i < len; i++) {
+            auto& enemy = tracked_enemies_by_agent_id[i];
+            if (enemy.state == EnemyState::NotApplicable) continue;
+            const DWORD color = enemy.state == EnemyState::Stale ? vq_color_enemy_stale : vq_color_enemy_alive;
+            teardrop_fill.SetColor(color);
+            teardrop_fill.SetCenterColor(color);
+            teardrop_fill.SetPosition(enemy.pos);
+            teardrop_fill.SetRotation(enemy.rotation);
+            teardrop_outline.SetPosition(enemy.pos);
+            teardrop_outline.SetRotation(enemy.rotation);
+            enemy_vertex_buffer.push_back(teardrop_outline);
+            enemy_vertex_buffer.push_back(teardrop_fill);
+        }
+    }
+
+    void RebuildCompassCircle()
+    {
+        compass_circle = D3DCircle({0.f, 0.f}, COMPASS_RANGE, COMPASS_CIRCLE_THICKNESS_PX * cached_px_to_game, (DWORD)vq_color_compass, COMPASS_CIRCLE_SEGMENTS);
+    }
+
+    void DrawEnemyCountLabel()
+    {
+        if (!should_draw) return;
+
+        const auto mm_top_left = MissionMapWidget::GetTopLeft();
+        const auto mm_bottom_right = MissionMapWidget::GetBottomRight();
+
+        int alive_count = 0, stale_count = 0;
+        for (size_t i = 0, len = std::min(tracked_enemies_by_agent_id.size(), highest_trackable_agent_id + 1); i < len; i++) {
+            const auto& enemy = tracked_enemies_by_agent_id[i];
+            if (enemy.state == EnemyState::Alive)
+                alive_count++;
+            else if (enemy.state == EnemyState::Stale)
+                stale_count++;
+        }
+
+        const uint32_t foes_remaining = GW::Map::GetFoesToKill();
+        const bool has_vq_data = foes_remaining > 0 || GW::Map::GetFoesKilled() > 0;
+
+        if (!alive_count && !stale_count && !(has_vq_data && foes_remaining > 0)) return;
+
+        char label[128];
+        int pos = 0;
+        if (alive_count > 0 || stale_count > 0) {
+            pos += snprintf(label + pos, sizeof(label) - pos, "%d", alive_count);
+            if (stale_count > 0) pos += snprintf(label + pos, sizeof(label) - pos, " (+%d?)", stale_count);
+            if (has_vq_data) pos += snprintf(label + pos, sizeof(label) - pos, " / %u remaining", foes_remaining);
+        }
+        else {
+            pos += snprintf(label + pos, sizeof(label) - pos, "%u remaining", foes_remaining);
+        }
+
+        constexpr float PADDING = 8.0f;
+        const float btn_size = ImGui::GetTextLineHeight() + 12.0f;
+        const ImVec2 text_pos(mm_top_left.x + PADDING + btn_size, mm_bottom_right.y - ImGui::GetTextLineHeight() - PADDING);
+
+        auto* draw_list = ImGui::GetBackgroundDrawList();
+        draw_list->AddText({text_pos.x + 1, text_pos.y + 1}, IM_COL32(0, 0, 0, 220), label);
+        draw_list->AddText({text_pos.x - 1, text_pos.y - 1}, IM_COL32(0, 0, 0, 220), label);
+        draw_list->AddText({text_pos.x + 1, text_pos.y - 1}, IM_COL32(0, 0, 0, 220), label);
+        draw_list->AddText({text_pos.x - 1, text_pos.y + 1}, IM_COL32(0, 0, 0, 220), label);
+        draw_list->AddText(text_pos, IM_COL32(255, 255, 255, 255), label);
+    }
+
+    void DrawVanquishToggleButton()
+    {
+        const auto mm_top_left = MissionMapWidget::GetTopLeft();
+        const auto mm_bottom_right = MissionMapWidget::GetBottomRight();
+
+        constexpr float PADDING = 4.0f;
+        const float btn_size = ImGui::GetTextLineHeight() + PADDING * 2;
+        const ImVec2 btn_pos(mm_top_left.x + PADDING, mm_bottom_right.y - btn_size - PADDING);
+
+        ImGui::SetNextWindowPos(btn_pos);
+        ImGui::SetNextWindowSize({0, 0});
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {2, 2});
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, {0, 0});
+        if (ImGui::Begin("##vq_toggle", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings)) {
+            if (show_vq_overlay) {
+                if (ImGui::Button(ICON_FA_SKULL "##vq_off")) show_vq_overlay = false;
+                if (ImGui::IsItemHovered()) ImGui::SetTooltip("VQ overlay active. Click to hide.");
+            }
+            else {
+                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+                if (ImGui::Button(ICON_FA_SKULL "##vq_on")) show_vq_overlay = true;
+                ImGui::PopStyleColor();
+                if (ImGui::IsItemHovered()) ImGui::SetTooltip("VQ overlay hidden. Click to show.");
+            }
+        }
+        ImGui::End();
+        ImGui::PopStyleVar(2);
+    }
+} // namespace
+
+void VanquishMapOverlayWidget::Draw(IDirect3DDevice9* dx_device)
+{
+    if (!visible || !MissionMapWidget::IsRenderReady() || !ToolboxUtils::IsExplorable()) return;
+
+    const auto& gameToScreen = MissionMapWidget::GetGameToScreenMatrix();
+    const auto mm_top_left = MissionMapWidget::GetTopLeft();
+    const auto mm_bottom_right = MissionMapWidget::GetBottomRight();
+
+    if (should_draw) {
+        const D3DStateGuard guard(dx_device);
+
+        dx_device->SetRenderState(D3DRS_SCISSORTESTENABLE, TRUE);
+        dx_device->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
+        dx_device->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
+        dx_device->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
+        dx_device->SetRenderState(D3DRS_LIGHTING, FALSE);
+        dx_device->SetRenderState(D3DRS_ZENABLE, FALSE);
+
+        RECT scissorRect;
+        scissorRect.left = static_cast<LONG>(ceilf(mm_top_left.x));
+        scissorRect.top = static_cast<LONG>(ceilf(mm_top_left.y));
+        scissorRect.right = static_cast<LONG>(floorf(mm_bottom_right.x));
+        scissorRect.bottom = static_cast<LONG>(floorf(mm_bottom_right.y));
+        dx_device->SetScissorRect(&scissorRect);
+
+        D3DVIEWPORT9 vp;
+        dx_device->GetViewport(&vp);
+        const D3DMATRIX ortho = MakeOrthoProjection(static_cast<float>(vp.Width), static_cast<float>(vp.Height));
+
+        dx_device->SetFVF(D3DFVF_XYZ | D3DFVF_DIFFUSE);
+        dx_device->SetTransform(D3DTS_WORLD, &gameToScreen);
+        dx_device->SetTransform(D3DTS_VIEW, &IDENTITY_MATRIX);
+        dx_device->SetTransform(D3DTS_PROJECTION, &ortho);
+
+        inaccessible_area_and_borders.Render(dx_device);
+        fog_buffer.Render(dx_device);
+        frontier_border.Render(dx_device);
+        enemy_vertex_buffer.Render(dx_device);
+
+        if (!compass_circle.empty()) {
+            if (const auto* player = GW::Agents::GetControlledCharacter()) {
+                D3DMATRIX compassMatrix = gameToScreen;
+                compassMatrix._41 = roundf(gameToScreen._41 + player->pos.x * gameToScreen._11 + player->pos.y * gameToScreen._21);
+                compassMatrix._42 = roundf(gameToScreen._42 + player->pos.x * gameToScreen._12 + player->pos.y * gameToScreen._22);
+                dx_device->SetTransform(D3DTS_WORLD, &compassMatrix);
+                compass_circle.Render(dx_device);
+            }
+        }
+    }
+
+    // ImGui overlays
+    if (should_draw)
+        DrawEnemyCountLabel();
+    DrawVanquishToggleButton();
+}
+
+void VanquishMapOverlayWidget::Update(float)
+{
+    if (!MissionMapWidget::IsRenderReady()) return;
+
+    cached_px_to_game = MissionMapWidget::GetPxToGame();
+    const float zoom = MissionMapWidget::GetZoom();
+    should_draw = visible && show_vq_overlay && ToolboxUtils::IsExplorable();
+
+    const auto map_id = GW::Map::GetMapID();
+    const auto instance_type = GW::Map::GetInstanceType();
+    static GW::Constants::InstanceType border_instance_type = GW::Constants::InstanceType::Loading;
+    const bool map_changed = map_id != border_map_id || instance_type != border_instance_type;
+    const bool zoom_changed = zoom != border_cached_zoom;
+    const auto player_pos = GW::PlayerMgr::GetPlayerPosition();
+
+    if (map_changed || zoom_changed) {
+        border_cached_zoom = zoom;
+        RebuildCompassCircle();
+        if (map_changed) {
+            border_map_id = map_id;
+            border_instance_type = instance_type;
+            RebuildMapBorder(); // calls BuildStaticMapGeometry + InitFogBuffer
+        }
+        else {
+            BuildStaticMapGeometry(); // zoom changed, rebuild with new thickness
+            RebuildFrontierBorder();
+        }
+    }
+
+    // Frame rate check for expensive updates
+    static clock_t last_check = TIMER_INIT();
+    if (!ToolboxUtils::FrameRateCheck(last_check, 30)) return;
+
+    if (ToolboxUtils::IsExplorable()) {
+        UpdateEnemyTracking();
+        if (UpdateExploration(player_pos))
+            RebuildFrontierBorder();
+    } else {
+        if (nav_active) StopNavigating();
+        if (tracked_enemies_map_id != GW::Constants::MapID::None) {
+            tracked_enemies_by_agent_id.assign(tracked_enemies_by_agent_id.size(), {});
+            tracked_enemies_map_id = GW::Constants::MapID::None;
+            tracked_enemies_instance_type = GW::Constants::InstanceType::Loading;
+            highest_trackable_agent_id = 0;
+            enemy_vertex_buffer.clear();
+        }
+        if (explored_map_id != GW::Constants::MapID::None) {
+            delete[] explored_cells;
+            explored_cells = nullptr;
+            explored_map_id = GW::Constants::MapID::None;
+            explored_instance_type = GW::Constants::InstanceType::Loading;
+        }
+    }
+}
+
+void VanquishMapOverlayWidget::Terminate()
+{
+    ToolboxWidget::Terminate();
+    delete[] cached_walkable_grid;
+    cached_walkable_grid = nullptr;
+    delete[] explored_cells;
+    explored_cells = nullptr;
+
+    for (auto buffer : vertex_buffers) {
+        buffer->Terminate();
+    }
+}
+
+void VanquishMapOverlayWidget::LoadSettings(ToolboxIni* ini)
+{
+    ToolboxWidget::LoadSettings(ini);
+    LOAD_BOOL(show_vq_overlay);
+
+    LOAD_COLOR(vq_color_inaccessible);
+    LOAD_COLOR(vq_color_fog_unexplored);
+    LOAD_COLOR(vq_color_border);
+    LOAD_COLOR(vq_color_frontier);
+    LOAD_COLOR(vq_color_compass);
+    LOAD_COLOR(vq_color_enemy_alive);
+    LOAD_COLOR(vq_color_enemy_stale);
+    LOAD_COLOR(vq_color_enemy_outline);
+    LOAD_FLOAT(vq_enemy_marker_size);
+}
+
+void VanquishMapOverlayWidget::SaveSettings(ToolboxIni* ini)
+{
+    ToolboxWidget::SaveSettings(ini);
+    SAVE_BOOL(show_vq_overlay);
+
+    SAVE_COLOR(vq_color_inaccessible);
+    SAVE_COLOR(vq_color_fog_unexplored);
+    SAVE_COLOR(vq_color_border);
+    SAVE_COLOR(vq_color_frontier);
+    SAVE_COLOR(vq_color_compass);
+    SAVE_COLOR(vq_color_enemy_alive);
+    SAVE_COLOR(vq_color_enemy_stale);
+    SAVE_COLOR(vq_color_enemy_outline);
+    SAVE_FLOAT(vq_enemy_marker_size);
+}
+
+void VanquishMapOverlayWidget::DrawSettingsInternal()
+{
+    ImGui::Checkbox("Vanquish Overlay", &show_vq_overlay);
+    ImGui::ShowHelp("Tracks enemy positions as they enter compass range.\nBlue = alive, Orange = last known (moved away).\nArrows on orange markers show last movement direction.\nAlso highlights areas you've explored during this session on the mission map.");
+
+    if (show_vq_overlay) {
+        ImGui::Indent();
+        bool static_changed = false;
+        bool fog_changed = false;
+
+        static_changed |= Colors::DrawSettingHueWheel("Inaccessible area", &vq_color_inaccessible);
+        static_changed |= Colors::DrawSettingHueWheel("Map border", &vq_color_border);
+        fog_changed |= Colors::DrawSettingHueWheel("Unexplored fog", &vq_color_fog_unexplored);
+        fog_changed |= Colors::DrawSettingHueWheel("Frontier edge", &vq_color_frontier);
+        bool rebuild_compass = Colors::DrawSettingHueWheel("Compass range", &vq_color_compass);
+        Colors::DrawSettingHueWheel("Enemy (alive)", &vq_color_enemy_alive);
+        Colors::DrawSettingHueWheel("Enemy (last known position)", &vq_color_enemy_stale);
+        Colors::DrawSettingHueWheel("Enemy outline", &vq_color_enemy_outline);
+        ImGui::SliderFloat("Enemy marker size", &vq_enemy_marker_size, 3.0f, 20.0f, "%.0f");
+        ImGui::Unindent();
+
+        if (static_changed) BuildStaticMapGeometry();
+        if (fog_changed) {
+            InitFogBuffer();
+            RebuildFrontierBorder();
+        }
+        if (rebuild_compass) RebuildCompassCircle();
+    }
+}
+
+bool VanquishMapOverlayWidget::ContextMenuItems()
+{
+    if (!show_vq_overlay) return true;
+    if (nav_active) {
+        if (ImGui::Button("Stop navigating")) {
+            StopNavigating();
+            return false;
+        }
+    }
+    else {
+        if (ImGui::Button("Navigate to closest enemy")) {
+            nav_active = true;
+            NavigateToClosestEnemy();
+            return false;
+        }
+    }
+    return true;
+}
+
+void VanquishMapOverlayWidget::GetTrackedEnemyCounts(int& alive, int& stale)
+{
+    alive = 0;
+    stale = 0;
+    for (size_t i = 0, len = std::min(tracked_enemies_by_agent_id.size(), highest_trackable_agent_id + 1); i < len; i++) {
+        const auto& enemy = tracked_enemies_by_agent_id[i];
+        if (enemy.state == EnemyState::Alive) alive++;
+        else if (enemy.state == EnemyState::Stale) stale++;
+    }
+}
+
+bool VanquishMapOverlayWidget::IsOverlayActive() { return should_draw; }
+bool VanquishMapOverlayWidget::IsNavigating() { return nav_active; }
+void VanquishMapOverlayWidget::StopNavigating() { ::StopNavigating(); }

--- a/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
+++ b/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
@@ -112,8 +112,6 @@ namespace {
     GW::Constants::MapID border_map_id = static_cast<GW::Constants::MapID>(0);
     float border_cached_zoom = 0.0f;
 
-    const D3DMATRIX IDENTITY_MATRIX = {{1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f}};
-
     bool IsFrontierEdge(int idx)
     {
         if (!explored_cells) return false;
@@ -615,41 +613,11 @@ namespace {
         ImGui::End();
         ImGui::PopStyleVar(2);
     }
-} // namespace
+    void OnMissionMapDraw(IDirect3DDevice9* dx_device)
+    {
+        if (!should_draw) return;
 
-void VanquishMapOverlayWidget::Draw(IDirect3DDevice9* dx_device)
-{
-    if (!visible || !MissionMapWidget::IsRenderReady() || !ToolboxUtils::IsExplorable()) return;
-
-    const auto& gameToScreen = MissionMapWidget::GetGameToScreenMatrix();
-    const auto mm_top_left = MissionMapWidget::GetTopLeft();
-    const auto mm_bottom_right = MissionMapWidget::GetBottomRight();
-
-    if (should_draw) {
-        const D3DStateGuard guard(dx_device);
-
-        dx_device->SetRenderState(D3DRS_SCISSORTESTENABLE, TRUE);
-        dx_device->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
-        dx_device->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
-        dx_device->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
-        dx_device->SetRenderState(D3DRS_LIGHTING, FALSE);
-        dx_device->SetRenderState(D3DRS_ZENABLE, FALSE);
-
-        RECT scissorRect;
-        scissorRect.left = static_cast<LONG>(ceilf(mm_top_left.x));
-        scissorRect.top = static_cast<LONG>(ceilf(mm_top_left.y));
-        scissorRect.right = static_cast<LONG>(floorf(mm_bottom_right.x));
-        scissorRect.bottom = static_cast<LONG>(floorf(mm_bottom_right.y));
-        dx_device->SetScissorRect(&scissorRect);
-
-        D3DVIEWPORT9 vp;
-        dx_device->GetViewport(&vp);
-        const D3DMATRIX ortho = MakeOrthoProjection(static_cast<float>(vp.Width), static_cast<float>(vp.Height));
-
-        dx_device->SetFVF(D3DFVF_XYZ | D3DFVF_DIFFUSE);
-        dx_device->SetTransform(D3DTS_WORLD, &gameToScreen);
-        dx_device->SetTransform(D3DTS_VIEW, &IDENTITY_MATRIX);
-        dx_device->SetTransform(D3DTS_PROJECTION, &ortho);
+        const auto& gameToScreen = MissionMapWidget::GetGameToScreenMatrix();
 
         inaccessible_area_and_borders.Render(dx_device);
         fog_buffer.Render(dx_device);
@@ -663,9 +631,21 @@ void VanquishMapOverlayWidget::Draw(IDirect3DDevice9* dx_device)
                 compassMatrix._42 = roundf(gameToScreen._42 + player->pos.x * gameToScreen._12 + player->pos.y * gameToScreen._22);
                 dx_device->SetTransform(D3DTS_WORLD, &compassMatrix);
                 compass_circle.Render(dx_device);
+                dx_device->SetTransform(D3DTS_WORLD, &gameToScreen);
             }
         }
     }
+} // namespace
+
+void VanquishMapOverlayWidget::Initialize()
+{
+    ToolboxWidget::Initialize();
+    MissionMapWidget::AddDrawCallback(&OnMissionMapDraw);
+}
+
+void VanquishMapOverlayWidget::Draw(IDirect3DDevice9*)
+{
+    if (!visible || !MissionMapWidget::IsRenderReady() || !ToolboxUtils::IsExplorable()) return;
 
     // ImGui overlays
     if (should_draw)
@@ -731,6 +711,8 @@ void VanquishMapOverlayWidget::Update(float)
 void VanquishMapOverlayWidget::Terminate()
 {
     ToolboxWidget::Terminate();
+    MissionMapWidget::RemoveDrawCallback(&OnMissionMapDraw);
+
     delete[] cached_walkable_grid;
     cached_walkable_grid = nullptr;
     delete[] explored_cells;

--- a/GWToolboxdll/Widgets/VanquishMapOverlayWidget.h
+++ b/GWToolboxdll/Widgets/VanquishMapOverlayWidget.h
@@ -24,6 +24,7 @@ public:
     [[nodiscard]] const char* Name() const override { return "Vanquish Overlay"; }
     [[nodiscard]] const char* Icon() const override { return ICON_FA_SKULL; }
 
+    void Initialize() override;
     void Draw(IDirect3DDevice9* pDevice) override;
     void Update(float delta) override;
     void Terminate() override;

--- a/GWToolboxdll/Widgets/VanquishMapOverlayWidget.h
+++ b/GWToolboxdll/Widgets/VanquishMapOverlayWidget.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <ToolboxWidget.h>
+
+class VanquishMapOverlayWidget : public ToolboxWidget {
+    VanquishMapOverlayWidget()
+    {
+        visible = false;
+        can_show_in_main_window = false;
+        has_closebutton = false;
+        has_titlebar = false;
+        is_resizable = false;
+        is_movable = false;
+    }
+    ~VanquishMapOverlayWidget() override = default;
+
+public:
+    static VanquishMapOverlayWidget& Instance()
+    {
+        static VanquishMapOverlayWidget instance;
+        return instance;
+    }
+
+    [[nodiscard]] const char* Name() const override { return "Vanquish Overlay"; }
+    [[nodiscard]] const char* Icon() const override { return ICON_FA_SKULL; }
+
+    void Draw(IDirect3DDevice9* pDevice) override;
+    void Update(float delta) override;
+    void Terminate() override;
+    void LoadSettings(ToolboxIni* ini) override;
+    void SaveSettings(ToolboxIni* ini) override;
+    void DrawSettingsInternal() override;
+
+    static void GetTrackedEnemyCounts(int& alive, int& stale);
+    static bool IsOverlayActive();
+    static bool IsNavigating();
+    static void StopNavigating();
+    static bool ContextMenuItems();
+};

--- a/GWToolboxdll/Widgets/VanquishWidget.cpp
+++ b/GWToolboxdll/Widgets/VanquishWidget.cpp
@@ -7,7 +7,7 @@
 #include <GWCA/Managers/PartyMgr.h>
 
 #include <Widgets/VanquishWidget.h>
-#include <Widgets/MissionMapWidget.h>
+#include <Widgets/VanquishMapOverlayWidget.h>
 
 #include "Utils/FontLoader.h"
 
@@ -57,7 +57,7 @@ void VanquishWidget::Draw(IDirect3DDevice9*)
         const ImVec2 max(min.x + size.x, min.y + size.y);
         if (ctrl_pressed && ImGui::IsMouseReleased(0) && ImGui::IsMouseHoveringRect(min, max)) {
             int alive = 0, stale = 0;
-            MissionMapWidget::GetTrackedEnemyCounts(alive, stale);
+            VanquishMapOverlayWidget::GetTrackedEnemyCounts(alive, stale);
             const int located = alive + stale;
             char buffer[256];
             if (located > 0) {

--- a/GWToolboxdll/Windows/TargetInfoWindow.cpp
+++ b/GWToolboxdll/Windows/TargetInfoWindow.cpp
@@ -1,5 +1,7 @@
 #include "stdafx.h"
 
+#include <regex>
+
 #include <GWCA/Constants/Constants.h>
 
 #include <GWCA/GameEntities/Agent.h>
@@ -88,30 +90,48 @@ namespace {
         {
             if (state != TargetInfoState::ParsingWikiPage)
                 return;
-            static constexpr ctll::fixed_string skill_list_regex = R"(<h2><span class=\"mw-headline\" id=\"Skills\">(?:.*?)<ul.*?>(.*?)(?:<\/ul>|<h2><span class=\"mw-headline\"))";
 
-            if (const auto m = ctre::search<skill_list_regex>(wiki_content)) {
-                const auto skill_list_found = m.get<1>().to_string();
+            // Use std::regex instead of CTRE to avoid MSVC template depth limits
+            static const std::regex skill_list_regex("<h2><span class=\"mw-headline\" id=\"Skills\">(?:.*?)<ul.*?>(.*?)(?:</ul>|<h2><span class=\"mw-headline\")", std::regex::optimize);
+            static const std::regex skill_link_regex("<a href=\"[^\"]+\" title=\"([^\"]+)\"", std::regex::optimize);
+            static const std::regex skill_section_regex("<h2><span class=\"mw-headline\" id=\"Skills\">(.*?)<h2><span class=\"mw-headline\"", std::regex::optimize);
+            static const std::regex build_table_regex("<table class=\"skill-progression\" (?:.*?)>(.*?)</table>", std::regex::optimize);
+            static const std::regex armor_ratings_regex("<h2><span class=\"mw-headline\" id=\"Armor_ratings\">(.*?)(?:</table>|<h2><span class=\"mw-headline\")", std::regex::optimize);
+            static const std::regex armor_cell_regex("<td>.*?title=\"([^\"]+)\".*?<td>([0-9 ()]+).*?</td>", std::regex::optimize);
+            static const std::regex items_dropped_regex("<h2><span class=\"mw-headline\" id=\"Items_dropped\">(?:.*?)<ul(.*?)(?:</ul>|<h2><span class=\"mw-headline\")", std::regex::optimize);
+            static const std::regex link_regex("<a href=\"[^\"]+\" title=\"([^\"]+)\"", std::regex::optimize);
+            static const std::regex skills_offered_regex("<h2><span class=\"mw-headline\" id=\"Skills_offered\">(?:.*?)<table(.*?)</table>", std::regex::optimize);
+            static const std::regex notes_regex("<h2><span class=\"mw-headline\" id=\"Notes\">(?:.*?)<ul.*?>(.*?)(?:</ul>|<h2><span class=\"mw-headline\")", std::regex::optimize);
+            static const std::regex list_item_regex("<li>(.*?)</li>", std::regex::optimize);
+            static const std::regex infobox_regex("<table[^>]+ class=\"[^\"]+infobox(.*?)</table>", std::regex::optimize);
+            static const std::regex infobox_image_regex("<td[^>]+class=\"[^\"]*?infobox-image.*?<a .*?href=\"[^\"]*?File:([^\"]+)", std::regex::optimize);
+            static const std::regex infobox_row_regex("(?:<tr>|<tr[^>]+>).*?(?:<th>|<th[^>]+>)(.*?)</th>.*?(?:<td>|<td[^>]+>)(.*?)</td>.*?</tr>", std::regex::optimize);
 
-                static constexpr ctll::fixed_string skill_link_regex = R"(<a href="[^"]+" title="([^"]+)\")";
-                for (const auto& skill_match : ctre::search_all<skill_link_regex>(skill_list_found)) {
-                    const auto skill_name = skill_match.get<1>().to_string();
+            std::smatch match;
+
+            if (std::regex_search(wiki_content, match, skill_list_regex)) {
+                const std::string skill_list_found = match[1].str();
+                auto skills_begin = std::sregex_iterator(skill_list_found.begin(), skill_list_found.end(), skill_link_regex);
+                auto skills_end = std::sregex_iterator();
+                for (auto it = skills_begin; it != skills_end; ++it) {
+                    const auto skill_name = (*it)[1].str();
                     const auto skill_name_text = native_html_to_text(skill_name);
                     if (skill_ids_by_name.contains(skill_name_text) && !std::ranges::contains(wiki_skills, skill_ids_by_name[skill_name_text])) {
                         wiki_skills.push_back(skill_ids_by_name[skill_name_text]);
                     }
                 }
             }
-            static constexpr ctll::fixed_string skill_section_regex = R"(<h2><span class="mw-headline" id="Skills">(.*?)<h2><span class="mw-headline")";
 
-            if (const auto section_match = ctre::search<skill_section_regex>(wiki_content)) {
-                const auto section_html = section_match.get<1>().to_string();
-                static constexpr ctll::fixed_string build_table_regex = R"(<table class="skill-progression" (?:.*?)>(.*?)<\/table>)";
-                for (const auto& table_match : ctre::search_all<build_table_regex>(section_html)) {
-                    const auto table_html = table_match.get<1>().to_string();
-                    static constexpr ctll::fixed_string skill_link_regex = R"(<a href="[^"]+" title="([^"]+)\")";
-                    for (const auto& skill_match : ctre::search_all<skill_link_regex>(table_html)) {
-                        std::string skill_name = skill_match.get<1>().to_string();
+            if (std::regex_search(wiki_content, match, skill_section_regex)) {
+                const std::string section_html = match[1].str();
+                auto tables_begin = std::sregex_iterator(section_html.begin(), section_html.end(), build_table_regex);
+                auto tables_end = std::sregex_iterator();
+                for (auto table_it = tables_begin; table_it != tables_end; ++table_it) {
+                    const std::string table_html = (*table_it)[1].str();
+                    auto skills_begin = std::sregex_iterator(table_html.begin(), table_html.end(), skill_link_regex);
+                    auto skills_end = std::sregex_iterator();
+                    for (auto skill_it = skills_begin; skill_it != skills_end; ++skill_it) {
+                        std::string skill_name = (*skill_it)[1].str();
                         std::string skill_name_text = native_html_to_text(skill_name);
                         if (skill_ids_by_name.contains(skill_name_text) && !std::ranges::contains(wiki_skills, skill_ids_by_name[skill_name_text])) {
                             wiki_skills.push_back(skill_ids_by_name[skill_name_text]);
@@ -120,40 +140,36 @@ namespace {
                 }
             }
 
-            static constexpr ctll::fixed_string armor_ratings_regex = R"(<h2><span class=\"mw-headline\" id=\"Armor_ratings\">(.*?)(?:<\/table>|<h2><span class=\"mw-headline\"))";
-            if (const auto m = ctre::search<armor_ratings_regex>(wiki_content)) {
-                const auto armor_table_found = m.get<1>().to_string();
-
-                static constexpr ctll::fixed_string armor_cell_regex = R"(<td>.*?title="([^"]+)\".*?<td>([0-9 \(\)]+).*?</td>)";
-                for (const auto& armor_match : ctre::search_all<armor_cell_regex>(armor_table_found)) {
-                    std::string key = armor_match.get<1>().to_string();
-                    std::string val = armor_match.get<2>().to_string();
+            if (std::regex_search(wiki_content, match, armor_ratings_regex)) {
+                const std::string armor_table_found = match[1].str();
+                auto armor_begin = std::sregex_iterator(armor_table_found.begin(), armor_table_found.end(), armor_cell_regex);
+                auto armor_end = std::sregex_iterator();
+                for (auto it = armor_begin; it != armor_end; ++it) {
+                    std::string key = (*it)[1].str();
+                    std::string val = (*it)[2].str();
                     from_html(key);
                     from_html(val);
                     if (!key.empty() && !val.empty()) wiki_armor_ratings[key] = val;
                 }
             }
 
-            static constexpr ctll::fixed_string items_dropped_regex = R"(<h2><span class=\"mw-headline\" id=\"Items_dropped\">(?:.*?)<ul(.*?)(?:<\/ul>|<h2><span class=\"mw-headline\"))";
-            if (const auto m = ctre::search<items_dropped_regex>(wiki_content)) {
-                const auto list_found = m.get<1>().to_string();
-
-                static constexpr ctll::fixed_string link_regex = R"(<a href="[^"]+" title="([^"]+)\")";
-                for (const auto& item_match : ctre::search_all<link_regex>(list_found)) {
-                    std::string item_dropped_html = item_match.get<1>().to_string();
+            if (std::regex_search(wiki_content, match, items_dropped_regex)) {
+                const std::string list_found = match[1].str();
+                auto items_begin = std::sregex_iterator(list_found.begin(), list_found.end(), link_regex);
+                auto items_end = std::sregex_iterator();
+                for (auto it = items_begin; it != items_end; ++it) {
+                    std::string item_dropped_html = (*it)[1].str();
                     const auto item_dropped_text = native_html_to_text(item_dropped_html);
                     if (!std::ranges::contains(items_dropped, item_dropped_text)) items_dropped.push_back(item_dropped_text);
                 }
             }
 
-            static constexpr ctll::fixed_string skills_offered_regex = R"(<h2><span class=\"mw-headline\" id=\"Skills_offered\">(?:.*?)<table(.*?)<\/table>)";
-
-            if (const auto m = ctre::search<skills_offered_regex>(wiki_content)) {
-                const auto skill_list_found = m.get<1>().to_string();
-
-                static constexpr ctll::fixed_string skill_link_regex = R"(<a href="[^"]+" title="([^"]+)\")";
-                for (const auto& skill_match : ctre::search_all<skill_link_regex>(skill_list_found)) {
-                    const auto skill_name = skill_match.get<1>().to_string();
+            if (std::regex_search(wiki_content, match, skills_offered_regex)) {
+                const std::string skill_list_found = match[1].str();
+                auto skills_begin = std::sregex_iterator(skill_list_found.begin(), skill_list_found.end(), skill_link_regex);
+                auto skills_end = std::sregex_iterator();
+                for (auto it = skills_begin; it != skills_end; ++it) {
+                    const auto skill_name = (*it)[1].str();
                     const auto skill_name_text = native_html_to_text(skill_name);
                     if (skill_ids_by_name.contains(skill_name_text) && !std::ranges::contains(skills_offered, skill_ids_by_name[skill_name_text])) {
                         skills_offered.push_back(skill_ids_by_name[skill_name_text]);
@@ -161,13 +177,12 @@ namespace {
                 }
             }
 
-            static constexpr ctll::fixed_string notes_regex = R"(<h2><span class=\"mw-headline\" id=\"Notes\">(?:.*?)<ul.*?>(.*?)(?:<\/ul>|<h2><span class=\"mw-headline\"))";
-            if (const auto m = ctre::search<notes_regex>(wiki_content)) {
-                const auto list_found = m.get<1>().to_string();
-
-                static constexpr ctll::fixed_string list_item_regex = R"(<li>(.*?)</li>)";
-                for (const auto& note_match : ctre::search_all<list_item_regex>(list_found)) {
-                    auto line = note_match.get<1>().to_string();
+            if (std::regex_search(wiki_content, match, notes_regex)) {
+                const std::string list_found = match[1].str();
+                auto notes_begin = std::sregex_iterator(list_found.begin(), list_found.end(), list_item_regex);
+                auto notes_end = std::sregex_iterator();
+                for (auto it = notes_begin; it != notes_end; ++it) {
+                    auto line = (*it)[1].str();
                     from_html(line);
                     if (!line.empty()) {
                         notes.push_back(line);
@@ -175,20 +190,20 @@ namespace {
                 }
             }
 
-            static constexpr ctll::fixed_string infobox_regex = R"(<table[^>]+ class=\"[^\"]+infobox(.*?)</table>)";
-            if (const auto m = ctre::search<infobox_regex>(wiki_content)) {
-                const auto infobox_content = m.get<1>().to_string();
+            if (std::regex_search(wiki_content, match, infobox_regex)) {
+                const std::string infobox_content = match[1].str();
 
-                static constexpr ctll::fixed_string infobox_image_regex = R"(<td[^>]+class=\"[^\"]*?infobox-image.*?<a .*?href=\"[^\"]*?File:([^\"]+))";
-                if (const auto img_match = ctre::search<infobox_image_regex>(infobox_content)) {
-                    image_url = img_match.get<1>().to_string();
+                std::smatch img_match;
+                if (std::regex_search(infobox_content, img_match, infobox_image_regex)) {
+                    image_url = img_match[1].str();
                     image = Resources::GetGuildWarsWikiImage(image_url.c_str(), 0, false);
                 }
 
-                static constexpr ctll::fixed_string infobox_row_regex = R"((?:<tr>|<tr[^>]+>).*?(?:<th>|<th[^>]+>)(.*?)</th>.*?(?:<td>|<td[^>]+>)(.*?)</td>.*?</tr>)";
-                for (const auto& row_match : ctre::search_all<infobox_row_regex>(infobox_content)) {
-                    std::string key = row_match.get<1>().to_string();
-                    std::string val = row_match.get<2>().to_string();
+                auto rows_begin = std::sregex_iterator(infobox_content.begin(), infobox_content.end(), infobox_row_regex);
+                auto rows_end = std::sregex_iterator();
+                for (auto it = rows_begin; it != rows_end; ++it) {
+                    std::string key = (*it)[1].str();
+                    std::string val = (*it)[2].str();
                     from_html(key);
                     from_html(val);
                     if (!key.empty() && !val.empty()) infobox_deets[key] = val;

--- a/deploy.bat
+++ b/deploy.bat
@@ -1,0 +1,17 @@
+@echo off
+setlocal
+
+set CONFIG=%~1
+if "%CONFIG%"=="" set CONFIG=Debug
+
+set SCRIPT_DIR=%~dp0
+set BUILD_DIR=%SCRIPT_DIR%build
+set BIN_DIR=%SCRIPT_DIR%bin\%CONFIG%
+set DLL=%BIN_DIR%\GWToolboxdll.dll
+set LAUNCHER=%BIN_DIR%\GWToolbox.exe
+
+echo Building (%CONFIG%)...
+cmake --build "%BUILD_DIR%" --target GWToolboxdll GWToolbox --config %CONFIG% -j 2 || exit /b 1
+
+echo Hot-reloading...
+"%LAUNCHER%" /hotreload "%DLL%"


### PR DESCRIPTION
MissionMapWidget now handles only mission map infrastructure (frame hooking, D3D rendering pipeline, coordinate transforms, minimap lines). All vanquish overlay logic (enemy tracking, fog/exploration, frontier borders, navigation, settings) moves to VanquishOverlayModule.

Notes:

This changes where settings are stored, so anyone who has previously changed any of the VQ overlay settings will have their settings restored to defaults.