### PR TITLE
Hide empty campaign categories in Completion window

### DIFF
--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -2303,6 +2303,9 @@ void CompletionWindow::Draw(IDirect3DDevice9* device)
             }
             filtered.push_back(outpost);
         }
+        if (hide_completed_missions && filtered.empty()) {
+            continue;
+        }
         char label[128];
         snprintf(label, _countof(label), "%s (%d of %d unlocked) - %.0f%%###campaign_outposts_%d",
                  CampaignName(campaign), completed, unlockable_outposts.size(), static_cast<float>(completed) / static_cast<float>(unlockable_outposts.size()) * 100.f, campaign);
@@ -2327,6 +2330,9 @@ void CompletionWindow::Draw(IDirect3DDevice9* device)
                 }
             }
             filtered.push_back(camp_missions[i]);
+        }
+        if (hide_completed_missions && filtered.empty()) {
+            continue;
         }
         char label[128];
         snprintf(label, _countof(label), "%s (%d of %d completed) - %.0f%%###campaign_missions_%d", CampaignName(camp.first), completed, camp_missions.size(), static_cast<float>(completed) / static_cast<float>(camp_missions.size()) * 100.f, camp.first);
@@ -2354,6 +2360,9 @@ void CompletionWindow::Draw(IDirect3DDevice9* device)
                 }
             }
             filtered.push_back(camp_missions[i]);
+        }
+        if (hide_completed_vanquishes && filtered.empty()) {
+            continue;
         }
         char label[128];
         snprintf(label, _countof(label), "%s (%d of %d completed) - %.0f%%###campaign_vanquishes_%d", CampaignName(camp.first), completed, camp_missions.size(), static_cast<float>(completed) / static_cast<float>(camp_missions.size()) * 100.f,
@@ -2395,6 +2404,9 @@ void CompletionWindow::Draw(IDirect3DDevice9* device)
             }
             filtered.push_back(camp_missions[i]);
         }
+        if (hide_unlocked_skills && filtered.empty()) {
+            continue;
+        }
         char label[128];
         snprintf(label, _countof(label), "%s (%d of %d completed) - %.0f%%###campaign_eskills_%d", CampaignName(camp.first), completed, camp_missions.size(), static_cast<float>(completed) / static_cast<float>(camp_missions.size()) * 100.f, camp.first);
         if (ImGui::CollapsingHeader(label)) {
@@ -2414,6 +2426,9 @@ void CompletionWindow::Draw(IDirect3DDevice9* device)
                 }
             }
             filtered.push_back(camp_missions[i]);
+        }
+        if (hide_unlocked_skills && filtered.empty()) {
+            continue;
         }
         char label[128];
         snprintf(label, _countof(label), "%s (%d of %d completed) - %.0f%%###campaign_skills_%d", CampaignName(camp.first), completed, camp_missions.size(), static_cast<float>(completed) / static_cast<float>(camp_missions.size()) * 100.f, camp.first);


### PR DESCRIPTION
## Summary
When "Hide completed/unlocked" was enabled and a campaign had nothing left to display, the empty category header still rendered and was clickable. Skip drawing the header for outposts, missions, vanquishes, elite skills and PvE skills when the filtered list is empty due to the hide setting.

## Test plan
- [ ] Enable "Hide completed missions" with a campaign at 100% — confirm that campaign's header no longer appears in the Missions section
- [ ] Repeat for outposts, vanquishes, elite skills, PvE skills
- [ ] Confirm partially-completed and 0%-completed categories still display normally

Closes #1567

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo6qnHxyVrRdgwgY7ZRNnu)_