### PR TITLE
Stop panned minimap from consuming left-clicks outside its rect

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -1895,8 +1895,13 @@ bool Minimap::OnMouseWheel(const UINT, const WPARAM wParam, const LPARAM)
 
 bool Minimap::IsInside(const int x, const int y) const
 {
-    // if outside square, return false
-
+    // if outside the minimap window rect, return false
+    const auto& tl = default_minimap_context.top_left;
+    const auto& br = default_minimap_context.bottom_right;
+    if (static_cast<float>(x) < tl.x || static_cast<float>(x) > br.x ||
+        static_cast<float>(y) < tl.y || static_cast<float>(y) > br.y) {
+        return false;
+    }
 
     // if centered, use radar range
     if (translation.x == 0 && translation.y == 0) {


### PR DESCRIPTION
## Summary
After panning the minimap (translation != 0), `Minimap::IsInside` returned `true` for any cursor coordinate, so `Minimap::WndProc` consumed every left-click anywhere on screen until the user reset the minimap position. Right-click was unaffected because Minimap only handles left-button messages.

Add an explicit check that the cursor lies within the minimap's drawn rect (`top_left`/`bottom_right` from the active render context) before any of the existing centered/panned handling.

## Test plan
- [ ] Pan the minimap (drag-modifier click + move) so it is no longer centered
- [ ] Click outside the minimap on the game world and confirm normal targeting/movement now works
- [ ] Click inside the minimap and confirm minimap interactions (target, drag, flag heroes) still work

Closes #1764

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo6qnHxyVrRdgwgY7ZRNnu)_