### PR TITLE
Fix wrong character selected when -character arg is absent

### DIFF
--- a/GWToolboxdll/Modules/LoginModule.cpp
+++ b/GWToolboxdll/Modules/LoginModule.cpp
@@ -27,7 +27,7 @@ namespace {
         wchar_t* cmp = nullptr;
         [[maybe_unused]] const bool ok = GW::UI::GetCommandLinePref(L"character", &cmp);
         DEBUG_ASSERT(ok);
-        if (cmp == parameter_value) {
+        if (cmp && cmp == parameter_value && wcslen(cmp) > 0) {
             // charname parameter
             original_charname_parameter = parameter_value;
             parameter_value = const_cast<wchar_t*>(L" ");


### PR DESCRIPTION
When -character is not specified, GetCommandLinePref sets cmp to an empty string pointer that matches parameter_value, causing the hook to replace it with a space and selecting the wrong character slot.