### PR TITLE
Hint at Custom Agents text color from name tag color settings

### DIFF
--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -2375,6 +2375,7 @@ void GameSettings::DrawSettingsInternal()
     ImGui::NewLine();
     ImGui::Checkbox("Show 'You have N Lockpicks' on Locked Chest name tags", &show_amount_of_lockpicks_under_locked_chest_nametag);
     ImGui::Text("In-game name tag colors:");
+    ImGui::ShowHelp("These set global name tag colors by category.\nTo set a custom color for a specific agent, see Minimap > Custom Agents > Text Color.");
     ImGui::Indent();
     ImGui::StartSpacedElements(checkbox_w);
     constexpr uint32_t flags = ImGuiColorEditFlags_NoInputs;


### PR DESCRIPTION
## Summary
Adds a help tooltip beside the "In-game name tag colors" header in Game Settings, pointing users to **Minimap > Custom Agents > Text Color** for setting per-agent name tag colors. The per-agent option was non-discoverable before.

## Test plan
- [ ] Open Game Settings and hover the help icon beside "In-game name tag colors:" — confirm the tooltip mentions Minimap > Custom Agents > Text Color

Closes #1671

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo6qnHxyVrRdgwgY7ZRNnu)_