### PR TITLE
Account inventory filter fixes

### DIFF
--- a/GWToolboxdll/Windows/AccountInventoryWindow.cpp
+++ b/GWToolboxdll/Windows/AccountInventoryWindow.cpp
@@ -1869,7 +1869,7 @@ void AccountInventoryWindow::Draw(IDirect3DDevice9*)
     ImGui::SetNextItemWidth(300.f * font_scale);
     if (ImGui::InputText("###item_filter", item_filter_buf, _countof(item_filter_buf))) needs_sorting = true;
     ImGui::SameLine();
-    ImGui::Text("Filter   %d/%d Items", filtered_item_count, inventory_sorted.size());
+    ImGui::Text("Filter   %d/%d Items", filtered_item_count, inventory.size());
     ImGui::TableNextRow();
     ImGui::TableNextColumn();
 

--- a/GWToolboxdll/Windows/AccountInventoryWindow.cpp
+++ b/GWToolboxdll/Windows/AccountInventoryWindow.cpp
@@ -1733,7 +1733,14 @@ void AccountInventoryWindow::Draw(IDirect3DDevice9*)
         ImGui::End();
     }
 
-    if (!visible) return;
+    if (!visible) {
+        name_filter_buf[0] = '\0';
+        location_filter_buf[0] = '\0';
+        model_ID_filter_buf[0] = '\0';
+        item_filter_buf[0] = '\0';
+        needs_sorting = true;
+        return;
+    }
 
     ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowSize(ImVec2(760.f * font_scale, 400.f * font_scale), ImGuiCond_FirstUseEver);


### PR DESCRIPTION
On that note, the trade window (and also some other windows) has a similar problem: When closing and re-opening it the filter text is still there, but the trade list isn't actually being filtered. The filter text field should either be cleared, or the filter should be re-applied. Personally I'm leaning towards clearing the text field - because closing a window usually implies destroying (non-persistent) state. Any preference?