### PR TITLE
Target dev branch for Claude-created PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,3 +46,6 @@ jobs:
           # Fall back to ANTHROPIC_API_KEY if the OAuth token is missing.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Branch off and target dev for any PRs Claude opens, since
+          # master is reserved for releases and dev is the integration branch.
+          base_branch: dev


### PR DESCRIPTION
## Summary
Set `base_branch: dev` on the `anthropics/claude-code-action` step so any PRs Claude creates branch off `dev` and target `dev`, matching how human contributors work. Without this, Claude defaults to the repository's default branch (`master`), which is reserved for releases.

## Test plan
- [ ] After merge, comment `@claude` on an issue with a small change request — confirm the PR Claude opens has `dev` as its base.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo6qnHxyVrRdgwgY7ZRNnu)_