### PR TITLE
Skip ignored players when forwarding trade chat

### DIFF
--- a/GWToolboxdll/Windows/TradeWindow.cpp
+++ b/GWToolboxdll/Windows/TradeWindow.cpp
@@ -21,6 +21,7 @@
 #include <Utils/GuiUtils.h>
 
 #include <Modules/Resources.h>
+#include <Windows/FriendListWindow.h>
 #include <Windows/TradeWindow.h>
 #include <GWToolbox.h>
 #include <Utils/TextUtils.h>
@@ -445,6 +446,9 @@ void TradeWindow::fetch()
 
         if (print_message) {
             std::wstring name_ws = TextUtils::StringToWString(msg.name);
+            if (FriendListWindow::GetIsPlayerIgnored(name_ws)) {
+                return; // Skip messages from ignored players
+            }
             std::wstring msg_ws = std::format(L"<c=#f96677><quote>{}",TextUtils::StringToWString(msg.message));
             external_trade_message = true;
             WriteChat(GW::Chat::Channel::CHANNEL_TRADE, msg_ws.c_str(),name_ws.c_str());


### PR DESCRIPTION
## Summary
The "Send Kamadan/Ascalon AE1 trade chat to your trade chat" option forwarded all matching messages, even from players on the ignore list. Check the ignore list before writing to chat so ignored players' spam is suppressed as expected.

## Test plan
- [ ] Add a known trade chat spammer to the ignore list
- [ ] Enable "Send Kamadan AE1 trade chat to your trade chat" and confirm their messages no longer appear

Closes #1566

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo6qnHxyVrRdgwgY7ZRNnu)_