### PR TITLE
Fix damage overlay disappearing for players below a disconnected party member

### DIFF
--- a/GWToolboxdll/Widgets/SnapsToPartyWindow.cpp
+++ b/GWToolboxdll/Widgets/SnapsToPartyWindow.cpp
@@ -241,10 +241,10 @@ bool SnapsToPartyWindow::RecalculatePartyPositions() {
         const auto player_container = GW::UI::GetChildFrame(player_health_bars, player.login_number);
         agent_health_bar = GW::UI::GetChildFrame(player_container, 0);
         if (!agent_health_bar)
-            return false;
+            continue;
         const auto agent_id = GW::PlayerMgr::GetPlayerAgentId(player.login_number);
         if (!agent_id)
-            return false;
+            continue;
         GetFramePosition(agent_health_bar, relative_to, &top_left, &bottom_right);
         agent_health_bar_positions[agent_id] = { top_left, bottom_right };
         for (auto& hero : party->heroes) {


### PR DESCRIPTION
RecalculatePartyPositions() was returning false when encountering a disconnected player's missing health bar frame, aborting position calculation for all remaining party members.

<img width="683" height="237" alt="image" src="https://github.com/user-attachments/assets/7f7ebecb-cb61-4808-ada2-8f4204c1ca55" />