### PR TITLE
Expand VQ overlay scissor rect to prevent base map bleeding at edges

### DIFF
--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -229,10 +229,10 @@ namespace {
         dx_device->SetRenderState(D3DRS_ZENABLE, FALSE);
 
         RECT scissorRect;
-        scissorRect.left = static_cast<LONG>(ceilf(mission_map_top_left.x));
-        scissorRect.top = static_cast<LONG>(ceilf(mission_map_top_left.y));
-        scissorRect.right = static_cast<LONG>(floorf(mission_map_bottom_right.x));
-        scissorRect.bottom = static_cast<LONG>(floorf(mission_map_bottom_right.y));
+        scissorRect.left = static_cast<LONG>(floorf(mission_map_top_left.x));
+        scissorRect.top = static_cast<LONG>(floorf(mission_map_top_left.y));
+        scissorRect.right = static_cast<LONG>(ceilf(mission_map_bottom_right.x));
+        scissorRect.bottom = static_cast<LONG>(ceilf(mission_map_bottom_right.y));
         dx_device->SetScissorRect(&scissorRect);
 
         D3DVIEWPORT9 vp;


### PR DESCRIPTION
Before:

<img width="814" height="806" alt="image" src="https://github.com/user-attachments/assets/293cfd75-029a-4ef5-86cb-72e38e3d6be8" />

After:

<img width="817" height="816" alt="image" src="https://github.com/user-attachments/assets/308e2341-f991-48d8-b565-c990d6f051e7" />
