### PR TITLE
Fix completion window defaulting to wrong character name

### DIFF
--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -2160,7 +2160,8 @@ void CompletionWindow::Draw(IDirect3DDevice9* device)
 
     const std::wstring* sel = nullptr;
     if (chosen_player_name_s.empty()) {
-        chosen_player_name = GetPlayerName() || L"";
+        const auto pn = GetPlayerName();
+        chosen_player_name = pn ? pn : L"";
         chosen_player_name_s = TextUtils::WStringToString(chosen_player_name);
         CheckProgress();
     }


### PR DESCRIPTION
The || operator on two pointers yields bool, not a null-coalesced pointer. This caused chosen_player_name to be set to wchar_t(1), which displays as "?" in the character selector.