### PR TITLE
Add Claude Code workflow for @claude mentions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,42 @@
+name: Claude
+
+# Triggers Claude Code on @claude mentions in issues and pull requests.
+# Restricted to repository members so randoms can't burn API spend by
+# pinging Claude in a public issue.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (
+        (github.event_name == 'issue_comment'              && contains(github.event.comment.body, '@claude') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'pull_request_review'         && contains(github.event.review.body,  '@claude') && (github.event.review.author_association  == 'OWNER' || github.event.review.author_association  == 'MEMBER' || github.event.review.author_association  == 'COLLABORATOR')) ||
+        (github.event_name == 'issues'                       && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'COLLABORATOR'))
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,4 +39,10 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
+          # Authenticate against your Claude Code subscription so usage
+          # comes out of the existing Max plan rather than API credits.
+          # Generate the token locally with `claude setup-token` and store
+          # it as a repository secret named CLAUDE_CODE_OAUTH_TOKEN.
+          # Fall back to ANTHROPIC_API_KEY if the OAuth token is missing.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
Adds a `Claude` GitHub Actions workflow so anyone with `OWNER` / `MEMBER` / `COLLABORATOR` association on `gwdevhub/GWToolboxpp` can `@claude` in:

- new issues (body or title)
- issue comments
- PR comments (which GitHub treats as issue comments)
- PR review comments
- PR reviews

…and Claude Code will pick up the task or post a review on the same PR/issue. The workflow uses `anthropics/claude-code-action@v1`.

The `author_association` checks gate it to repo members so external users can't drive API spend by typing `@claude` in a public issue.

Targeted at `master` so the workflow lives where Actions actually look for workflow files on the default branch.

## Auth options
The workflow supports either:

1. **Claude Code subscription (recommended for personal Max plan)** — runs come out of the existing subscription, no separate API spend. Generate a token locally with `claude setup-token` and store it as a secret named `CLAUDE_CODE_OAUTH_TOKEN`.
2. **Anthropic API key** — store as `ANTHROPIC_API_KEY`. Used as fallback if `CLAUDE_CODE_OAUTH_TOKEN` isn't set.

Either secret can live at the repo or org level (`gwdevhub`); GitHub resolves both transparently. For org-level secrets, allow access for `GWToolboxpp` under "Repository access" in org Actions settings.

## Test plan
- [ ] Add the secret (`CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`) at repo or org level.
- [ ] Comment `@claude please summarise this issue` from a member account on any issue — confirm a Claude run is triggered and a reply is posted.
- [ ] Comment `@claude` from a non-member account — confirm nothing happens (job skipped by the `if:` gate).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo6qnHxyVrRdgwgY7ZRNnu)_