### PR TITLE
Add hot reload support and deploy script

### DIFF
--- a/GWToolbox/Settings.cpp
+++ b/GWToolbox/Settings.cpp
@@ -24,6 +24,7 @@ void PrintUsage(const bool terminate)
             "    /localdll                  Check launcher directory for toolbox dll, won't try to install or update\n\n"
 
             "    /pid <process id>          Process id of the target in which to inject\n"
+            "    /hotreload <dll path>      Signal running toolbox to unload, copy DLL, and re-inject\n"
     );
 
     if (terminate) {
@@ -102,6 +103,15 @@ void ParseCommandLine()
         }
         else if (wcscmp(arg, L"/localdll") == 0) {
             settings.localdll = true;
+            settings.noupdate = true;
+            settings.noinstall = true;
+        }
+        else if (wcscmp(arg, L"/hotreload") == 0) {
+            if (++i == argc) {
+                fprintf(stderr, "'/hotreload' must be followed by a DLL path\n");
+                PrintUsage(true);
+            }
+            settings.hotreload_dll = argv[i];
             settings.noupdate = true;
             settings.noinstall = true;
         }

--- a/GWToolbox/Settings.h
+++ b/GWToolbox/Settings.h
@@ -13,7 +13,8 @@ struct Settings {
     bool noupdate = false;
     bool noinstall = false;
     bool localdll = false;
-    uint32_t pid;
+    uint32_t pid = 0;
+    std::wstring hotreload_dll; // path to DLL to hot-reload
 };
 
 extern Settings settings;

--- a/GWToolbox/main.cpp
+++ b/GWToolbox/main.cpp
@@ -37,6 +37,101 @@ static bool RestartAsAdminForInjection(const uint32_t target_pid)
     return RestartAsAdmin(args);
 }
 
+static bool HotReloadDll(const std::wstring& new_dll_path)
+{
+    // Find all GW processes with toolbox loaded
+    std::vector<Process> gw_processes;
+    if (!GetProcessesByWindowClass(gw_processes, L"ArenaNet_Dx_Window_Class")) {
+        fprintf(stderr, "No Guild Wars processes found\n");
+        return false;
+    }
+
+    std::vector<DWORD> target_pids;
+    for (auto& proc : gw_processes) {
+        ProcessModule module;
+        if (proc.GetModule(&module, L"GWToolboxdll.dll")) {
+            target_pids.push_back(proc.GetProcessId());
+        }
+    }
+    gw_processes.clear(); // Close handles so DLL can unload
+
+    if (target_pids.empty()) {
+        fprintf(stderr, "No Guild Wars process with GWToolbox loaded found\n");
+        return false;
+    }
+
+    // Signal all instances to unload (manual-reset event, all instances see it)
+    HANDLE event = OpenEventA(EVENT_MODIFY_STATE, FALSE, "GWToolboxHotReload");
+    if (!event) {
+        fprintf(stderr, "Could not open GWToolboxHotReload event (error %lu)\n", GetLastError());
+        return false;
+    }
+    if (!SetEvent(event)) {
+        fprintf(stderr, "SetEvent failed (error %lu)\n", GetLastError());
+        CloseHandle(event);
+        return false;
+    }
+
+    // Wait for all instances to unload
+    for (int i = 0; i < 300; i++) { // up to 30 seconds
+        Sleep(100);
+        bool all_unloaded = true;
+        for (const auto pid : target_pids) {
+            Process proc;
+            if (!proc.Open(pid, PROCESS_QUERY_INFORMATION | PROCESS_VM_READ)) continue;
+            ProcessModule check;
+            if (proc.GetModule(&check, L"GWToolboxdll.dll")) {
+                all_unloaded = false;
+                break;
+            }
+        }
+        if (all_unloaded) goto unloaded;
+    }
+    ResetEvent(event);
+    CloseHandle(event);
+    fprintf(stderr, "Timeout waiting for DLLs to unload\n");
+    return false;
+
+unloaded:
+    ResetEvent(event);
+    CloseHandle(event);
+    Sleep(200); // Brief pause to ensure file handles are released
+
+    // Determine install path and copy the new DLL
+    std::filesystem::path install_dll = GetInstallationDir();
+    if (install_dll.empty()) {
+        fprintf(stderr, "GetInstallationDir failed\n");
+        return false;
+    }
+    install_dll = install_dll.parent_path() / L"GWToolboxdll.dll";
+
+    std::error_code ec;
+    std::filesystem::copy_file(new_dll_path, install_dll,
+        std::filesystem::copy_options::overwrite_existing, ec);
+    if (ec) {
+        fprintf(stderr, "Failed to copy DLL: %s\n", ec.message().c_str());
+        return false;
+    }
+
+    // Re-inject into all processes
+    bool any_failed = false;
+    for (const auto pid : target_pids) {
+        Process proc;
+        if (!proc.Open(pid)) {
+            any_failed = true;
+            continue;
+        }
+        DWORD exit_code;
+        if (!InjectRemoteThread(&proc, install_dll.wstring().c_str(), &exit_code)) {
+            fprintf(stderr, "Re-injection into process %lu failed\n", pid);
+            any_failed = true;
+            continue;
+        }
+    }
+
+    return !any_failed;
+}
+
 static bool InjectInstalledDllInProcess(const Process* process, std::wstring& error)
 {
     std::wstring exe_filename;
@@ -156,6 +251,13 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int n
     AsyncRestScopeInit RestInitializer;
 
     Process proc;
+    if (!settings.hotreload_dll.empty()) {
+        if (!HotReloadDll(settings.hotreload_dll)) {
+            fprintf(stderr, "Hot reload failed\n");
+            return 1;
+        }
+        return 0;
+    }
     if (settings.install) {
         Install(settings.quiet, error);
         return 0;

--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -64,6 +64,8 @@ namespace {
     bool must_self_destruct = false; // is true when toolbox should quit
     GW::HookEntry Update_Entry;
 
+    HANDLE hot_reload_event = nullptr;
+
     std::recursive_mutex module_management_mutex;
 
 
@@ -729,6 +731,11 @@ DWORD __stdcall GWToolbox::MainLoop(LPVOID module) noexcept
         Sleep(160);
 
         UnloadGWCADll();
+
+        if (hot_reload_event) {
+            CloseHandle(hot_reload_event);
+            hot_reload_event = nullptr;
+        }
     } __except (EXCEPT_EXPRESSION_ENTRY) {
         Log::Log("SafeThreadEntry __except body\n");
     }
@@ -762,6 +769,10 @@ void GWToolbox::Initialize(LPVOID module)
     UpdateInitialising(.0f);
     AttachGameLoopCallback();
     pending_detach_dll = false;
+
+    if (!hot_reload_event) {
+        hot_reload_event = CreateEventA(nullptr, TRUE, FALSE, "GWToolboxHotReload");
+    }
 }
 
 std::filesystem::path GWToolbox::LoadSettings()
@@ -935,6 +946,13 @@ void GWToolbox::Update(GW::HookStatus*)
             break;
         default:
             return;
+    }
+
+    // Check for hot reload signal
+    if (hot_reload_event && WaitForSingleObject(hot_reload_event, 0) == WAIT_OBJECT_0) {
+        Log::Info("Hot reload requested, unloading...");
+        SignalTerminate();
+        return;
     }
 
     UpdateModulesTerminating(delta_f);

--- a/deploy.bat
+++ b/deploy.bat
@@ -1,0 +1,17 @@
+@echo off
+setlocal
+
+set CONFIG=%~1
+if "%CONFIG%"=="" set CONFIG=Debug
+
+set SCRIPT_DIR=%~dp0
+set BUILD_DIR=%SCRIPT_DIR%build
+set BIN_DIR=%SCRIPT_DIR%bin\%CONFIG%
+set DLL=%BIN_DIR%\GWToolboxdll.dll
+set LAUNCHER=%BIN_DIR%\GWToolbox.exe
+
+echo Building (%CONFIG%)...
+cmake --build "%BUILD_DIR%" --target GWToolboxdll GWToolbox --config %CONFIG% -j 2 || exit /b 1
+
+echo Hot-reloading...
+"%LAUNCHER%" /hotreload "%DLL%"


### PR DESCRIPTION
Launcher: /hotreload <dll-path> signals running toolbox instances to unload via a named event, waits for unload, copies the new DLL, and re-injects into all GW processes.

DLL: creates a manual-reset event "GWToolboxHotReload" on init and polls it each frame to trigger graceful unloading.

Includes deploy.bat convenience script for build + hot reload. Supports config argument: deploy.bat Debug or deploy.bat RelWithDebInfo.