### PR TITLE
feat: refill pcons when entering outpost and enabled

### DIFF
--- a/GWToolboxdll/Windows/Pcons.cpp
+++ b/GWToolboxdll/Windows/Pcons.cpp
@@ -187,7 +187,10 @@ void Pcon::Update(int delay)
         maptype = GW::Map::GetInstanceType();
         SetPlayerName();
         ResetCounts();
-        Refill(refill_if_below_threshold && IsEnabled() && PconsWindow::Instance().GetEnabled());
+        Refill(false);
+        if (maptype == GW::Constants::InstanceType::Outpost) {
+            Refill(refill_if_below_threshold && IsEnabled() && PconsWindow::Instance().GetEnabled());
+        }
     }
     // Refill pcons if needed.
     UpdateRefill();

--- a/GWToolboxdll/Windows/PconsWindow.cpp
+++ b/GWToolboxdll/Windows/PconsWindow.cpp
@@ -664,10 +664,6 @@ void PconsWindow::MapChanged()
 
     player = nullptr;
     elite_area_disable_triggered = false;
-    // Refill pcons automatically when entering an outpost if enabled.
-    if (instance_type == InstanceType::Outpost) {
-        Refill(enabled && Pcon::refill_if_below_threshold);
-    }
     // Find out which objectives we need to complete for this map.
     const auto map_objectives_it = objectives_to_complete_by_map_id.find(map_id);
     if (map_objectives_it != objectives_to_complete_by_map_id.end()) {

--- a/GWToolboxdll/Windows/PconsWindow.cpp
+++ b/GWToolboxdll/Windows/PconsWindow.cpp
@@ -664,6 +664,10 @@ void PconsWindow::MapChanged()
 
     player = nullptr;
     elite_area_disable_triggered = false;
+    // Refill pcons automatically when entering an outpost if enabled.
+    if (instance_type == InstanceType::Outpost) {
+        Refill(enabled && Pcon::refill_if_below_threshold);
+    }
     // Find out which objectives we need to complete for this map.
     const auto map_objectives_it = objectives_to_complete_by_map_id.find(map_id);
     if (map_objectives_it != objectives_to_complete_by_map_id.end()) {


### PR DESCRIPTION
I have heard from several people now that this is the behavior they are expecting out of this feature, but they think it is broken or buggy.

* Expected behavior: Entering outpost with pcons enabled -> refill triggers
* Current behavior: Entering outpost with pcons enabled -> disable pcons -> enable pcons -> refill triggers

This implemented what these users are expecting. Personally it's never really bothered me, but I can see their point.