### PR TITLE
fix: ensure FillCircle are drawn on Minimap

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/CustomRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/CustomRenderer.h
@@ -40,7 +40,7 @@ class CustomRenderer : public D3DVertexBuffer {
     private:
         void SyncGeometry();
 
-        D3DFillCircle fill_circle;
+        D3DFillCircle fill_circle{{}, 1.f};
         D3DLineCircle line_circle;
     };
 


### PR DESCRIPTION
Prior, FillCircle markers were properly rendered on terrain (if enabled), but would not show up on Minimap anymore, even with an alpha component. I did not investigate when this started happening.

Since all the mutation methods check for `vertices.empty()`, we need to initialize `D3DFillCircle` with the non-default constructor. With this, FillCircle markers properly render on the Minimap.