### PR TITLE
Note Chasing Zenmai restriction on Wing, Three Blade capture

### DIFF
--- a/GWToolboxdll/Widgets/WorldMapWidget_Constants.h
+++ b/GWToolboxdll/Widgets/WorldMapWidget_Constants.h
@@ -453,7 +453,7 @@ namespace WorldMapWidget_Constants {
         {GW::Constants::SkillID::Ray_of_Judgment, 01, "Rei Bi", GW::Constants::MapID::Dragons_Throat_area__What_Waits_in_Shadow, {{1169, 376}}, "Only during \"What Waits in Shadow\" quest."},
         {GW::Constants::SkillID::Stolen_Speed, 01, "Seiran of the Cards", GW::Constants::MapID::Dragons_Throat_area__What_Waits_in_Shadow, {{1191, 376}}, "Only during \"What Waits in Shadow\" quest."},
         {GW::Constants::SkillID::Temple_Strike, 01, "Lai, Graceful Blade", GW::Constants::MapID::Dragons_Throat_area__What_Waits_in_Shadow, {{1213, 376}}, "Only during \"What Waits in Shadow\" quest."},
-        {GW::Constants::SkillID::Triple_Chop, 01, "Wing, Three Blade", GW::Constants::MapID::Bukdek_Byway, {{481, 338}}},
+        {GW::Constants::SkillID::Triple_Chop, 01, "Wing, Three Blade", GW::Constants::MapID::Bukdek_Byway, {{481, 338}}, "Not during \"Chasing Zenmai\" quest."},
         {GW::Constants::SkillID::Expel_Hexes, 01, "Jin, the Purifier", GW::Constants::MapID::Bukdek_Byway, {{531, 371}}, "Not during \"Chasing Zenmai\" quest."},
         {GW::Constants::SkillID::Elemental_Attunement, 01, "Chung, the Attuned", GW::Constants::MapID::Bukdek_Byway, {{550, 422}}, "Only during \"Eliminate the Am Fah\" quest."},
         {GW::Constants::SkillID::Palm_Strike,


### PR DESCRIPTION
## Summary
Wing, Three Blade does not spawn in Bukdek Byway while the quest "Chasing Zenmai" is in the player's quest log (per wiki). Add the restriction note matching nearby NPCs like Jin, the Purifier and Kenshi Steelhand.

## Test plan
- [ ] Hover the Wing, Three Blade marker on the world map and confirm the new note appears

Closes #1760

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo6qnHxyVrRdgwgY7ZRNnu)_