### PR TITLE
Fix use-after-free in AccountInventoryWindow::RemoveItem

### DIFF
--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -2850,7 +2850,7 @@ void GetAchievements(const std::wstring& player_name)
     if (!(!player_name.empty() && player_name.size() < 20)) {
         return Log::Error("Invalid player name for hall of monuments command");
     }
-    memset(&hom_achievements, 0, sizeof(hom_achievements));
+    hom_achievements = HallOfMonumentsAchievements{};
     HallOfMonumentsModule::AsyncGetAccountAchievements(
         player_name, &hom_achievements, OnAchievementsLoaded);
 }

--- a/GWToolboxdll/Windows/AccountInventoryWindow.cpp
+++ b/GWToolboxdll/Windows/AccountInventoryWindow.cpp
@@ -1234,12 +1234,13 @@ struct MergeStack;
                 (*it)->occupied_inventory--;
             }
         }
+        auto ini_id = GetIniID(i->account, i->character);
         if (auto it = inventory.find(i); it != inventory.end()) {
             inventory.erase(it);
         }
         inventory_lookup.erase(item_id);
         needs_sorting = true;
-        inventory_dirty.insert(GetIniID(i->account, i->character));
+        inventory_dirty.insert(std::move(ini_id));
         save_dirty_inventories_timer = TIMER_INIT();
         return true;
     }

--- a/GWToolboxdll/Windows/AccountInventoryWindow.cpp
+++ b/GWToolboxdll/Windows/AccountInventoryWindow.cpp
@@ -215,8 +215,6 @@ const char* HERO_NAME[] = {
         IDirect3DTexture9** texture; // output of GetItemImage
         std::string location{};     // (Player) <Storage Pane> or <Hero Name>
 
-        bool valid() { return bag_id > GW::Constants::Bag::None && bag_id < GW::Constants::Bag::Max;}
-
         void CopyKeyTo(InventoryItem* i)
         {
             i->account = account;
@@ -469,7 +467,7 @@ struct MergeStack;
     clock_t map_loaded_delayed_timer{};
     clock_t save_dirty_inventories_timer{};
     bool map_loaded_delayed_trigger = false;
-    InventoryItem item_to_move;
+    std::optional<InventoryItem> item_to_move;
 
     // config options
     bool detailed_view = false;
@@ -607,9 +605,9 @@ struct MergeStack;
 
     void MoveItem()
     {
-        if (!item_to_move.valid()) return;
-        auto it = inventory.find(&item_to_move);
-        memset(&item_to_move, 0, sizeof(item_to_move));
+        if (!item_to_move) return;
+        auto it = inventory.find(&*item_to_move);
+        item_to_move.reset();
         if (it == inventory.end()) return;
 
         const auto item = it->get();
@@ -639,8 +637,8 @@ struct MergeStack;
         if (!memeq(&i->account,&current_account)) return;
         if (move) {
             if (IsHeroArmor(i->hero_id, i->slot)) return; // can not unequip hero armor
-            memset(&item_to_move, 0, sizeof(item_to_move));
-            i->CopyKeyTo(&item_to_move);
+            item_to_move.emplace();
+            i->CopyKeyTo(&*item_to_move);
         }
         bool item_is_in_chest = IsChestBag(i->bag_id);
         bool item_is_on_current_character = i->character == current_character;
@@ -650,10 +648,10 @@ struct MergeStack;
             cached_heroes.push_back(i->hero_id);
         }
 
-        if (item_is_in_chest && item_to_move.valid()) {
+        if (item_is_in_chest && item_to_move) {
             MoveItem();
         }
-        else if (item_is_in_chest && !item_to_move.valid()) {
+        else if (item_is_in_chest && !item_to_move) {
             GW::GameThread::Enqueue([bag_id = i->bag_id]() {
                 uint32_t pane;
                 if (bag_id == GW::Constants::Bag::Material_Storage)
@@ -670,7 +668,7 @@ struct MergeStack;
             reroll_stage = RerollStage::RerollToItem;
             StepReroll();
         }
-        else if (item_is_on_current_character && !item_is_on_hero && item_to_move.valid()) {
+        else if (item_is_on_current_character && !item_is_on_hero && item_to_move) {
             MoveItem();
         }
         else if (!item_is_on_current_character) {
@@ -681,7 +679,7 @@ struct MergeStack;
             if (!RerollWindow::Instance().Reroll(TextUtils::StringToWString(i->character).c_str(), false, false, true, false)) {
                 // reroll failed, abort
                 reroll_stage = RerollStage::None;
-                memset(&item_to_move, 0, sizeof(item_to_move));
+                item_to_move.reset();
             }
         }
     }
@@ -1192,7 +1190,7 @@ struct MergeStack;
         save_dirty_inventories_timer = TIMER_INIT();
         needs_sorting = true;
 
-        if (item_to_move.valid() && GW::Constants::HeroID::NoHero != i_raw->hero_id && ItemEqual{}(&item_to_move, i_raw)) {
+        if (item_to_move && GW::Constants::HeroID::NoHero != i_raw->hero_id && ItemEqual{}(&*item_to_move, i_raw)) {
             // If we had to change characters and item_to_move is on a player character,
             // then we get here during loading before MoveItem can work.
             // In that case StepReroll will take care of moving the item.
@@ -1378,7 +1376,7 @@ void AccountInventoryWindow::Update(float)
     }
     if (reroll_stage == RerollStage::WaitForHeroWithItem && TIMER_DIFF(add_hero_timer) > ADD_HERO_TIMEOUT) {
         // failed to load hero in time, forget item_to_move
-        memset(&item_to_move, 0, sizeof(item_to_move));
+        item_to_move.reset();
         reroll_stage = RerollStage::None;
     }
     if (save_dirty_inventories_timer && !inventory_dirty.empty() && TIMER_DIFF(save_dirty_inventories_timer) > SAVE_DIRTY_INVENTORIES_TIMEOUT) {


### PR DESCRIPTION
ref #1845

```
 	KERNELBASE.dll!751a4644()	Unknown
 	[Frames below may be incorrect and/or missing, no symbols loaded for KERNELBASE.dll]	
 	GWToolboxdll.dll!_CxxThrowException() Line 79	C++
 	GWToolboxdll.dll!std::_Xlength_error(const char * _Message) Line 19	C++
 	GWToolboxdll.dll!std::_Xlen_string() Line 574	C++
 	GWToolboxdll.dll!std::wstring::_Construct<2,wchar_t const *>(const wchar_t * const _Arg, const unsigned int _Count) Line 932	C++
 	GWToolboxdll.dll!std::wstring::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>>(const std::wstring & _Right) Line 768	C++
>	GWToolboxdll.dll!AccountInventoryWindow::RemoveItem(unsigned int item_id) Line 1673	C++
 	GWToolboxdll.dll!AccountInventoryWindow::Initialize::__l6::<lambda_1>::operator()(GW::HookStatus * __formal, GW::UI::UIMessage message_id, void * wparam, void * __formal) Line 152	C++
 	GWToolboxdll.dll!std::invoke<`AccountInventoryWindow::Initialize'::`6'::<lambda_1> &,GW::HookStatus *,enum GW::UI::UIMessage,void *,void *>(AccountInventoryWindow::Initialize::__l6::<lambda_1> & _Obj, GW::HookStatus * && _Arg1, GW::UI::UIMessage && <_Args2_0>, void * && <_Args2_1>, void * && <_Args2_2>) Line 1811	C++
 	GWToolboxdll.dll!std::_Func_impl_no_alloc<`AccountInventoryWindow::Initialize'::`6'::<lambda_1>,void,GW::HookStatus *,enum GW::UI::UIMessage,void *,void *>::_Do_call(GW::HookStatus * && <_Args_0>, GW::UI::UIMessage && <_Args_1>, void * && <_Args_2>, void * && <_Args_3>) Line 1005	C++
 	gwca.dll!5a332ce1()	Unknown
 	gwca.dll!5a33160b()	Unknown
 	Gw.exe!00cb5528()	Unknown
 	Gw.exe!00cb0e03()	Unknown
 	Gw.exe!00c475f6()	Unknown
 	Gw.exe!00c47ab4()	Unknown
 	Gw.exe!0091f7db()	Unknown
 	Gw.exe!0091fe6d()	Unknown
 	Gw.exe!00a9c998()	Unknown
 	Gw.exe!00a991a2()	Unknown
 	Gw.exe!00a98768()	Unknown
 	Gw.exe!00a9a88f()	Unknown
 	Gw.exe!00911030()	Unknown
 	Gw.exe!0090df27()	Unknown
 	Gw.exe!00910792()	Unknown
 	Gw.exe!00a44a01()	Unknown
 	kernel32.dll!76c85d49()	Unknown
 	ntdll.dll!76f1d83b()	Unknown
 	ntdll.dll!76f1d7c1()	Unknown
```

Happened while standing on nine rings. `i` seems to be invalid (because we just removed it from the container):

<!--StartFragment-->

  | Name | Value | Type
-- | -- | -- | --
◢ | i | 0x67457c20 {account=&lt;Error reading characters of string.&gt; character=&lt;Error reading characters of string.&gt; ...} | AccountInventoryWindow::InventoryItem *
  | ▶ account | &lt;Error reading characters of string.&gt; | std::wstring
  | ▶ character | &lt;Error reading characters of string.&gt; | std::wstring


<!--EndFragment-->
