### PR TITLE
Fix iterator invalidations

### DIFF
--- a/GWToolboxdll/Modules/PluginModule.cpp
+++ b/GWToolboxdll/Modules/PluginModule.cpp
@@ -261,10 +261,13 @@ void PluginModule::LoadSettings(ToolboxIni* ini)
         }
     }
     // Find any plugins that are currently loaded but not supposed to be
-    auto to_unload = std::views::filter(plugins_loaded, [&](auto plugin) {
-        return !std::ranges::contains(plugins_loaded_from_ini, plugin);
-    });
-    for (const auto plugin : std::views::reverse(to_unload)) {
+    std::vector<Plugin*> to_unload;
+    for (const auto plugin : plugins_loaded) {
+        if (!std::ranges::contains(plugins_loaded_from_ini, plugin)) {
+            to_unload.push_back(plugin);
+        }
+    }
+    for (const auto plugin : to_unload) {
         UnloadPlugin(plugin);
     }
 }
@@ -310,7 +313,8 @@ void PluginModule::Update(const float delta)
 void PluginModule::SignalTerminate()
 {
     ToolboxUIElement::SignalTerminate();
-    for (const auto plugin : plugins_loaded) {
+    const auto snapshot = plugins_loaded;
+    for (const auto plugin : snapshot) {
         UnloadPlugin(plugin);
     }
 }

--- a/GWToolboxdll/Modules/PluginModule.cpp
+++ b/GWToolboxdll/Modules/PluginModule.cpp
@@ -261,13 +261,10 @@ void PluginModule::LoadSettings(ToolboxIni* ini)
         }
     }
     // Find any plugins that are currently loaded but not supposed to be
-    std::vector<Plugin*> to_unload;
-    for (const auto plugin : plugins_loaded) {
-        if (!std::ranges::contains(plugins_loaded_from_ini, plugin)) {
-            to_unload.push_back(plugin);
-        }
-    }
-    for (const auto plugin : to_unload) {
+    auto to_unload = std::views::filter(plugins_loaded, [&](auto plugin) {
+        return !std::ranges::contains(plugins_loaded_from_ini, plugin);
+    }) | std::ranges::to<std::vector>();
+    for (const auto plugin : std::views::reverse(to_unload)) {
         UnloadPlugin(plugin);
     }
 }


### PR DESCRIPTION
Both of these loops iterate `plugins_loaded` while mutating it via `UnloadPlugin` which invalidates the iterators and skips some plugins. This manifests itself when using 3 or more plugins as we then see `ASSERT(plugins_loaded.empty())` failing when closing the game and causing the crash modal to appear.

This started happening after commit 40037100, I think because of the change in `UpdateModulesTerminating` which calls `m->Terminate()` when panicking:
```
if (m->CanTerminate() || panicking) {
    m->Terminate();
```

The fix is to clone the vectors before iterating them which ensures the iterators keep walking while we mutate `plugins_loaded`.