### PR TITLE
Show Nicholas Sandford info in pre-searing item tooltips

### DIFF
--- a/GWToolboxdll/Modules/ItemTooltipModule.cpp
+++ b/GWToolboxdll/Modules/ItemTooltipModule.cpp
@@ -8,6 +8,7 @@
 #include <GWCA/Managers/AgentMgr.h>
 #include <GWCA/Managers/GameThreadMgr.h>
 #include <GWCA/Managers/ItemMgr.h>
+#include <GWCA/Managers/MapMgr.h>
 #include <GWCA/Managers/UIMgr.h>
 
 #include <GWCA/Constants/Constants.h>
@@ -179,19 +180,34 @@ namespace {
     void AppendNicholasInfo(const uint32_t item_id, std::wstring& description)
     {
         const auto item = GW::Items::GetItemById(item_id);
-        const auto nicholas_info = DailyQuests::GetNicholasItemInfo(item->name_enc);
-        if (!nicholas_info) return;
-
-        const auto collection_time = DailyQuests::GetTimestampFromNicholasTheTraveller(nicholas_info);
-        const auto current_time = time(nullptr);
+        if (!item) return;
 
         std::wstring text;
-        if (collection_time <= current_time) {
-            text = std::format(L"Nicholas The Traveler collects {} of these right now!", nicholas_info->quantity);
+        const auto current_time = time(nullptr);
+        if (GW::Map::IsPreSearing()) {
+            const auto sandford_info = DailyQuests::GetNicholasSandfordItemInfo(item->name_enc);
+            if (!sandford_info) return;
+            constexpr uint32_t sandford_quantity = 5; // Nicholas Sandford always asks for 5
+            const auto collection_time = DailyQuests::GetTimestampFromNicholasSandford(sandford_info);
+            if (collection_time <= current_time) {
+                text = std::format(L"Nicholas Sandford collects {} of these right now!", sandford_quantity);
+            }
+            else {
+                text = std::format(L"Nicholas Sandford collects {} of these {}!", sandford_quantity, TextUtils::RelativeTimeW(collection_time));
+            }
         }
         else {
-            text = std::format(L"Nicholas The Traveler collects {} of these {}!", nicholas_info->quantity, TextUtils::RelativeTimeW(collection_time));
+            const auto nicholas_info = DailyQuests::GetNicholasItemInfo(item->name_enc);
+            if (!nicholas_info) return;
+            const auto collection_time = DailyQuests::GetTimestampFromNicholasTheTraveller(nicholas_info);
+            if (collection_time <= current_time) {
+                text = std::format(L"Nicholas The Traveler collects {} of these right now!", nicholas_info->quantity);
+            }
+            else {
+                text = std::format(L"Nicholas The Traveler collects {} of these {}!", nicholas_info->quantity, TextUtils::RelativeTimeW(collection_time));
+            }
         }
+
         if (!description.empty())
             description += L"\x2";
         description += EncodedNewParagraph + L"\x2" + EncodedColouredString(EncodedLiteral(text), nicholas_color);

--- a/GWToolboxdll/Windows/DailyQuestsWindow.cpp
+++ b/GWToolboxdll/Windows/DailyQuestsWindow.cpp
@@ -1801,6 +1801,31 @@ DailyQuests::NicholasCycleData* DailyQuests::GetNicholasItemInfo(const wchar_t* 
     return nullptr;
 }
 
+DailyQuests::QuestData* DailyQuests::GetNicholasSandfordItemInfo(const wchar_t* item_name_encoded)
+{
+    if (!item_name_encoded) return nullptr;
+    for (auto& sandford_item : nicholas_sandford_cycles) {
+        if (sandford_item.enc_name == item_name_encoded) {
+            return &sandford_item;
+        }
+    }
+    return nullptr;
+}
+
+time_t DailyQuests::GetTimestampFromNicholasSandford(QuestData* data)
+{
+    constexpr time_t NICHOLAS_PRE_START_DATE = 1239260400;
+    constexpr int SECONDSINADAY = 86400;
+    auto index = -1;
+    for (auto i = 0; i < static_cast<int>(NICHOLAS_PRE_COUNT); i++) {
+        if (&nicholas_sandford_cycles[i] == data) {
+            index = i;
+        }
+    }
+    assert(index != -1);
+    return GetNextEventTime(NICHOLAS_PRE_START_DATE, time(nullptr), index, NICHOLAS_PRE_COUNT, SECONDSINADAY);
+}
+
 DailyQuests::DailyQuestResult DailyQuests::GetNicholasTheTraveller(time_t unix)
 {
     constexpr time_t EPOCH = 1323097200;

--- a/GWToolboxdll/Windows/DailyQuestsWindow.h
+++ b/GWToolboxdll/Windows/DailyQuestsWindow.h
@@ -71,10 +71,13 @@ public:
     static DailyQuestResult GetNicholasTheTraveller(time_t unix = 0);
     static time_t GetTimestampFromNicholasTheTraveller(DailyQuests::NicholasCycleData* data);
     static DailyQuestResult GetNicholasSandford(time_t unix = 0);
+    static time_t GetTimestampFromNicholasSandford(DailyQuests::QuestData* data);
     static DailyQuestResult GetVanguardQuest(time_t unix = 0);
     static DailyQuestResult GetWantedByShiningBlade(time_t unix = 0);
     static DailyQuestResult GetWeeklyPvEBonus(time_t unix = 0);
     static DailyQuestResult GetWeeklyPvPBonus(time_t unix = 0);
     // Returns info about the nicholas item if the given item name matches
     static NicholasCycleData* GetNicholasItemInfo(const wchar_t* item_name_encoded);
+    // Returns info about the Nicholas Sandford (pre-searing) item if the given item name matches
+    static QuestData* GetNicholasSandfordItemInfo(const wchar_t* item_name_encoded);
 };


### PR DESCRIPTION
## Summary
Hovering a Sandford collectible (Grawl Necklace, Charr Carving, etc.) in pre-searing now adds a tooltip line analogous to Nicholas the Traveler in post-searing:

> "Nicholas Sandford collects 5 of these in N days!"

Sandford's quantity is always 5 per request, so it is hard-coded.

Implementation:
- New `DailyQuests::GetNicholasSandfordItemInfo` returns the matching pre-searing cycle entry by encoded item name.
- New `DailyQuests::GetTimestampFromNicholasSandford` returns the next collection time using the existing pre-searing rotation (24h period, 52-day cycle, epoch 2009-04-09).
- `ItemTooltipModule::AppendNicholasInfo` switches on `GW::Map::IsPreSearing()` so Sandford-only items don't accidentally show a Traveler tooltip in post-searing.

The existing "Show Nicholas the Traveler info in item tooltip" toggle controls both, since it would be confusing to have a separate setting for a feature that's effectively the same thing in pre-searing.

## Test plan
- [ ] In a pre-searing character, hover a Sandford collectible (e.g. Skale Fins) and confirm the new tooltip line appears with the correct day-count
- [ ] Verify the same item in post-searing does NOT show the Sandford line (it shouldn't trigger Traveler either if it's not in his cycle)
- [ ] Confirm the existing Traveler tooltip in post-searing is unchanged

Closes #1749

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo6qnHxyVrRdgwgY7ZRNnu)_