### PR TITLE
Clarify auto-show title progress help text

### DIFF
--- a/GWToolboxdll/Widgets/TitleTrackerWidget.cpp
+++ b/GWToolboxdll/Widgets/TitleTrackerWidget.cpp
@@ -499,7 +499,9 @@ void TitleTrackerWidget::DrawSettingsInternal()
     if (ImGui::Checkbox("Automatically show title progress for current map", &automatically_show_title_progress_for_current_map)) {
         RefreshTitleProgress();
     }
-    ImGui::ShowHelp("e.g. when in an Asuran area, display title progress for the Asuran title track");
+    ImGui::ShowHelp("e.g. when in an Asuran area, display title progress for the Asuran title track.\n"
+                    "This only adds titles that are NOT ticked in the list below;\n"
+                    "ticked titles are always shown regardless of the current map.");
     ImGui::InputFloat("Progress bar height", &progress_bar_height, 1.f, 4.f, "%.f");
     ImGui::Text("Show/Hide Titles:");
     ImGui::Indent();


### PR DESCRIPTION
## Summary
The Title Tracker's "Automatically show title progress for current map" tooltip didn't explain how it interacts with the per-title checklist below: ticked titles are sticky and always shown regardless of the current map, while the auto-show only ever adds untick titles for areas you visit. Spell that out in the tooltip.

This addresses point 1 of #1694; the rest of the issue is feature work that I'm leaving for a separate change.

## Test plan
- [ ] Hover the help icon next to "Automatically show title progress for current map" and confirm the new wording describes the ticked-vs-untick behavior

Refs #1694

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo6qnHxyVrRdgwgY7ZRNnu)_