### PR TITLE
Skip agents with NaN positions in VQ enemy tracking

### DIFF
--- a/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
+++ b/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
@@ -504,6 +504,7 @@ namespace {
                 continue;
             }
 
+            if (isnan(living->pos.x) || isnan(living->pos.y)) continue;
             tracked.pos = {living->pos.x, living->pos.y};
             tracked.rotation = living->rotation_angle;
             tracked.state = EnemyState::Alive;


### PR DESCRIPTION
Agents with NaN coordinates permanently poison the static D3DTeardrop templates via SetPosition's relative delta path.