### PR TITLE
Refactor texture lifecycle: TBComPtr, shared_future, RAII throughout

### DIFF
--- a/GWToolboxdll/Modules/GwDatTextureModule.cpp
+++ b/GWToolboxdll/Modules/GwDatTextureModule.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 
+#include <future>
 #include <GWCA/Utilities/Scanner.h>
 #include <GWCA/Managers/ItemMgr.h>
 
@@ -192,7 +193,7 @@ namespace {
     struct GwImg {
         uint32_t m_file_id = 0;
         Vec2i m_dims;
-        IDirect3DTexture9* m_tex = nullptr;
+        Resources::Texture m_tex;
     };
 
     std::map<uint32_t,GwImg*> textures_by_file_id;
@@ -280,17 +281,23 @@ void GwDatTextureModule::Initialize()
 
 
 
-IDirect3DTexture9** GwDatTextureModule::LoadTextureFromFileId(uint32_t file_id)
+Resources::Texture GwDatTextureModule::LoadTextureFromFileId(uint32_t file_id)
 {
     auto found = textures_by_file_id.find(file_id);
     if (found != textures_by_file_id.end())
-        return &found->second->m_tex;
-    auto gwimg_ptr = new GwImg(file_id);
+        return found->second->m_tex;
+    auto gwimg_ptr = new GwImg{file_id};
     textures_by_file_id[file_id] = gwimg_ptr;
-    Resources::Instance().EnqueueDxTask([gwimg_ptr](IDirect3DDevice9* device) {
-        gwimg_ptr->m_tex = CreateTexture(device, gwimg_ptr->m_file_id, gwimg_ptr->m_dims);
-        });
-    return &gwimg_ptr->m_tex;
+    auto promise = std::make_shared<std::promise<TBComPtr<IDirect3DTexture9>>>();
+    auto future = promise->get_future().share();
+    Resources::Instance().EnqueueDxTask([gwimg_ptr, promise](IDirect3DDevice9* device) {
+        TBComPtr<IDirect3DTexture9> tex;
+        auto* raw = CreateTexture(device, gwimg_ptr->m_file_id, gwimg_ptr->m_dims);
+        if (raw) tex.Attach(raw);
+        promise->set_value(std::move(tex));
+    });
+    gwimg_ptr->m_tex = Resources::Texture{std::move(future)};
+    return gwimg_ptr->m_tex;
 }
 void GwDatTextureModule::Terminate()
 {

--- a/GWToolboxdll/Modules/GwDatTextureModule.h
+++ b/GWToolboxdll/Modules/GwDatTextureModule.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ToolboxModule.h>
+#include <Modules/Resources.h>
 
 namespace GW {
     struct RecObject;
@@ -22,11 +23,11 @@ public:
     bool HasSettings() override { return false; }
 
     void Initialize() override;
-    
+
     void Terminate() override;
 
     static bool CloseHandle(GW::RecObject* handle);
     static bool ReadDatFile(const wchar_t* fileHash, std::vector<uint8_t>* bytes_out, uint32_t stream_id = 0);
 
-    static IDirect3DTexture9** LoadTextureFromFileId(uint32_t file_id);
+    static Resources::Texture LoadTextureFromFileId(uint32_t file_id);
 };

--- a/GWToolboxdll/Modules/ItemDrops.h
+++ b/GWToolboxdll/Modules/ItemDrops.h
@@ -2,7 +2,9 @@
 
 #include <ToolboxModule.h>
 #include "InventoryManager.h"
+#include <Modules/Resources.h>
 #include <Utils/ToolboxUtils.h>
+#include <Utils/ComPtr.h>
 
 
 class ItemDrops : public ToolboxModule {
@@ -28,7 +30,7 @@ public:
     struct PendingDrop {
         uint32_t instance_time = 0;
         time_t system_time = 0;
-        IDirect3DTexture9** icon = 0;
+        Resources::Texture icon;
         wchar_t* item_name_enc = 0;
         GW::Constants::MapID map_id = GW::Constants::MapID::None;
 
@@ -58,7 +60,7 @@ public:
         static const wchar_t* GetCSVHeader();
         GuiUtils::EncString* GetItemName();
     };
-    static_assert(sizeof(PendingDrop) == 48);
+    // sizeof changed: icon is now a Texture (shared_future) instead of a raw pointer
 
     std::vector<PendingDrop*>& GetDropHistory();
     int GetTotalGoldValue();

--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 
+#include <future>
 #include <DirectXTex.h>
 #include <DDSTextureLoader/DDSTextureLoader9.h>
 #include <WICTextureLoader/WICTextureLoader9.h>
@@ -114,10 +115,9 @@ namespace {
         "5/5e/Paragon-tango-icon-48",
         "3/38/Dervish-tango-icon-48"
     };
-    std::unordered_map<uint32_t, IDirect3DTexture9**> profession_icons;
-    std::unordered_map<GW::Constants::SkillID, IDirect3DTexture9**> skill_images;
-    std::unordered_map<std::wstring, IDirect3DTexture9**> item_images;
-    std::unordered_map<std::string, IDirect3DTexture9**> guild_wars_wiki_images;
+    std::unordered_map<uint32_t, Resources::Texture> profession_icons;
+    std::unordered_map<GW::Constants::SkillID, Resources::Texture> skill_images;
+    std::unordered_map<std::wstring, Resources::Texture> item_images;
     const std::unordered_map<std::string, const char*> damagetype_icon_urls = {
         {"Blunt damage", "1/19/Blunt_damage.png/60px-Blunt_damage.png"},
         {"Piercing damage", "1/1a/Piercing_damage.png/60px-Piercing_damage.png"},
@@ -128,7 +128,7 @@ namespace {
         {"Lightning damage", "0/06/Lightning_damage.png/60px-Lightning_damage.png"},
     };
 
-    std::unordered_map<std::string, IDirect3DTexture9**> damagetype_icons;
+    std::unordered_map<std::string, Resources::Texture> damagetype_icons;
     std::unordered_map<GW::Constants::MapID, GuiUtils::EncString*> map_names;
     std::unordered_map<GW::Constants::SkillID, GuiUtils::EncString*> skill_names;
     std::unordered_map<GW::Constants::MapID, GuiUtils::EncString*> region_names;
@@ -152,7 +152,6 @@ namespace {
     // tasks to be done in main thread
     std::queue<std::function<void()>> main_jobs;
 
-    IDirect3DTexture9* empty_texture_ptr = nullptr;
     bool should_stop = false;
 
     // snprintf error message, pass to callback as a failure. Used internally.
@@ -244,9 +243,9 @@ namespace {
     };
 } // namespace
 
-extern "C" __declspec(dllexport) IDirect3DTexture9** __cdecl GetSkillImage(GW::Constants::SkillID skill_id)
+extern "C" __declspec(dllexport) const IDirect3DTexture9* __cdecl GetSkillImage(GW::Constants::SkillID skill_id)
 {
-    return Resources::GetSkillImage(skill_id);
+    return Resources::GetSkillImage(skill_id).Get();
 }
 
 Resources::Resources()
@@ -432,21 +431,10 @@ void Resources::Cleanup()
         delete worker; // Will trigger assertion
     }
     workers.clear();
-    for (const auto& tex : skill_images | std::views::values) {
-        if(tex && *tex) (*tex)->Release();
-        delete tex;
-    }
     skill_images.clear();
-    for (const auto& tex : item_images | std::views::values) {
-        if (tex && *tex) (*tex)->Release();
-        delete tex;
-    }
     item_images.clear();
-    for (const auto& img : guild_wars_wiki_images | std::views::values) {
-        if (img && *img) (*img)->Release();
-        delete img;
-    }
-    guild_wars_wiki_images.clear();
+    profession_icons.clear();
+    damagetype_icons.clear();
     for (const auto& enc_strings : encoded_string_ids | std::views::values) {
         for (const auto& enc_string : enc_strings | std::views::values) {
             enc_string->Release();
@@ -796,11 +784,17 @@ HRESULT Resources::TryCreateTexture(IDirect3DDevice9* pDevice, const HMODULE hSr
     return res;
 }
 
-void Resources::LoadTexture(IDirect3DTexture9** texture, const std::filesystem::path& path_to_file, AsyncLoadCallback callback)
+Resources::Texture Resources::LoadTexture(const std::filesystem::path& path_to_file, AsyncLoadCallback callback)
 {
-    EnqueueDxTask([path_to_file, texture, callback](IDirect3DDevice9* device) {
+    auto promise = std::make_shared<std::promise<TBComPtr<IDirect3DTexture9>>>();
+    auto future = promise->get_future().share();
+    EnqueueDxTask([path_to_file, promise, callback](IDirect3DDevice9* device) {
         std::wstring error;
-        const HRESULT res = TryCreateTexture(device, path_to_file.c_str(), texture, error);
+        IDirect3DTexture9* raw = nullptr;
+        const HRESULT res = TryCreateTexture(device, path_to_file.c_str(), &raw, error);
+        TBComPtr<IDirect3DTexture9> tex;
+        if (raw) tex.Attach(raw);
+        promise->set_value(std::move(tex));
         const bool success = res == D3D_OK;
         if (callback) {
             callback(success, error);
@@ -809,13 +803,20 @@ void Resources::LoadTexture(IDirect3DTexture9** texture, const std::filesystem::
             Log::LogW(L"Failed to load texture from file %s\n%s", TextUtils::PrintFilename(path_to_file.wstring()).c_str(), error.c_str());
         }
     });
+    return Texture{std::move(future)};
 }
 
-void Resources::LoadTexture(IDirect3DTexture9** texture, WORD id, AsyncLoadCallback callback)
+Resources::Texture Resources::LoadTexture(WORD id, AsyncLoadCallback callback)
 {
-    EnqueueDxTask([id, texture, callback](IDirect3DDevice9* device) {
+    auto promise = std::make_shared<std::promise<TBComPtr<IDirect3DTexture9>>>();
+    auto future = promise->get_future().share();
+    EnqueueDxTask([id, promise, callback](IDirect3DDevice9* device) {
         std::wstring error{};
-        const bool success = TryCreateTexture(device, GWToolbox::GetDLLModule(), MAKEINTRESOURCE(id), texture, error) == D3D_OK;
+        IDirect3DTexture9* raw = nullptr;
+        TBComPtr<IDirect3DTexture9> tex;
+        const bool success = TryCreateTexture(device, GWToolbox::GetDLLModule(), MAKEINTRESOURCE(id), &raw, error) == D3D_OK;
+        if (raw) tex.Attach(raw);
+        promise->set_value(std::move(tex));
         if (callback) {
             callback(success, error);
         }
@@ -823,15 +824,33 @@ void Resources::LoadTexture(IDirect3DTexture9** texture, WORD id, AsyncLoadCallb
             Log::LogW(L"Failed to load texture from id %d\n%s", id, error.c_str());
         }
     });
+    return Texture{std::move(future)};
 }
 
-void Resources::LoadTexture(IDirect3DTexture9** texture, const std::filesystem::path& path_to_file, const std::string& url, AsyncLoadCallback callback)
+Resources::Texture Resources::LoadTexture(const std::filesystem::path& path_to_file, const std::string& url, AsyncLoadCallback callback)
 {
-    EnsureFileExists(path_to_file, url, [texture, path_to_file, callback](const bool success, const std::wstring& error) {
+    auto promise = std::make_shared<std::promise<TBComPtr<IDirect3DTexture9>>>();
+    auto future = promise->get_future().share();
+    EnsureFileExists(path_to_file, url, [promise, path_to_file, callback](const bool success, const std::wstring& error) {
         if (success) {
-            LoadTexture(texture, path_to_file, callback);
+            EnqueueDxTask([path_to_file, promise, callback](IDirect3DDevice9* device) {
+                std::wstring err;
+                IDirect3DTexture9* raw = nullptr;
+                const HRESULT res = TryCreateTexture(device, path_to_file.c_str(), &raw, err);
+                TBComPtr<IDirect3DTexture9> tex;
+                if (raw) tex.Attach(raw);
+                promise->set_value(std::move(tex));
+                const bool ok = res == D3D_OK;
+                if (callback) {
+                    callback(ok, err);
+                }
+                else if (!ok) {
+                    Log::LogW(L"Failed to load texture from file %s\n%s", TextUtils::PrintFilename(path_to_file.wstring()).c_str(), err.c_str());
+                }
+            });
         }
         else {
+            promise->set_value(TBComPtr<IDirect3DTexture9>{});
             if (callback) {
                 callback(success, error);
             }
@@ -840,18 +859,37 @@ void Resources::LoadTexture(IDirect3DTexture9** texture, const std::filesystem::
             }
         }
     });
+    return Texture{std::move(future)};
 }
 
-void Resources::LoadTexture(IDirect3DTexture9** texture, const std::filesystem::path& path_to_file, WORD id, AsyncLoadCallback callback)
+Resources::Texture Resources::LoadTexture(const std::filesystem::path& path_to_file, WORD id, AsyncLoadCallback callback)
 {
-    LoadTexture(texture, path_to_file, [texture, id, callback](const bool success, const std::wstring& error) {
-        if (!success) {
-            LoadTexture(texture, id, callback);
+    auto promise = std::make_shared<std::promise<TBComPtr<IDirect3DTexture9>>>();
+    auto future = promise->get_future().share();
+    EnqueueDxTask([path_to_file, id, promise, callback](IDirect3DDevice9* device) {
+        std::wstring error;
+        IDirect3DTexture9* raw = nullptr;
+        TBComPtr<IDirect3DTexture9> tex;
+        HRESULT res = TryCreateTexture(device, path_to_file.c_str(), &raw, error);
+        if (raw) {
+            tex.Attach(raw);
         }
-        else if (callback) {
+        else {
+            raw = nullptr;
+            error.clear();
+            res = TryCreateTexture(device, GWToolbox::GetDLLModule(), MAKEINTRESOURCE(id), &raw, error);
+            if (raw) tex.Attach(raw);
+        }
+        promise->set_value(std::move(tex));
+        const bool success = res == D3D_OK;
+        if (callback) {
             callback(success, error);
         }
+        else if (!success) {
+            Log::LogW(L"Failed to load texture from file %s or resource %d\n%s", TextUtils::PrintFilename(path_to_file.wstring()).c_str(), id, error.c_str());
+        }
     });
+    return Texture{std::move(future)};
 }
 
 bool Resources::ResourceToFile(const WORD id, const std::filesystem::path& path_to_file, std::wstring& error)
@@ -917,15 +955,14 @@ void Resources::Update(float)
     func();
 }
 
-IDirect3DTexture9** Resources::GetProfessionIcon(GW::Constants::Profession p)
+auto Resources::GetProfessionIcon(GW::Constants::Profession p) -> Texture
 {
     const auto prof_id = std::to_underlying(p);
-    if (profession_icons.contains(prof_id)) {
-        return profession_icons.at(prof_id);
+    auto it = profession_icons.find(prof_id);
+    if (it != profession_icons.end()) {
+        return it->second;
     }
-    const auto texture = new IDirect3DTexture9*;
-    *texture = nullptr;
-    profession_icons[prof_id] = texture;
+    auto& entry = profession_icons[prof_id];
     if (profession_icon_urls[prof_id][0]) {
         const auto path = GetPath(PROF_ICONS_PATH);
         EnsureFolderExists(path);
@@ -933,13 +970,13 @@ IDirect3DTexture9** Resources::GetProfessionIcon(GW::Constants::Profession p)
         swprintf(local_image, _countof(local_image), L"%s\\%d.png", path.c_str(), p);
         char remote_image[128];
         snprintf(remote_image, _countof(remote_image), "https://wiki.guildwars.com/images/%s.png", profession_icon_urls[prof_id]);
-        LoadTexture(texture, local_image, remote_image, [prof_id](const bool success, const std::wstring& error) {
+        entry = LoadTexture(local_image, remote_image, [prof_id](const bool success, const std::wstring& error) {
             if (!success) {
                 Log::ErrorW(L"Failed to load icon for profession %d\n%s", prof_id, error.c_str());
             }
         });
     }
-    return texture;
+    return entry;
 }
 
 bool Resources::GetTextureSize(IDirect3DTexture9* texture, ImVec2* out)
@@ -955,30 +992,29 @@ bool Resources::GetTextureSize(IDirect3DTexture9* texture, ImVec2* out)
     return true;
 }
 
-IDirect3DTexture9** Resources::GetDamagetypeImage(std::string dmg_type)
+auto Resources::GetDamagetypeImage(std::string dmg_type) -> Texture
 {
-    if (damagetype_icons.contains(dmg_type)) {
-        return damagetype_icons.at(dmg_type);
+    auto it = damagetype_icons.find(dmg_type);
+    if (it != damagetype_icons.end()) {
+        return it->second;
     }
-    const auto texture = new IDirect3DTexture9*;
-    *texture = nullptr;
-    damagetype_icons[dmg_type] = texture;
+    auto& entry = damagetype_icons[dmg_type];
     if (damagetype_icon_urls.contains(dmg_type)) {
         const auto path = GetPath(DMGTYPE_ICONS_PATH);
         EnsureFolderExists(path);
         const auto local_path = path / TextUtils::SanitiseFilename(dmg_type + ".png");
         const auto remote_path = std::format("https://wiki.guildwars.com/images/thumb/{}", damagetype_icon_urls.at(dmg_type));
-        LoadTexture(texture, local_path, remote_path, [dmg_type](const bool success, const std::wstring& error) {
+        entry = LoadTexture(local_path, remote_path, [dmg_type](const bool success, const std::wstring& error) {
             if (!success) {
                 const auto dmg_type_wstr = TextUtils::StringToWString(dmg_type);
                 Log::ErrorW(L"Failed to load icon for %d\n%s", dmg_type_wstr.c_str(), error.c_str());
             }
         });
     }
-    return texture;
+    return entry;
 }
 
-IDirect3DTexture9** Resources::GetGuildWarsWikiImage(const char* filename, size_t width, const bool urlencode_filename)
+auto Resources::GetGuildWarsWikiImage(const char* filename, size_t width, const bool urlencode_filename) -> Texture
 {
     ASSERT(filename && filename[0]);
     std::string filename_on_disk;
@@ -989,38 +1025,48 @@ IDirect3DTexture9** Resources::GetGuildWarsWikiImage(const char* filename, size_
         filename_on_disk = filename;
     }
     const auto filename_sanitised = TextUtils::SanitiseFilename(filename_on_disk);
-    if (guild_wars_wiki_images.contains(filename_sanitised)) {
-        return guild_wars_wiki_images.at(filename_sanitised);
-    }
-    const auto callback = [filename_sanitised](const bool success, const std::wstring& error) {
+
+    auto promise = std::make_shared<std::promise<TBComPtr<IDirect3DTexture9>>>();
+    Texture handle{promise->get_future().share()};
+
+    // Capturing handle (a Texture containing a shared_future) keeps the
+    // shared state alive until the DX task completes and the promise is resolved.
+    const auto callback = [handle, filename_sanitised](const bool success, const std::wstring& error) {
         if (!success) {
-            Log::LogW(L"Failed to load Guild Wars Wiki file%S\n%s", filename_sanitised.c_str(), error.c_str());
+            Log::LogW(L"Failed to load Guild Wars Wiki file %S\n%s", filename_sanitised.c_str(), error.c_str());
         }
         else {
             Log::LogW(L"Loaded Guild Wars Wiki file %S", filename_sanitised.c_str());
         }
     };
-    const auto texture = new IDirect3DTexture9*;
-    *texture = nullptr;
-    guild_wars_wiki_images[filename] = texture;
     static std::filesystem::path path = GetPath(GUILD_WARS_WIKI_FILES_PATH);
     if (!EnsureFolderExists(path)) {
+        promise->set_value(TBComPtr<IDirect3DTexture9>{});
         trigger_failure_callback(callback, L"Failed to create folder %s", path.wstring().c_str());
-        return texture;
+        return handle;
     }
     const auto path_to_file = std::format("{}\\{}", path.string(), filename_sanitised);
     // Check for local file
     if (std::filesystem::exists(path_to_file)) {
-        LoadTexture(texture, path_to_file, callback);
-        return texture;
+        EnqueueDxTask([promise, path_to_file = std::filesystem::path{path_to_file}, callback](IDirect3DDevice9* device) {
+            std::wstring error;
+            IDirect3DTexture9* raw = nullptr;
+            TryCreateTexture(device, path_to_file.c_str(), &raw, error);
+            TBComPtr<IDirect3DTexture9> tex;
+            if (raw) tex.Attach(raw);
+            promise->set_value(std::move(tex));
+            callback(raw != nullptr, error);
+        });
+        return handle;
     }
     // No local file found; download from wiki via skill link URL
     std::string wiki_url = "https://wiki.guildwars.com/wiki/File:";
     wiki_url.append(urlencode_filename ? TextUtils::UrlEncode(filename, '_') : filename);
-    Instance().Download(wiki_url, [texture, filename_sanitised, callback, width](const bool ok, const std::string& response, void*) {
+    Instance().Download(wiki_url, [promise, handle, filename_sanitised, callback, width](const bool ok, const std::string& response, void*) {
         if (!ok) {
+            promise->set_value(TBComPtr<IDirect3DTexture9>{});
             callback(ok, TextUtils::StringToWString(response));
-            return; // Already logged whatever errors
+            return;
         }
 
         // Find a valid png or jpg image inside the HTML response
@@ -1043,6 +1089,7 @@ IDirect3DTexture9** Resources::GetGuildWarsWikiImage(const char* filename, size_
                         m2.get<2>().to_string());
                 }
                 else {
+                    promise->set_value(TBComPtr<IDirect3DTexture9>{});
                     trigger_failure_callback(callback, L"Regex failed evaluating GWW thumbnail from %S", image_url.c_str());
                     return;
                 }
@@ -1053,13 +1100,30 @@ IDirect3DTexture9** Resources::GetGuildWarsWikiImage(const char* filename, size_
                 image_url = std::format("https://wiki.guildwars.com{}", image_url);
             }
 
-            LoadTexture(texture, path_to_file2, image_url, callback);
+            EnsureFileExists(std::filesystem::path{path_to_file2}, image_url, [promise, path_to_file2, callback](const bool success, const std::wstring& error) {
+                if (success) {
+                    EnqueueDxTask([promise, path_to_file2, callback](IDirect3DDevice9* device) {
+                        std::wstring err;
+                        IDirect3DTexture9* raw = nullptr;
+                        TryCreateTexture(device, std::filesystem::path{path_to_file2}.c_str(), &raw, err);
+                        TBComPtr<IDirect3DTexture9> tex;
+                        if (raw) tex.Attach(raw);
+                        promise->set_value(std::move(tex));
+                        callback(raw != nullptr, err);
+                    });
+                }
+                else {
+                    promise->set_value(TBComPtr<IDirect3DTexture9>{});
+                    callback(false, error);
+                }
+            });
         }
         else {
+            promise->set_value(TBComPtr<IDirect3DTexture9>{});
             trigger_failure_callback(callback, L"Regex failed loading file %S", filename_sanitised.c_str());
         }
     });
-    return texture;
+    return handle;
 }
 
 std::filesystem::path Resources::GetExePath()
@@ -1075,22 +1139,31 @@ std::filesystem::path Resources::GetExePath()
     return std::filesystem::path(buffer);
 }
 
-IDirect3DTexture9** Resources::GetSkillImage(GW::Constants::SkillID skill_id)
+auto Resources::GetSkillImage(GW::Constants::SkillID skill_id) -> Texture
 {
     const auto skill = GW::SkillbarMgr::GetSkillConstantData(skill_id);
-    return skill && skill->icon_file_id ? GwDatTextureModule::LoadTextureFromFileId(skill->icon_file_id) : &empty_texture_ptr;
+    if (skill && skill->icon_file_id) {
+        return GwDatTextureModule::LoadTextureFromFileId(skill->icon_file_id);
+    }
+    return Texture{};
 }
-IDirect3DTexture9** Resources::GetSkillHiResImage(GW::Constants::SkillID skill_id)
+auto Resources::GetSkillHiResImage(GW::Constants::SkillID skill_id) -> Texture
 {
     const auto skill = GW::SkillbarMgr::GetSkillConstantData(skill_id);
-    return skill && skill->icon_file_id_hi_res ? GwDatTextureModule::LoadTextureFromFileId(skill->icon_file_id_hi_res) : &empty_texture_ptr;
+    if (skill && skill->icon_file_id_hi_res) {
+        return GwDatTextureModule::LoadTextureFromFileId(skill->icon_file_id_hi_res);
+    }
+    return Texture{};
 }
 
-IDirect3DTexture9** Resources::GetSkillImageFromGWW(GW::Constants::SkillID skill_id)
+auto Resources::GetSkillImageFromGWW(GW::Constants::SkillID skill_id) -> Texture
 {
-    if (skill_images.contains(skill_id)) {
-        return skill_images.at(skill_id);
+    auto it = skill_images.find(skill_id);
+    if (it != skill_images.end()) {
+        return it->second;
     }
+    auto promise = std::make_shared<std::promise<TBComPtr<IDirect3DTexture9>>>();
+    auto& texture = skill_images[skill_id] = Texture{promise->get_future().share()};
     const auto callback = [skill_id](const bool success, const std::wstring& error) {
         if (!success) {
             Log::ErrorW(L"Failed to load skill image %d\n%s", skill_id, error.c_str());
@@ -1099,14 +1172,13 @@ IDirect3DTexture9** Resources::GetSkillImageFromGWW(GW::Constants::SkillID skill
             Log::LogW(L"Loaded skill image %d", skill_id);
         }
     };
-    const auto texture = new IDirect3DTexture9*;
-    *texture = nullptr;
-    skill_images[skill_id] = texture;
     if (skill_id == static_cast<GW::Constants::SkillID>(0)) {
+        promise->set_value(TBComPtr<IDirect3DTexture9>{});
         return texture;
     }
     static std::filesystem::path path = GetPath(SKILL_IMAGES_PATH);
     if (!EnsureFolderExists(path)) {
+        promise->set_value(TBComPtr<IDirect3DTexture9>{});
         trigger_failure_callback(callback, L"Failed to create folder %s", path.wstring().c_str());
         return texture;
     }
@@ -1114,20 +1186,37 @@ IDirect3DTexture9** Resources::GetSkillImageFromGWW(GW::Constants::SkillID skill
     // Check for local jpg file
     swprintf(path_to_file, _countof(path_to_file), L"%s\\%d.jpg", path.wstring().c_str(), skill_id);
     if (std::filesystem::exists(path_to_file)) {
-        LoadTexture(texture, path_to_file, callback);
+        EnqueueDxTask([promise, path_to_file = std::filesystem::path{path_to_file}, callback](IDirect3DDevice9* device) {
+            std::wstring error;
+            IDirect3DTexture9* raw = nullptr;
+            TryCreateTexture(device, path_to_file.c_str(), &raw, error);
+            TBComPtr<IDirect3DTexture9> tex;
+            if (raw) tex.Attach(raw);
+            promise->set_value(std::move(tex));
+            callback(raw != nullptr, error);
+        });
         return texture;
     }
     // Check for local png file
     swprintf(path_to_file, _countof(path_to_file), L"%s\\%d.png", path.wstring().c_str(), skill_id);
     if (std::filesystem::exists(path_to_file)) {
-        LoadTexture(texture, path_to_file, callback);
+        EnqueueDxTask([promise, path_to_file = std::filesystem::path{path_to_file}, callback](IDirect3DDevice9* device) {
+            std::wstring error;
+            IDirect3DTexture9* raw = nullptr;
+            TryCreateTexture(device, path_to_file.c_str(), &raw, error);
+            TBComPtr<IDirect3DTexture9> tex;
+            if (raw) tex.Attach(raw);
+            promise->set_value(std::move(tex));
+            callback(raw != nullptr, error);
+        });
         return texture;
     }
     // No local file found; download from wiki via skill link URL
     char url[128];
     snprintf(url, _countof(url), "https://wiki.guildwars.com/wiki/Game_link:Skill_%d", skill_id);
-    Instance().Download(url, [texture, skill_id, callback](const bool ok, const std::string& response, void*) {
+    Instance().Download(url, [promise, skill_id, callback](const bool ok, const std::string& response, void*) {
         if (!ok) {
+            promise->set_value(TBComPtr<IDirect3DTexture9>{});
             callback(ok, TextUtils::StringToWString(response));
             return; // Already logged whatever errors
         }
@@ -1160,6 +1249,7 @@ IDirect3DTexture9** Resources::GetSkillImageFromGWW(GW::Constants::SkillID skill
             image_extension = m3.get<2>().to_string();
         }
         else {
+            promise->set_value(TBComPtr<IDirect3DTexture9>{});
             trigger_failure_callback(callback, L"Regex failed loading skill id %d", skill_id);
             return;
         }
@@ -1176,7 +1266,23 @@ IDirect3DTexture9** Resources::GetSkillImageFromGWW(GW::Constants::SkillID skill
             snprintf(url, _countof(url), "https://wiki.guildwars.com%s%s", image_path.c_str(), image_extension.c_str());
         }
 
-        LoadTexture(texture, path_to_file, url, callback);
+        EnsureFileExists(std::filesystem::path{path_to_file}, std::string{url}, [promise, path_to_file = std::filesystem::path{path_to_file}, callback](const bool success, const std::wstring& error) {
+            if (success) {
+                EnqueueDxTask([promise, path_to_file, callback](IDirect3DDevice9* device) {
+                    std::wstring err;
+                    IDirect3DTexture9* raw = nullptr;
+                    TryCreateTexture(device, path_to_file.c_str(), &raw, err);
+                    TBComPtr<IDirect3DTexture9> tex;
+                    if (raw) tex.Attach(raw);
+                    promise->set_value(std::move(tex));
+                    callback(raw != nullptr, err);
+                });
+            }
+            else {
+                promise->set_value(TBComPtr<IDirect3DTexture9>{});
+                callback(false, error);
+            }
+        });
     });
     return texture;
 }
@@ -1280,10 +1386,10 @@ GuiUtils::EncString* Resources::DecodeStringId(const uint32_t enc_str_id, GW::Co
     return enc_string;
 }
 
-IDirect3DTexture9** Resources::GetItemImage(GW::Item* item)
+auto Resources::GetItemImage(GW::Item* item) -> Texture
 {
     if (!(item && item->model_file_id))
-        return nullptr;
+        return Texture{};
     uint32_t model_id_to_load = 0;
     const bool is_composite_item = (item->interaction & 4) != 0;
 
@@ -1303,14 +1409,17 @@ IDirect3DTexture9** Resources::GetItemImage(GW::Item* item)
     // @Enhancement: How to apply dye_info to the result?
 }
 
-IDirect3DTexture9** Resources::GetItemImage(const std::wstring& item_name)
+auto Resources::GetItemImage(const std::wstring& item_name) -> Texture
 {
     if (item_name.empty()) {
-        return nullptr;
+        return Texture{};
     }
-    if (item_images.contains(item_name)) {
-        return item_images.at(item_name);
+    auto it = item_images.find(item_name);
+    if (it != item_images.end()) {
+        return it->second;
     }
+    auto promise = std::make_shared<std::promise<TBComPtr<IDirect3DTexture9>>>();
+    auto& texture = item_images[item_name] = Texture{promise->get_future().share()};
     const auto callback = [item_name](const bool success, const std::wstring& error) {
         if (!success) {
             Log::LogW(L"Error: Failed to load item image %s\n%s", item_name.c_str(), error.c_str());
@@ -1319,9 +1428,6 @@ IDirect3DTexture9** Resources::GetItemImage(const std::wstring& item_name)
             Log::LogW(L"Loaded item image %s", item_name.c_str());
         }
     };
-    const auto texture = new IDirect3DTexture9*;
-    *texture = nullptr;
-    item_images[item_name] = texture;
     static std::filesystem::path path = GetPath(ITEM_IMAGES_PATH);
     ASSERT(EnsureFolderExists(path));
 
@@ -1329,14 +1435,23 @@ IDirect3DTexture9** Resources::GetItemImage(const std::wstring& item_name)
     // Check for local png image
     swprintf(path_to_file, _countof(path_to_file), L"%s\\%s.png", path.c_str(), item_name.c_str());
     if (std::filesystem::exists(path_to_file)) {
-        LoadTexture(texture, path_to_file, callback);
+        EnqueueDxTask([promise, path_to_file = std::filesystem::path{path_to_file}, callback](IDirect3DDevice9* device) {
+            std::wstring error;
+            IDirect3DTexture9* raw = nullptr;
+            TryCreateTexture(device, path_to_file.c_str(), &raw, error);
+            TBComPtr<IDirect3DTexture9> tex;
+            if (raw) tex.Attach(raw);
+            promise->set_value(std::move(tex));
+            callback(raw != nullptr, error);
+        });
         return texture;
     }
 
     // No local file found; download from wiki via searching by the item name; the wiki will usually return a 302 redirect if its an exact item match
     const std::string search_str = GuiUtils::WikiUrl(item_name);
-    Instance().Download(search_str, [texture, item_name, callback](const bool ok, const std::string& response, void*) {
+    Instance().Download(search_str, [promise, item_name, callback](const bool ok, const std::string& response, void*) {
         if (!ok) {
+            promise->set_value(TBComPtr<IDirect3DTexture9>{});
             callback(ok, TextUtils::StringToWString(response));
             return;
         }
@@ -1352,12 +1467,14 @@ IDirect3DTexture9** Resources::GetItemImage(const std::wstring& item_name)
             // Failed to find via item name; try via page title
             const std::regex title_finder("<title>(.*) - Guild Wars Wiki.*</title>");
             if (!std::regex_search(response, m, title_finder)) {
+                promise->set_value(TBComPtr<IDirect3DTexture9>{});
                 trigger_failure_callback(callback, L"Failed to find title HTML for %s from wiki", item_name.c_str());
                 return;
             }
             const std::string html_item_name = TextUtils::HtmlEncode(m[1].str());
             snprintf(regex_str, sizeof(regex_str), R"(<img[^>]+alt=['"][^>]*%s[^>]*['"][^>]+src=['"]([^"']+)([.](png)))", html_item_name.c_str());
             if (!std::regex_search(response, m, std::regex(regex_str))) {
+                promise->set_value(TBComPtr<IDirect3DTexture9>{});
                 trigger_failure_callback(callback, L"Failed to find image HTML for %s from wiki", item_name.c_str());
                 return;
             }
@@ -1375,7 +1492,23 @@ IDirect3DTexture9** Resources::GetItemImage(const std::wstring& item_name)
             // Image URL is relative to domain
             snprintf(url, _countof(url), "https://wiki.guildwars.com%s%s", image_path.c_str(), image_extension.c_str());
         }
-        LoadTexture(texture, path_to_file, url, callback);
+        EnsureFileExists(std::filesystem::path{path_to_file}, std::string{url}, [promise, path_to_file = std::filesystem::path{path_to_file}, callback](const bool success, const std::wstring& error) {
+            if (success) {
+                EnqueueDxTask([promise, path_to_file, callback](IDirect3DDevice9* device) {
+                    std::wstring err;
+                    IDirect3DTexture9* raw = nullptr;
+                    TryCreateTexture(device, path_to_file.c_str(), &raw, err);
+                    TBComPtr<IDirect3DTexture9> tex;
+                    if (raw) tex.Attach(raw);
+                    promise->set_value(std::move(tex));
+                    callback(raw != nullptr, err);
+                });
+            }
+            else {
+                promise->set_value(TBComPtr<IDirect3DTexture9>{});
+                callback(false, error);
+            }
+        });
     });
     return texture;
 }

--- a/GWToolboxdll/Modules/Resources.h
+++ b/GWToolboxdll/Modules/Resources.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <future>
 #include <ToolboxModule.h>
 #include <Utf8.h>
+#include <Utils/ComPtr.h>
 
 namespace GuiUtils {
     class EncString;
@@ -77,40 +79,43 @@ public:
     // Callback for binary, usually only curl stuff; try to stick to wstrings where possible
     using AsyncLoadMbCallback = std::function<void(bool success, const std::string& response, void* context)>;
 
-    // Load from file to D3DTexture, runs callback on completion
-    static void LoadTexture(IDirect3DTexture9** texture, const std::filesystem::path& path_to_file, AsyncLoadCallback callback = nullptr);
-    // Load from compiled resource id to D3DTexture, runs callback on completion
-    static void LoadTexture(IDirect3DTexture9** texture, WORD id, AsyncLoadCallback callback = nullptr);
-    // Load from file to D3DTexture, fallback to resource id, runs callback on completion
-    static void LoadTexture(IDirect3DTexture9** texture, const std::filesystem::path& path_to_file, WORD id, AsyncLoadCallback callback = nullptr);
-    // Load from file to D3DTexture, fallback to remote location, runs callback on completion
-    static void LoadTexture(IDirect3DTexture9** texture, const std::filesystem::path& path_to_file, const std::string& url, AsyncLoadCallback callback = nullptr);
+    // Wraps a shared_future that resolves to a D3D texture once loaded.
+    // .Get() returns the raw pointer (or nullptr if not yet loaded).
+    class Texture {
+        std::shared_future<TBComPtr<IDirect3DTexture9>> future;
+    public:
+        Texture() = default;
+        Texture(std::shared_future<TBComPtr<IDirect3DTexture9>> f) : future(std::move(f)) {}
+        IDirect3DTexture9* Get() const {
+            if (!future.valid()) return nullptr;
+            if (future.wait_for(std::chrono::seconds(0)) != std::future_status::ready) return nullptr;
+            return future.get().Get();
+        }
+        explicit operator bool() const { return Get() != nullptr; }
+    };
 
-    // Guaranteed to return a pointer, but reference will be null until the texture has been loaded
-    static IDirect3DTexture9** GetProfessionIcon(GW::Constants::Profession p);
+    // Load a texture asynchronously, returns a future that resolves when the DX task completes
+    static Texture LoadTexture(const std::filesystem::path& path_to_file, AsyncLoadCallback callback = nullptr);
+    static Texture LoadTexture(WORD id, AsyncLoadCallback callback = nullptr);
+    static Texture LoadTexture(const std::filesystem::path& path_to_file, WORD id, AsyncLoadCallback callback = nullptr);
+    static Texture LoadTexture(const std::filesystem::path& path_to_file, const std::string& url, AsyncLoadCallback callback = nullptr);
+
+    static Texture GetProfessionIcon(GW::Constants::Profession p);
     static bool GetTextureSize(IDirect3DTexture9* texture, ImVec2* out);
-    // Guaranteed to return a pointer, but reference will be null until the texture has been loaded
-    static IDirect3DTexture9** GetDamagetypeImage(std::string dmg_type);
-    // Fetches skill image from gw dat via file_id
-    static IDirect3DTexture9** GetSkillImage(GW::Constants::SkillID skill_id);
-    static IDirect3DTexture9** GetSkillHiResImage(GW::Constants::SkillID skill_id);
-    // Fetches skill page from GWW, parses out the image for the skill then downloads that to disk
-    // Not elegant, but without a proper API to provide images, and to avoid including libxml, this is the next best thing.
-    // Guaranteed to return a pointer, but reference will be null until the texture has been loaded
-    static IDirect3DTexture9** GetSkillImageFromGWW(GW::Constants::SkillID skill_id);
+    static Texture GetDamagetypeImage(std::string dmg_type);
+    static Texture GetSkillImage(GW::Constants::SkillID skill_id);
+    static Texture GetSkillHiResImage(GW::Constants::SkillID skill_id);
+    static Texture GetSkillImageFromGWW(GW::Constants::SkillID skill_id);
 
     static GuiUtils::EncString* GetSkillName(const GW::Constants::SkillID skill_id);
 
-    static IDirect3DTexture9** GetItemImage(GW::Item* item);
-    // Fetches item page from GWW, parses out the image for the item then downloads that to disk
-    // Not elegant, but without a proper API to provide images, and to avoid including libxml, this is the next best thing.
-    // Guaranteed to return a pointer, but reference will be null until the texture has been loaded
-    static IDirect3DTexture9** GetItemImage(const std::wstring& item_name);
+    static Texture GetItemImage(GW::Item* item);
+    static Texture GetItemImage(const std::wstring& item_name);
     static bool SaveTextureToFile(IDirect3DTexture9* texture, const std::filesystem::path& file_path);
-    // Fetches File page from GWW, parses out the image for the file given
-    // Not elegant, but without a proper API to provide images, and to avoid including libxml, this is the next best thing.
-    // Guaranteed to return a pointer, but reference will be null until the texture has been loaded
-    static IDirect3DTexture9** GetGuildWarsWikiImage(const char* filename, size_t width = 0, bool urlencode_filename = true);
+
+    // Fetches File page from GWW, parses out the image for the file given.
+    // Caller owns the returned future; D3D texture is released when the last copy drops.
+    static Texture GetGuildWarsWikiImage(const char* filename, size_t width = 0, bool urlencode_filename = true);
 
     static std::filesystem::path GetExePath();
 

--- a/GWToolboxdll/Unused/HeroEquipmentModule.cpp
+++ b/GWToolboxdll/Unused/HeroEquipmentModule.cpp
@@ -23,7 +23,7 @@ namespace {
 
     std::map<uint32_t, GW::UI::FramePosition> frame_layouts_by_child_id;
 
-    IDirect3DTexture9** icon_texture = nullptr;
+    Resources::Texture icon_texture;
     // Precompute UV coordinates for each state
     ImVec2 uv_normal[2], uv_hover[2], uv_active[2];
 
@@ -447,7 +447,7 @@ void HeroEquipmentModule::Draw(IDirect3DDevice9*)
 
     // Load the texture once outside the loop
 
-    if (!(icon_texture && *icon_texture)) return;
+    if (!icon_texture) return;
 
     const auto root = GW::UI::GetRootFrame();
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0);
@@ -502,7 +502,7 @@ void HeroEquipmentModule::Draw(IDirect3DDevice9*)
 
         // Draw the button texture
         ImGui::SetCursorScreenPos(btn_pos);
-        ImGui::Image(*icon_texture, btn_size, *uv_min, *uv_max);
+        ImGui::Image(icon_texture.Get(), btn_size, *uv_min, *uv_max);
 
         ImGui::End();
     }

--- a/GWToolboxdll/Utils/ComPtr.h
+++ b/GWToolboxdll/Utils/ComPtr.h
@@ -1,0 +1,40 @@
+#pragma once
+
+template<typename T>
+class TBComPtr {
+    T* ptr = nullptr;
+
+public:
+    TBComPtr() = default;
+    ~TBComPtr() { if (ptr) ptr->Release(); }
+
+    TBComPtr(const TBComPtr& o) : ptr(o.ptr) { if (ptr) ptr->AddRef(); }
+
+    TBComPtr& operator=(const TBComPtr& o)
+    {
+        if (ptr != o.ptr) {
+            if (ptr) ptr->Release();
+            ptr = o.ptr;
+            if (ptr) ptr->AddRef();
+        }
+        return *this;
+    }
+
+    TBComPtr(TBComPtr&& o) noexcept : ptr(o.ptr) { o.ptr = nullptr; }
+
+    TBComPtr& operator=(TBComPtr&& o) noexcept
+    {
+        if (this != &o) {
+            if (ptr) ptr->Release();
+            ptr = o.ptr;
+            o.ptr = nullptr;
+        }
+        return *this;
+    }
+
+    // Takes ownership of p without calling AddRef.
+    void Attach(T* p) { if (ptr) ptr->Release(); ptr = p; }
+    void Reset() { Attach(nullptr); }
+    T* Get() const { return ptr; }
+    explicit operator bool() const { return ptr != nullptr; }
+};

--- a/GWToolboxdll/Utils/GuiUtils.cpp
+++ b/GWToolboxdll/Utils/GuiUtils.cpp
@@ -147,19 +147,19 @@ namespace GuiUtils {
         const auto primary_icon = Resources::GetProfessionIcon(skill_template.primary);
 
         auto cursor_pos = ImGui::GetCursorPos();
-        ImGui::ImageCropped(*primary_icon, { text_size, text_size });
+        ImGui::ImageCropped(primary_icon.Get(), { text_size, text_size });
 
         if (skill_template.secondary != GW::Constants::Profession::None) {
             cursor_pos.y += text_size;
             ImGui::SetCursorPos(cursor_pos);
             const auto secondary_icon = Resources::GetProfessionIcon(skill_template.secondary);
-            ImGui::ImageCropped(*secondary_icon, { text_size, text_size });
+            ImGui::ImageCropped(secondary_icon.Get(), { text_size, text_size });
             cursor_pos.y -= text_size;
         }
         cursor_pos.x += text_size;
         for (auto& skill : skill_template.skills) {
             ImGui::SetCursorPos(cursor_pos);
-            ImGui::ImageCropped(*Resources::GetSkillImage(skill), skill_size);
+            ImGui::ImageCropped(Resources::GetSkillImage(skill).Get(), skill_size);
             cursor_pos.x += skill_size.x;
         }
     }

--- a/GWToolboxdll/Widgets/ActiveQuestWidget.cpp
+++ b/GWToolboxdll/Widgets/ActiveQuestWidget.cpp
@@ -36,7 +36,7 @@ namespace {
     GW::Constants::QuestID active_quest_id = GW::Constants::QuestID::None;
     GuiUtils::EncString active_quest_name;
     std::vector<QuestObjective> active_quest_objectives; // (index, objective, completed)
-    IDirect3DTexture9** p_quest_marker_texture;
+    Resources::Texture p_quest_marker_texture;
     bool force_update = false;
 
     void SetForceUpdate(GW::HookStatus*, GW::UI::UIMessage,void*,void*) {
@@ -46,13 +46,13 @@ namespace {
     void DrawQuestIcon() {
         static constexpr auto UV0 = ImVec2(0.0f, 0.0f);
         static constexpr auto ICON_SIZE = ImVec2(24.0f, 24.0f);
-        if(!p_quest_marker_texture || !*p_quest_marker_texture) {
+        if(!p_quest_marker_texture) {
             return;
         }
 
         ImGui::PushID("quest_icon");
-        auto uv1 = ImGui::CalculateUvCrop(*p_quest_marker_texture, ICON_SIZE);
-        ImGui::Image(*p_quest_marker_texture, ICON_SIZE, UV0, uv1);
+        auto uv1 = ImGui::CalculateUvCrop(p_quest_marker_texture.Get(), ICON_SIZE);
+        ImGui::Image(p_quest_marker_texture.Get(), ICON_SIZE, UV0, uv1);
         ImGui::PopID();
     }
 }

--- a/GWToolboxdll/Widgets/BondsWidget.cpp
+++ b/GWToolboxdll/Widgets/BondsWidget.cpp
@@ -268,9 +268,9 @@ void BondsWidget::Terminate()
 bool BondsWidget::DrawBondImage(uint32_t agent_id, GW::Constants::SkillID skill_id, ImVec2* top_left_out, ImVec2* bottom_right_out) {
     if (!GetBondPosition(agent_id, skill_id, top_left_out, bottom_right_out))
         return false;
-    const auto texture = *Resources::GetSkillImage(skill_id);
+    const auto& texture = Resources::GetSkillImage(skill_id);
     if (texture) {
-        ImGui::AddImageCropped(texture, *top_left_out, *bottom_right_out);
+        ImGui::AddImageCropped(texture.Get(), *top_left_out, *bottom_right_out);
         return true;
     }
     return false;

--- a/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 
+#include <Utils/ComPtr.h>
 #include <GWCA/Context/MapContext.h>
 #include <GWCA/GameContainers/GamePos.h>
 #include <GWCA/GameEntities/Camera.h>
@@ -29,9 +30,9 @@ namespace {
 
     GameWorldRenderer::RenderableVectors renderables;
     std::mutex renderables_mutex{};
-    IDirect3DVertexShader9* vshader = nullptr;
-    IDirect3DPixelShader9* pshader = nullptr;
-    IDirect3DVertexDeclaration9* vertex_declaration = nullptr;
+    TBComPtr<IDirect3DVertexShader9> vshader;
+    TBComPtr<IDirect3DPixelShader9> pshader;
+    TBComPtr<IDirect3DVertexDeclaration9> vertex_declaration;
 
     constexpr GW::Vec2f lerp(const GW::Vec2f& a, const GW::Vec2f& b, const float t)
     {
@@ -337,30 +338,39 @@ void GameWorldRenderer::Render(IDirect3DDevice9* device)
     device->GetVertexShaderConstantF(4, old_proj_matrix, 4);
     device->GetPixelShaderConstantF(0, old_ps_constants, 3);
 
-    IDirect3DVertexShader9* vshader_old = nullptr;
-    IDirect3DPixelShader9* pshader_old = nullptr;
+    TBComPtr<IDirect3DVertexShader9> vshader_old;
+    TBComPtr<IDirect3DPixelShader9> pshader_old;
+    TBComPtr<IDirect3DVertexDeclaration9> old_vertex_declaration;
 
-    if (device->GetVertexShader(&vshader_old) != D3D_OK) {
+    IDirect3DVertexShader9* raw_vs = nullptr;
+    if (device->GetVertexShader(&raw_vs) != D3D_OK) {
         Log::Error("GameWorldRenderer: unable to GetVertexShader, aborting render.");
     }
-    if (device->GetPixelShader(&pshader_old) != D3D_OK) {
+    vshader_old.Attach(raw_vs);
+
+    IDirect3DPixelShader9* raw_ps = nullptr;
+    if (device->GetPixelShader(&raw_ps) != D3D_OK) {
         Log::Error("GameWorldRenderer: unable to GetPixelShader, aborting render.");
     }
+    pshader_old.Attach(raw_ps);
 
-    if (vshader == nullptr || device->SetVertexShader(vshader) != D3D_OK) {
+    if (!vshader || device->SetVertexShader(vshader.Get()) != D3D_OK) {
         Log::Error("GameWorldRenderer: unable to SetVertexShader, aborting render.");
         return;
     }
-    if (pshader == nullptr || device->SetPixelShader(pshader) != D3D_OK) {
+    if (!pshader || device->SetPixelShader(pshader.Get()) != D3D_OK) {
         Log::Error("GameWorldRenderer: unable to SetPixelShader, aborting render.");
         return;
     }
-    IDirect3DVertexDeclaration9* old_vertex_declaration = nullptr;
-    if (device->GetVertexDeclaration(&old_vertex_declaration) != D3D_OK) {
+
+    IDirect3DVertexDeclaration9* raw_decl = nullptr;
+    if (device->GetVertexDeclaration(&raw_decl) != D3D_OK) {
         Log::Error("GameWorldRenderer: unable to GetVertexShader declaration, aborting render.");
         return;
     }
-    if (device->SetVertexDeclaration(vertex_declaration) != D3D_OK) {
+    old_vertex_declaration.Attach(raw_decl);
+
+    if (device->SetVertexDeclaration(vertex_declaration.Get()) != D3D_OK) {
         Log::Error("GameWorldRenderer: unable to SetVertexShader declaration, aborting render.");
         return;
     }
@@ -420,23 +430,14 @@ void GameWorldRenderer::Render(IDirect3DDevice9* device)
     device->SetVertexShaderConstantF(0, old_view_matrix, 4);
     device->SetVertexShaderConstantF(4, old_proj_matrix, 4);
     device->SetPixelShaderConstantF(0, old_ps_constants, 3);
-    if (device->SetVertexShader(vshader_old) != D3D_OK) {
+    if (device->SetVertexShader(vshader_old.Get()) != D3D_OK) {
         Log::Error("GameWorldRenderer: unable to reset SetVertexShader.");
     }
-    if (device->SetPixelShader(pshader_old) != D3D_OK) {
+    if (device->SetPixelShader(pshader_old.Get()) != D3D_OK) {
         Log::Error("GameWorldRenderer: unable to reset SetPixelShader.");
     }
-    if (device->SetVertexDeclaration(old_vertex_declaration) != D3D_OK) {
+    if (device->SetVertexDeclaration(old_vertex_declaration.Get()) != D3D_OK) {
         Log::Error("GameWorldRenderer: unable to set old SetVertexShader declaration, aborting render.");
-    }
-    if (old_vertex_declaration) {
-        old_vertex_declaration->Release();
-    }
-    if (vshader_old) {
-        vshader_old->Release();
-    }
-    if (pshader_old) {
-        pshader_old->Release();
     }
 }
 
@@ -446,19 +447,23 @@ bool GameWorldRenderer::ConfigureProgrammablePipeline(IDirect3DDevice9* device)
         {0, 0, D3DDECLTYPE_FLOAT3, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0},
         {0, 12, D3DDECLTYPE_D3DCOLOR, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_COLOR, 0},
         D3DDECL_END()};
-    if (device->CreateVertexDeclaration(decl, &vertex_declaration) != D3D_OK) {
-        //Log::Error("GameWorldRenderer: unable to CreateVertexDeclaration");
+    IDirect3DVertexDeclaration9* raw_decl = nullptr;
+    if (device->CreateVertexDeclaration(decl, &raw_decl) != D3D_OK) {
         return false;
     }
+    vertex_declaration.Attach(raw_decl);
 
-    if (device->CreateVertexShader(reinterpret_cast<const DWORD*>(&game_world_renderer_vs), &vshader) != D3D_OK) {
-        //Log::Error("GameWorldRenderer: unable to CreateVertexShader");
+    IDirect3DVertexShader9* raw_vs = nullptr;
+    if (device->CreateVertexShader(reinterpret_cast<const DWORD*>(&game_world_renderer_vs), &raw_vs) != D3D_OK) {
         return false;
     }
-    if (device->CreatePixelShader(reinterpret_cast<const DWORD*>(&game_world_renderer_dotted_ps), &pshader) != D3D_OK) {
-        //Log::Error("GameWorldRenderer: unable to CreatePixelShader");
+    vshader.Attach(raw_vs);
+
+    IDirect3DPixelShader9* raw_ps = nullptr;
+    if (device->CreatePixelShader(reinterpret_cast<const DWORD*>(&game_world_renderer_dotted_ps), &raw_ps) != D3D_OK) {
         return false;
     }
+    pshader.Attach(raw_ps);
     need_configure_pipeline = false;
     return true;
 }
@@ -504,15 +509,9 @@ void GameWorldRenderer::Terminate()
 {
     // free up any vertex buffers
     renderables.clear();
-    if (vshader)
-        vshader->Release();
-    vshader = nullptr;
-    if (pshader)
-        pshader->Release();
-    pshader = nullptr;
-    if (vertex_declaration)
-        vertex_declaration->Release();
-    vertex_declaration = nullptr;
+    vshader.Reset();
+    pshader.Reset();
+    vertex_declaration.Reset();
 }
 
 void GameWorldRenderer::SyncAllMarkers()

--- a/GWToolboxdll/Widgets/SkillMonitorWidget.cpp
+++ b/GWToolboxdll/Widgets/SkillMonitorWidget.cpp
@@ -265,9 +265,9 @@ void SkillMonitorWidget::Draw(IDirect3DDevice9*)
                 const ImVec2 top_left = {history_flip_direction ? window_x + (i * img_size) : window_x + width - (i * img_size) - img_size, health_bar_pos->top_left.y};
                 const ImVec2 bottom_right = {top_left.x + img_size, top_left.y + img_size};
 
-                const auto texture = *Resources::GetSkillImage(skill_activation.id);
+                const auto& texture = Resources::GetSkillImage(skill_activation.id);
                 if (texture) {
-                    draw_list->AddImage(texture, top_left, bottom_right);
+                    draw_list->AddImage(texture.Get(), top_left, bottom_right);
                 }
 
                 if (status_border_thickness != 0) {

--- a/GWToolboxdll/Widgets/WorldMapWidget.cpp
+++ b/GWToolboxdll/Widgets/WorldMapWidget.cpp
@@ -121,9 +121,9 @@ namespace {
 
     ImRect controls_window_rect = {0, 0, 0, 0};
 
-    IDirect3DTexture9** quest_icon_texture = nullptr;
-    IDirect3DTexture9** player_icon_texture = nullptr;
-    IDirect3DTexture9** portal_icon_texture = nullptr;
+    Resources::Texture quest_icon_texture;
+    Resources::Texture player_icon_texture;
+    Resources::Texture portal_icon_texture;
 
     bool showing_all_outposts = false;
     bool apply_quest_colors = false;
@@ -629,12 +629,12 @@ namespace {
             }
         }
 
-        const auto texture = Resources::GetSkillImage(boss.skill_id);
+        const auto& texture = Resources::GetSkillImage(boss.skill_id);
         // const auto texture = Resources::GetProfessionIcon((GW::Constants::Profession)skill->profession);
 
-        if (!(texture && *texture)) return false;
+        if (!texture) return false;
 
-        if (!Resources::GetTextureSize(*texture, &skill_texture_size)) return false;
+        if (!Resources::GetTextureSize(texture.Get(), &skill_texture_size)) return false;
 
         float icon_size = world_map_context->zoom == 1.f ? 32.f : 16.f;
         const auto half_size = icon_size / 2.f;
@@ -745,7 +745,7 @@ namespace {
 
             const ImRect icon_rect = {{viewport_quest_pos.x - half_size, viewport_quest_pos.y - half_size}, {viewport_quest_pos.x + half_size, viewport_quest_pos.y + half_size}};
 
-            ImGui::AddImageScaled(draw_list, *texture, icon_rect.Min, skill_texture_size, icon_size, icon_size);
+            ImGui::AddImageScaled(draw_list, texture.Get(), icon_rect.Min, skill_texture_size, icon_size, icon_size);
             hovered |= icon_rect.Contains(ImGui::GetMousePos());
         }
 
@@ -776,7 +776,7 @@ namespace {
             ImVec2 uv_points[4];
             CalculateUVCoords(0.0f, 0.5f, uv_points); // Left-hand side of the sprite map
 
-            draw_list->AddImageQuad(*quest_icon_texture, rotated_points[0], rotated_points[1], rotated_points[2], rotated_points[3], uv_points[0], uv_points[1], uv_points[2], uv_points[3], color & IM_COL32_A_MASK ? color : IM_COL32_WHITE);
+            draw_list->AddImageQuad(quest_icon_texture.Get(), rotated_points[0], rotated_points[1], rotated_points[2], rotated_points[3], uv_points[0], uv_points[1], uv_points[2], uv_points[3], color & IM_COL32_A_MASK ? color : IM_COL32_WHITE);
 
             return icon_rect.Contains(ImGui::GetMousePos());
         };
@@ -801,7 +801,7 @@ namespace {
             ImVec2 uv_points[4];
             CalculateUVCoords(0.5f, 1.0f, uv_points); // Right-hand side of the sprite map
 
-            draw_list->AddImageQuad(*quest_icon_texture, rotated_points[0], rotated_points[1], rotated_points[2], rotated_points[3], uv_points[0], uv_points[1], uv_points[2], uv_points[3], color & IM_COL32_A_MASK ? color : IM_COL32_WHITE);
+            draw_list->AddImageQuad(quest_icon_texture.Get(), rotated_points[0], rotated_points[1], rotated_points[2], rotated_points[3], uv_points[0], uv_points[1], uv_points[2], uv_points[3], color & IM_COL32_A_MASK ? color : IM_COL32_WHITE);
 
             return icon_rect.Contains(ImGui::GetMousePos());
         };
@@ -850,7 +850,7 @@ namespace {
         const auto viewport_pos = CalculateViewportPos(pos, world_map_context->top_left);
         const ImRect icon_rect = {{viewport_pos.x - quest_icon_size_half, viewport_pos.y - quest_icon_size_half}, {viewport_pos.x + quest_icon_size_half, viewport_pos.y + quest_icon_size_half}};
 
-        draw_list->AddImage(*quest_icon_texture, icon_rect.Min, icon_rect.Max);
+        draw_list->AddImage(quest_icon_texture.Get(), icon_rect.Min, icon_rect.Max);
 
         return icon_rect.Contains(ImGui::GetMousePos());
     }
@@ -880,7 +880,7 @@ void WorldMapWidget::Initialize()
     memset(show_elite_capture_locations, true, sizeof(show_elite_capture_locations));
     quest_icon_texture = GwDatTextureModule::LoadTextureFromFileId(0x1b4d5);
     player_icon_texture = GwDatTextureModule::LoadTextureFromFileId(0x5d3b);
-    portal_icon_texture = GwDatTextureModule::LoadTextureFromFileId(0x246c); // IDirect3DTexture9**
+    portal_icon_texture = GwDatTextureModule::LoadTextureFromFileId(0x246c);
 
     uintptr_t address = GW::Scanner::Find("\x8b\x45\xfc\xf7\x40\x10\x00\x00\x01\x00", "xxxxxxxxxx", 0xa);
     if (address) {
@@ -1112,12 +1112,12 @@ void WorldMapWidget::Draw(IDirect3DDevice9*)
         ImGui::Indent();
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, {0.f, 0.f});
         for (size_t i = 1; i < _countof(show_elite_capture_locations); i++) {
-            const auto icon = Resources::GetProfessionIcon((GW::Constants::Profession)i);
-            if (!(icon && *icon)) continue;
+            const auto& icon = Resources::GetProfessionIcon((GW::Constants::Profession)i);
+            if (!icon) continue;
             if (i != 1) ImGui::SameLine();
             ImGui::PushID(i);
             ImGui::PushStyleColor(ImGuiCol_Button, show_elite_capture_locations[i] ? completed_bg.Value : ImGui::GetStyleColorVec4(ImGuiCol_Button));
-            if (ImGui::IconButton("", *icon, {24.f, 24.f})) {
+            if (ImGui::IconButton("", icon.Get(), {24.f, 24.f})) {
                 show_elite_capture_locations[i] = !show_elite_capture_locations[i];
             }
             ImGui::PopStyleColor();
@@ -1209,7 +1209,7 @@ void WorldMapWidget::Draw(IDirect3DDevice9*)
             portal_pos, {portal_pos.x + ICON_SIZE.x, portal_pos.y + ICON_SIZE.y}
         };
 
-        draw_list->AddImage(*GwDatTextureModule::LoadTextureFromFileId(0x1b4d5), hover_rect.GetTL(), hover_rect.GetBR());
+        draw_list->AddImage(GwDatTextureModule::LoadTextureFromFileId(0x1b4d5).Get(), hover_rect.GetTL(), hover_rect.GetBR());
 
 
         if (hover_rect.Contains(ImGui::GetMousePos())) {

--- a/GWToolboxdll/Windows/AccountInventoryWindow.cpp
+++ b/GWToolboxdll/Windows/AccountInventoryWindow.cpp
@@ -231,7 +231,7 @@ const char* HERO_NAME[] = {
 
         uint32_t item_id{};
         // caches, do not serialize
-        IDirect3DTexture9** texture; // output of GetItemImage
+        Resources::Texture texture; // output of GetItemImage
         std::string location{};     // (Player) <Storage Pane> or <Hero Name>
 
         void CopyKeyTo(InventoryItem* i)
@@ -1954,8 +1954,8 @@ void AccountInventoryWindow::Draw(IDirect3DDevice9*)
         }
         else {
             const auto pos = ImGui::GetCursorPos();
-            if (i_front->texture && *(i_front->texture))
-                clicked = ImGui::IconButton(nullptr, *i_front->texture, button_size, ImGuiButtonFlags_None, button_size);
+            if (i_front->texture)
+                clicked = ImGui::IconButton(nullptr, i_front->texture.Get(), button_size, ImGuiButtonFlags_None, button_size);
             else
                 clicked = ImGui::Button("???", button_size);
 

--- a/GWToolboxdll/Windows/ArmoryWindow.cpp
+++ b/GWToolboxdll/Windows/ArmoryWindow.cpp
@@ -674,7 +674,7 @@ namespace GWArmory {
         return player && player->GetIsFemale();
     }
 
-    IDirect3DTexture9** GetArmorPieceImage(uint32_t model_file_id, uint32_t interaction) {
+    Resources::Texture GetArmorPieceImage(uint32_t model_file_id, uint32_t interaction) {
         const bool is_composite_item = (interaction & 4) != 0;
 
         uint32_t model_id_to_load = 0;
@@ -855,15 +855,15 @@ namespace GWArmory {
             }
 
             const auto texture = GetArmorPieceImage(piece->model_file_id, piece->interaction);
-            if (!texture || !*texture) {
+            if (!texture) {
                 ImGui::PopID();
                 continue;
             }
-    
-            const auto uv1 = ImGui::CalculateUvCrop(*texture, scaled_size);
+
+            const auto uv1 = ImGui::CalculateUvCrop(texture.Get(), scaled_size);
             const auto& bg = player_piece->model_file_id == piece->model_file_id ? equipped_color : normal_bg;
             ImGui::NextSpacedElement();
-            if (ImGui::ImageButton(*texture, scaled_size, uv0, uv1, -1, bg, tint)) {
+            if (ImGui::ImageButton(texture.Get(), scaled_size, uv0, uv1, -1, bg, tint)) {
                 player_piece->model_file_id = piece->model_file_id;
                 player_piece->interaction = piece->interaction;
                 player_piece->type = piece->type;

--- a/GWToolboxdll/Windows/BuildsWindow.cpp
+++ b/GWToolboxdll/Windows/BuildsWindow.cpp
@@ -564,7 +564,7 @@ namespace {
                 if (active) {
                     ImGui::PushStyleColor(ImGuiCol_Button, build_edit_pcon_enabled_color);
                 }
-                if (ImGui::IconButton("", *pcon->GetTexture(), {skill_height, skill_height})) {
+                if (ImGui::IconButton("", pcon->GetTexture().Get(), {skill_height, skill_height})) {
                     if (!active) {
                         build->pcons.emplace(pcon->ini);
                     }
@@ -634,7 +634,7 @@ namespace {
                 if (i) {
                     ImGui::SameLine(0, 0);
                 }
-                ImGui::ImageCropped(*Resources::GetSkillImage(skills[i]), skill_size);
+                ImGui::ImageCropped(Resources::GetSkillImage(skills[i]).Get(), skill_size);
                 if (ImGui::IsItemHovered()) {
                     const GW::Skill* s = GW::SkillbarMgr::GetSkillConstantData(skills[i]);
                     if (s) {

--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -93,9 +93,9 @@ namespace {
 
     std::wstring last_player_name;
 
-    void GetOutpostIcons(MapID map_id, IDirect3DTexture9** icons_out[4], uint8_t mission_state, bool is_hard_mode = false)
+    void GetOutpostIcons(MapID map_id, Resources::Texture icons_out[4], uint8_t mission_state, bool is_hard_mode = false)
     {
-        memset(icons_out, 0, sizeof(icons_out) * sizeof(*icons_out));
+        for (size_t i = 0; i < 4; i++) icons_out[i] = {};
 
         WorldMapIcon icon_file_ids[4] = {WorldMapIcon::None};
         uint32_t icon_idx = 0;
@@ -810,9 +810,7 @@ size_t Mission::GetLoadedIcons(IDirect3DTexture9* icons_out[4])
     for (size_t i = 0; i < _countof(icons) && icons_added < 4; i++) {
         if (!icons[i])
             break;
-        if (*icons[i]) {
-            icons_out[icons_added++] = *icons[i];
-        }
+        icons_out[icons_added++] = icons[i].Get();
     }
     return icons_added;
 }
@@ -924,7 +922,7 @@ void Mission::OnHover()
             icon_size.x = icon_size.y;
             const auto map = GW::Map::GetMapInfo(outpost);
             for (auto char_completion : chars_without_completed) {
-                ImGui::Image(*Resources::GetProfessionIcon(char_completion->profession), icon_size);
+                ImGui::Image(Resources::GetProfessionIcon(char_completion->profession).Get(), icon_size);
                 bool is_hm_complete = ::IsAreaComplete(TextUtils::StringToWString(char_completion->name_str).c_str(), outpost, CompletionCheck::HardMode, map);
                 bool is_nm_complete = ::IsAreaComplete(TextUtils::StringToWString(char_completion->name_str).c_str(), outpost, CompletionCheck::NormalMode, map);
                 ImGui::SameLine();
@@ -995,7 +993,7 @@ void OutpostUnlock::OnHover()
             auto icon_size = ImGui::CalcTextSize(" ");
             icon_size.x = icon_size.y;
             for (auto char_completion : chars_without_completed) {
-                ImGui::Image(*Resources::GetProfessionIcon(char_completion->profession), icon_size);
+                ImGui::Image(Resources::GetProfessionIcon(char_completion->profession).Get(), icon_size);
                 ImGui::SameLine();
                 ImGui::TextUnformatted(char_completion->name_str.c_str());
             }
@@ -1064,23 +1062,17 @@ const char* HeroUnlock::Name()
 size_t HeroUnlock::GetLoadedIcons(IDirect3DTexture9* icons_out[4])
 {
     if (!icons_loaded) {
-        *icons = new IDirect3DTexture9*();
         const auto path = Resources::GetPath(L"img/heros");
         Resources::EnsureFolderExists(path);
         wchar_t local_image[MAX_PATH];
         swprintf(local_image, _countof(local_image), L"%s/hero_%d.jpg", path.c_str(), skill_id);
         char remote_image[128];
         snprintf(remote_image, _countof(remote_image), "https://github.com/gwdevhub/GWToolboxpp/raw/master/resources/heros/hero_%d.jpg", skill_id);
-        Resources::LoadTexture(*icons, local_image, remote_image);
+        hero_texture = Resources::LoadTexture(std::filesystem::path{local_image}, std::string{remote_image});
+        *icons = hero_texture;
         icons_loaded = true;
     }
     return Mission::GetLoadedIcons(icons_out);
-}
-
-HeroUnlock::~HeroUnlock()
-{
-    if (*icons)
-        delete*icons;
 }
 
 void HeroUnlock::OnClick()
@@ -1177,7 +1169,7 @@ void PvESkill::OnHover()
             auto icon_size = ImGui::CalcTextSize(" ");
             icon_size.x = icon_size.y;
             for (auto char_completion : chars_without_completed) {
-                ImGui::Image(*Resources::GetProfessionIcon(char_completion->profession), icon_size);
+                ImGui::Image(Resources::GetProfessionIcon(char_completion->profession).Get(), icon_size);
                 ImGui::SameLine();
                 ImGui::TextUnformatted(char_completion->name_str.c_str());
             }

--- a/GWToolboxdll/Windows/CompletionWindow.h
+++ b/GWToolboxdll/Windows/CompletionWindow.h
@@ -3,6 +3,7 @@
 #include <GWCA/Constants/Constants.h>
 
 #include <Modules/HallOfMonumentsModule.h>
+#include <Modules/Resources.h>
 #include <ToolboxWindow.h>
 #include <Color.h>
 #include <Utils/GuiUtils.h>
@@ -21,8 +22,8 @@ namespace Missions {
         GW::Constants::QuestID zm_quest;
 
         uint8_t mission_state = 0;
-        // Array of placeholder pointers; the actual IDirect3DTexture9* is loaded from dx9
-        IDirect3DTexture9** icons[4] = { nullptr };
+        // Array of Texture values; populated asynchronously from dx9
+        Resources::Texture icons[4];
         bool icons_loaded = false;
         ImVec2 icon_uv_offset[2] = { { .0f,.0f },{0.f,0.f} };
 
@@ -77,9 +78,10 @@ namespace Missions {
     class HeroUnlock : public PvESkill {
     public:
         HeroUnlock(GW::Constants::HeroID _hero_id);
-        ~HeroUnlock();
 
         size_t GetLoadedIcons(IDirect3DTexture9* icons_out[4]) override;
+
+        Resources::Texture hero_texture;
 
         void OnClick() override;
         void OnHover() override { ImGui::SetTooltip(Name()); };

--- a/GWToolboxdll/Windows/DailyQuestsWindow.cpp
+++ b/GWToolboxdll/Windows/DailyQuestsWindow.cpp
@@ -948,7 +948,7 @@ namespace {
             auto icon_size = ImGui::CalcTextSize(" ");
             icon_size.x = icon_size.y;
             for (auto char_completion : chars_without_completed) {
-                ImGui::Image(*Resources::GetProfessionIcon(char_completion->profession), icon_size);
+                ImGui::Image(Resources::GetProfessionIcon(char_completion->profession).Get(), icon_size);
                 ImGui::SameLine();
                 ImGui::TextUnformatted(char_completion->name_str.c_str());
             }

--- a/GWToolboxdll/Windows/DropTrackerWindow.cpp
+++ b/GWToolboxdll/Windows/DropTrackerWindow.cpp
@@ -58,7 +58,8 @@ namespace {
     void DrawItemIcon(const ItemDrops::PendingDrop* drop)
     {
         if (icon_size > 0) {
-            ImGui::Image((ImTextureID)(intptr_t)*drop->icon, ImVec2(icon_size, icon_size));
+            if (drop->icon)
+                ImGui::Image(drop->icon.Get(), ImVec2(icon_size, icon_size));
         }
     }
 

--- a/GWToolboxdll/Windows/GWMarketWindow.cpp
+++ b/GWToolboxdll/Windows/GWMarketWindow.cpp
@@ -81,7 +81,7 @@ namespace {
         }
     }
 
-    IDirect3DTexture9** GetCurrencyImage(Currency currency)
+    Resources::Texture GetCurrencyImage(Currency currency)
     {
         switch (currency) {
             case Currency::Platinum:
@@ -93,7 +93,7 @@ namespace {
             case Currency::Arms:
                 return GwDatTextureModule::LoadTextureFromFileId(0x2ae18);
         }
-        return nullptr;
+        return {};
     }
 
     const char* GetOrderTypeString(OrderType type)
@@ -1121,7 +1121,7 @@ namespace {
             ImGui::SameLine(0, 0);
             const auto tex = GetCurrencyImage(price.type);
             if (tex) {
-                ImGui::ImageCropped((void*)*tex, {font_size.y, font_size.y});
+                ImGui::ImageCropped(tex.Get(), {font_size.y, font_size.y});
                 ImGui::SameLine(0, 0);
             }
             if (price.price == static_cast<int>(price.price)) {
@@ -1241,7 +1241,7 @@ namespace {
             ImGui::SameLine(0, 0);
             const auto tex = GetCurrencyImage(price.type);
             if (tex) {
-                ImGui::ImageCropped((void*)*tex, {font_size.y, font_size.y});
+                ImGui::ImageCropped(tex.Get(), {font_size.y, font_size.y});
                 ImGui::SameLine(0, 0);
             }
             if (price.price == static_cast<int>(price.price)) {
@@ -1349,8 +1349,8 @@ namespace {
         ImGui::SameLine(350);
         if (!item.prices.empty()) {
             const auto& price = item.prices[0];
-            if (auto* texture = GetCurrencyImage(price.type)) {
-                ImGui::Image(*texture, ImVec2(16, 16));
+            if (auto texture = GetCurrencyImage(price.type)) {
+                ImGui::Image(texture.Get(), ImVec2(16, 16));
                 ImGui::SameLine();
             }
             ImGui::Text("%.0f %s", price.price, GetPriceTypeString(price.type));

--- a/GWToolboxdll/Windows/InfoWindow.cpp
+++ b/GWToolboxdll/Windows/InfoWindow.cpp
@@ -291,7 +291,7 @@ namespace {
         InfoField("Bag/Slot", "%s", slot);
         InfoField("ModelID", "%d", item->model_id);
         InfoField("Name", "%s", name->string().c_str());
-        ImGui::Image(*Resources::GetItemImage(item), { 48,48 });
+        ImGui::Image(Resources::GetItemImage(item).Get(), { 48,48 });
         auto draw_advanced = [&, item] {
             InfoField("Addr", "%p", item);
             InfoField("Id", "%d", item->item_id);
@@ -573,9 +573,9 @@ namespace {
         GW::Hook::LeaveHook();
     }
 
-    std::unordered_map<uint32_t, IDirect3DTexture9**> textures_created_by_file_id;
-    std::unordered_map<IDirect3DTexture9**, uint32_t> texture_file_ids;
-    std::vector<IDirect3DTexture9**> textures_created;
+    std::unordered_map<uint32_t, Resources::Texture> textures_created_by_file_id;
+    std::unordered_map<uint32_t, uint32_t> texture_index_to_file_id;
+    std::vector<uint32_t> textures_created_order;
 
     std::map<uint32_t, IDirect3DTexture9*> dx9_textures_created_by_hash;
     bool record_dx9_textures = false;
@@ -668,10 +668,8 @@ namespace {
         const auto out = CreateTexture_Ret(file_name, flags);
         uint32_t file_id = FileHashToFileId(file_name);
         if (textures_created_by_file_id.find(file_id) == textures_created_by_file_id.end()) {
-            const auto f = GwDatTextureModule::LoadTextureFromFileId(file_id);
-            textures_created.push_back(f);
-            textures_created_by_file_id[file_id] = f;
-            texture_file_ids[f] = file_id;
+            textures_created_by_file_id[file_id] = GwDatTextureModule::LoadTextureFromFileId(file_id);
+            textures_created_order.push_back(file_id);
         }
         GW::Hook::LeaveHook();
         return out;
@@ -712,8 +710,7 @@ namespace {
             GW::Hook::RemoveHook(CreateTexture_Func);
             CreateTexture_Func = 0;
             textures_created_by_file_id.clear();
-            textures_created.clear();
-            texture_file_ids.clear();
+            textures_created_order.clear();
         }
     }
     void HookOnGWCASendUIMessage(bool hook) {
@@ -984,7 +981,7 @@ namespace {
         }
         if (ImGui::CollapsingHeader("Loaded Textures by GW File")) {
             record_textures = true;
-            ImGui::PushID(&textures_created);
+            ImGui::PushID(&textures_created_order);
             constexpr ImVec2 scaled_size = { 64.f, 64.f };
             constexpr ImVec4 tint(1, 1, 1, 1);
             const auto normal_bg = ImColor(IM_COL32(0, 0, 0, 0));
@@ -992,8 +989,7 @@ namespace {
 
             if (ImGui::SmallButton("Reset")) {
                 textures_created_by_file_id.clear();
-                textures_created.clear();
-                texture_file_ids.clear();
+                textures_created_order.clear();
             }
 
             ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
@@ -1002,36 +998,38 @@ namespace {
 
             ImGui::StartSpacedElements(scaled_size.x);
 
-            for (const auto texture : textures_created) {
-                ImGui::PushID(texture);
-                if (!texture || !*texture) {
+            for (const auto file_id : textures_created_order) {
+                ImGui::PushID(static_cast<int>(file_id));
+                auto it = textures_created_by_file_id.find(file_id);
+                if (it == textures_created_by_file_id.end() || !it->second) {
                     ImGui::PopID();
                     continue;
                 }
+                const auto& texture = it->second;
 
-                const auto uv1 = ImGui::CalculateUvCrop(*texture, scaled_size);
+                const auto uv1 = ImGui::CalculateUvCrop(texture.Get(), scaled_size);
                 ImGui::NextSpacedElement();
-                const auto clicked = ImGui::ImageButton(*texture, scaled_size, uv0, uv1, -1, normal_bg, tint);
+                const auto clicked = ImGui::ImageButton(texture.Get(), scaled_size, uv0, uv1, -1, normal_bg, tint);
                 static wchar_t out[3];
                 if (ImGui::IsItemHovered()) {
-                    ArenaNetFileParser::FileIdToFileHash(texture_file_ids[texture], out);
-                    ImGui::SetTooltip("File ID: 0x%08x\nFile Hash: 0x%04x 0x%04x", texture_file_ids[texture], out[0], out[1]);
+                    ArenaNetFileParser::FileIdToFileHash(file_id, out);
+                    ImGui::SetTooltip("File ID: 0x%08x\nFile Hash: 0x%04x 0x%04x", file_id, out[0], out[1]);
                 }
                 if (clicked) {
-                    ImGui::SetContextMenu([texture](void*) {
+                    ImGui::SetContextMenu([file_id, &texture](void*) {
                         if (ImGui::Button("Download as DDS (naming by gw file id)")) {
-                            const auto filename = std::format("{:#010x}.dds", texture_file_ids[texture]);
+                            const auto filename = std::format("{:#010x}.dds", file_id);
                             const auto write_to = Resources::GetPath("extracted_textures", filename);
                             Resources::EnsureFolderExists(Resources::GetPath("extracted_textures"));
-                            Resources::SaveTextureToFile(*texture, write_to);
+                            Resources::SaveTextureToFile(texture.Get(), write_to);
                             return false;
                         }
                         if (ImGui::Button("Download as DDS (naming by hash for gMod)")) {
-                            const auto hash = Resources::GetTexmodHash(*texture);
+                            const auto hash = Resources::GetTexmodHash(texture.Get());
                             const auto filename = std::format("GW.EXE_0x{:08X}.dds", hash);
                             const auto write_to = Resources::GetPath("extracted_textures", filename);
                             Resources::EnsureFolderExists(Resources::GetPath("extracted_textures"));
-                            Resources::SaveTextureToFile(*texture, write_to);
+                            Resources::SaveTextureToFile(texture.Get(), write_to);
                             return false;
                         }
                         return true;

--- a/GWToolboxdll/Windows/MaterialsWindow.cpp
+++ b/GWToolboxdll/Windows/MaterialsWindow.cpp
@@ -25,11 +25,11 @@ namespace {
 
     constexpr DWORD MIN_TIME_BETWEEN_RETRY = 160; // 10 frames
 
-    IDirect3DTexture9** tex_essence = nullptr;
-    IDirect3DTexture9** tex_grail = nullptr;
-    IDirect3DTexture9** tex_armor = nullptr;
-    IDirect3DTexture9** tex_powerstone = nullptr;
-    IDirect3DTexture9** tex_resscroll = nullptr;
+    Resources::Texture tex_essence;
+    Resources::Texture tex_grail;
+    Resources::Texture tex_armor;
+    Resources::Texture tex_powerstone;
+    Resources::Texture tex_resscroll;
 
     // Negative values have special meanings:
     static constexpr auto PRICE_DEFAULT = -1;
@@ -406,7 +406,7 @@ void MaterialsWindow::Draw(IDirect3DDevice9*)
         // while minimizing the rescaling
 
         // === Essence ===
-        ImGui::Image(*tex_essence, ImVec2(50, 50),
+        ImGui::Image(tex_essence.Get(), ImVec2(50, 50),
                      ImVec2(4.0f / 64, 9.0f / 64), ImVec2(47.0f / 64, 52.0f / 64));
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Essence of Celerity\nFeathers and Dust");
@@ -458,7 +458,7 @@ void MaterialsWindow::Draw(IDirect3DDevice9*)
 
         ImGui::Separator();
         // === Grail ===
-        ImGui::Image(*tex_grail, ImVec2(50, 50),
+        ImGui::Image(tex_grail.Get(), ImVec2(50, 50),
                      ImVec2(3.0f / 64, 11.0f / 64), ImVec2(49.0f / 64, 57.0f / 64));
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Grail of Might\nIron and Dust");
@@ -501,7 +501,7 @@ void MaterialsWindow::Draw(IDirect3DDevice9*)
 
         ImGui::Separator();
         // === Armor ===
-        ImGui::Image(*tex_armor, ImVec2(50, 50),
+        ImGui::Image(tex_armor.Get(), ImVec2(50, 50),
                      ImVec2(0, 1.0f / 64), ImVec2(59.0f / 64, 60.0f / 64));
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Armor of Salvation\nIron and Bones");
@@ -544,7 +544,7 @@ void MaterialsWindow::Draw(IDirect3DDevice9*)
 
         ImGui::Separator();
         // === Powerstone ===
-        ImGui::Image(*tex_powerstone, ImVec2(50, 50),
+        ImGui::Image(tex_powerstone.Get(), ImVec2(50, 50),
                      ImVec2(0, 6.0f / 64), ImVec2(54.0f / 64, 60.0f / 64));
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Powerstone of Courage\nGranite and Dust");
@@ -586,7 +586,7 @@ void MaterialsWindow::Draw(IDirect3DDevice9*)
 
         ImGui::Separator();
         // === Res scroll ===
-        ImGui::Image(*tex_resscroll, ImVec2(50, 50),
+        ImGui::Image(tex_resscroll.Get(), ImVec2(50, 50),
                      ImVec2(1.0f / 64, 4.0f / 64), ImVec2(56.0f / 64, 59.0f / 64));
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Scroll of Resurrection\nFibers and Bones");

--- a/GWToolboxdll/Windows/PartyStatisticsWindow.cpp
+++ b/GWToolboxdll/Windows/PartyStatisticsWindow.cpp
@@ -51,7 +51,7 @@ namespace {
 
     IDirect3DTexture9* GetSkillImage(const GW::Constants::SkillID skill_id)
     {
-        return *Resources::GetSkillImage(skill_id);
+        return Resources::GetSkillImage(skill_id).Get();
     }
 
 

--- a/GWToolboxdll/Windows/Pcons.cpp
+++ b/GWToolboxdll/Windows/Pcons.cpp
@@ -116,24 +116,24 @@ wchar_t* Pcon::SetPlayerName()
     return c->player_name;
 }
 
-IDirect3DTexture9** Pcon::GetTexture()
+const Resources::Texture& Pcon::GetTexture()
 {
     if (!texture) {
         texture = Resources::GetItemImage(filename);
     }
     return texture;
-}   
+}
 
 void Pcon::Draw(IDirect3DDevice9*)
 {
-    const auto t = GetTexture();
-    if (!(t && *t)) return;
+    const auto& t = GetTexture();
+    if (!t) return;
     const ImVec2 pos = ImGui::GetCursorPos();
     const ImVec2 s(size, size);
     const ImVec4 bg = IsEnabled() ? ImColor(enabled_bg_color).Value : ImVec4(0, 0, 0, 0);
     constexpr ImVec4 tint(1, 1, 1, 1);
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
-    if (ImGui::ImageButton(*t, s, uv0, uv1, 0, bg, tint)) {
+    if (ImGui::ImageButton(t.Get(), s, uv0, uv1, 0, bg, tint)) {
         OnButtonClick();
     }
     ImGui::PopStyleColor();
@@ -176,7 +176,8 @@ void Pcon::Draw(IDirect3DDevice9*)
 
 void Pcon::Terminate()
 {
-    texture = nullptr;
+    texture = {};
+
 }
 
 void Pcon::Update(int delay)

--- a/GWToolboxdll/Windows/Pcons.h
+++ b/GWToolboxdll/Windows/Pcons.h
@@ -4,7 +4,9 @@
 #include <GWCA/GameEntities/Item.h>
 #include <GWCA/Managers/MapMgr.h>
 
+#include <Modules/Resources.h>
 #include <Timer.h>
+#include <Utils/ComPtr.h>
 
 class Pcon {
 public:
@@ -73,7 +75,7 @@ public:
     static uint32_t MoveItem(const GW::Item* item, GW::Bag* bag, size_t slot,
                              size_t quantity = 0);
     wchar_t* SetPlayerName();
-    IDirect3DTexture9** GetTexture();
+    const Resources::Texture& GetTexture();
     // Pass true to start refill, or false to stop.
     void Refill(bool do_refill = true);
     void SetEnabled(bool enabled);
@@ -129,7 +131,7 @@ protected:
     virtual size_t PointsPerUse(const GW::Item* item) const = 0;
 
 private:
-    IDirect3DTexture9** texture = nullptr;
+    Resources::Texture texture;
     const ImVec2 uv0 = {0, 0};
     const ImVec2 uv1 = {1, 1};
 };

--- a/GWToolboxdll/Windows/PconsWindow.cpp
+++ b/GWToolboxdll/Windows/PconsWindow.cpp
@@ -956,9 +956,9 @@ void PconsWindow::DrawSettingsInternal()
                 ImGui::PushID(pcon->ini.c_str());
                 ImGui::Checkbox("###checked", &pcon->visible);
                 ImGui::SameLine();
-                const auto tex = pcon->GetTexture();
+                const auto& tex = pcon->GetTexture();
                 if (tex) {
-                    ImGui::ImageFit(*tex, ImVec2(font_size, font_size));
+                    ImGui::ImageFit(tex.Get(), ImVec2(font_size, font_size));
                     ImGui::SameLine();
                 }
                 ImGui::TextUnformatted(pcon->chat.c_str());

--- a/GWToolboxdll/Windows/RerollWindow.cpp
+++ b/GWToolboxdll/Windows/RerollWindow.cpp
@@ -453,7 +453,7 @@ void RerollWindow::Draw(IDirect3DDevice9*)
                 ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
                 ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.f));
             }
-            if (ImGui::IconButton(buf.c_str(), *Resources::GetProfessionIcon(profession), btn_dim)) {
+            if (ImGui::IconButton(buf.c_str(), Resources::GetProfessionIcon(profession).Get(), btn_dim)) {
                 const bool _same_map = travel_to_same_location_after_rerolling;
                 bool _same_party = travel_to_same_location_after_rerolling && rejoin_party_after_rerolling;
                 if (rejoin_party_after_rerolling && !_same_party) {

--- a/GWToolboxdll/Windows/SkillListingWindow.cpp
+++ b/GWToolboxdll/Windows/SkillListingWindow.cpp
@@ -195,26 +195,26 @@ void SkillListingWindow::Draw(IDirect3DDevice9*)
             continue;
         }
         ImGui::SameLine(offset += tiny_text_width);
-        const auto low_res_img = skills[i]->skill->icon_file_id ? GwDatTextureModule::LoadTextureFromFileId(skills[i]->skill->icon_file_id) : nullptr;
-        const auto hi_res_img = skills[i]->skill->icon_file_id_2 ? GwDatTextureModule::LoadTextureFromFileId(skills[i]->skill->icon_file_id_2) : nullptr;
-        const auto to_use = low_res_img ? low_res_img : hi_res_img;
-        if (to_use) 
-            ImGui::ImageCropped(to_use ? *to_use : nullptr, {20.f, 20.f});
+        auto low_res_img = skills[i]->skill->icon_file_id ? GwDatTextureModule::LoadTextureFromFileId(skills[i]->skill->icon_file_id) : Resources::Texture{};
+        auto hi_res_img = skills[i]->skill->icon_file_id_2 ? GwDatTextureModule::LoadTextureFromFileId(skills[i]->skill->icon_file_id_2) : Resources::Texture{};
+        const auto& to_use = low_res_img ? low_res_img : hi_res_img;
+        if (to_use)
+            ImGui::ImageCropped(to_use.Get(), {20.f, 20.f});
         /*
-        if (low_res_img && *low_res_img) {
+        if (low_res_img && low_res_img.Get()) {
             const auto filename = std::format("{}_lowres.jpg", (uint32_t)skills[i]->skill->skill_id);
             const auto write_to = Resources::GetPath("skill_images", filename);
             if (!std::filesystem::exists(write_to)) {
                 Resources::EnsureFolderExists(Resources::GetPath("skill_images"));
-                Resources::SaveTextureToFile(*low_res_img, write_to);
+                Resources::SaveTextureToFile(low_res_img.Get(), write_to);
             }
         }
-        if (hi_res_img && *hi_res_img) {
+        if (hi_res_img && hi_res_img.Get()) {
             const auto filename = std::format("{}_hires.jpg", (uint32_t)skills[i]->skill->skill_id);
             const auto write_to = Resources::GetPath("skill_images", filename);
             if (!std::filesystem::exists(write_to)) {
                 Resources::EnsureFolderExists(Resources::GetPath("skill_images"));
-                Resources::SaveTextureToFile(*hi_res_img, write_to);
+                Resources::SaveTextureToFile(hi_res_img.Get(), write_to);
             }
         }
         */

--- a/GWToolboxdll/Windows/TargetInfoWindow.cpp
+++ b/GWToolboxdll/Windows/TargetInfoWindow.cpp
@@ -62,7 +62,7 @@ namespace {
     struct AgentInfo {
         GuiUtils::EncString name;
         std::string image_url;
-        IDirect3DTexture9** image = nullptr;
+        Resources::Texture image;
         std::string wiki_content;
         std::string wiki_search_term;
         std::vector<GW::Constants::SkillID> wiki_skills;
@@ -407,7 +407,7 @@ void TargetInfoWindow::Draw(IDirect3DDevice9*)
         ImGui::TextUnformatted("Target info pending...");
         return ImGui::End();
     }
-    const auto has_image = current_agent_info->image;
+    const auto has_image = static_cast<bool>(current_agent_info->image);
     if (ImGui::BeginTable("table1", has_image ? 2 : 1)) {
         ImGui::TableSetupColumn("col0", ImGuiTableColumnFlags_WidthStretch, 1.0f);
         if (has_image)
@@ -415,7 +415,7 @@ void TargetInfoWindow::Draw(IDirect3DDevice9*)
         ImGui::TableNextRow();
         if (has_image) {
             ImGui::TableNextColumn();
-            ImGui::ImageFit(*current_agent_info->image, ImGui::GetContentRegionAvail());
+            ImGui::ImageFit(current_agent_info->image.Get(), ImGui::GetContentRegionAvail());
         }
         ImGui::TableNextColumn();
         ImGui::PushFont(FontLoader::GetFont(), static_cast<float>(FontLoader::FontSize::header2));
@@ -436,8 +436,8 @@ void TargetInfoWindow::Draw(IDirect3DDevice9*)
                 const float btnw = ImGui::GetContentRegionAvail().x;
                 const ImVec2 btn_dims = {btnw, .0f};
                 const auto skill = GW::SkillbarMgr::GetSkillConstantData(skill_id);
-                const auto skill_img = Resources::GetSkillImage(skill_id);
-                if (ImGui::IconButton(Resources::DecodeStringId(skill->name)->string().c_str(), *skill_img, btn_dims)) {
+                const auto& skill_img = Resources::GetSkillImage(skill_id);
+                if (ImGui::IconButton(Resources::DecodeStringId(skill->name)->string().c_str(), skill_img.Get(), btn_dims)) {
                     wchar_t url_buf[64];
                     swprintf(url_buf, _countof(url_buf), L"Game_link:Skill_%d", skill_id);
                     GuiUtils::OpenWiki(url_buf);
@@ -455,8 +455,8 @@ void TargetInfoWindow::Draw(IDirect3DDevice9*)
                 const float btnw = ImGui::GetContentRegionAvail().x;
                 const ImVec2 btn_dims = {btnw, .0f};
                 const auto skill = GW::SkillbarMgr::GetSkillConstantData(skill_id);
-                const auto skill_img = Resources::GetSkillImage(skill_id);
-                if (ImGui::IconButton(Resources::DecodeStringId(skill->name)->string().c_str(), *skill_img, btn_dims)) {
+                const auto& skill_img = Resources::GetSkillImage(skill_id);
+                if (ImGui::IconButton(Resources::DecodeStringId(skill->name)->string().c_str(), skill_img.Get(), btn_dims)) {
                     wchar_t url_buf[64];
                     swprintf(url_buf, _countof(url_buf), L"Game_link:Skill_%d", skill_id);
                     GuiUtils::OpenWiki(url_buf);
@@ -482,9 +482,9 @@ void TargetInfoWindow::Draw(IDirect3DDevice9*)
                 };
                 ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, {0.f, .5f});
                 const auto label = std::format("{}: {}", damage_type, armour_rating);
-                if (const auto dmgtype_img = Resources::GetDamagetypeImage(damage_type)) {
+                if (const auto& dmgtype_img = Resources::GetDamagetypeImage(damage_type)) {
                     ImGui::PushID(damage_type.c_str());
-                    if (ImGui::IconButton(label.c_str(), *dmgtype_img, btn_dims)) {
+                    if (ImGui::IconButton(label.c_str(), dmgtype_img.Get(), btn_dims)) {
                         open_wiki();
                     }
                     ImGui::PopID();
@@ -508,8 +508,8 @@ void TargetInfoWindow::Draw(IDirect3DDevice9*)
                 const float btnw = ImGui::GetContentRegionAvail().x;
                 const ImVec2 btn_dims = {btnw, .0f};
                 const auto item_name_ws = TextUtils::StringToWString(item_name);
-                const auto item_image = Resources::GetItemImage(item_name_ws);
-                if (ImGui::IconButton(item_name.c_str(), *item_image, btn_dims)) {
+                const auto& item_image = Resources::GetItemImage(item_name_ws);
+                if (ImGui::IconButton(item_name.c_str(), item_image.Get(), btn_dims)) {
                     GuiUtils::SearchWiki(item_name_ws.c_str());
                 }
             }

--- a/GWToolboxdll/Windows/TravelWindow.cpp
+++ b/GWToolboxdll/Windows/TravelWindow.cpp
@@ -214,7 +214,7 @@ namespace {
 
     bool to_minimize = false;
 
-    IDirect3DTexture9** scroll_texture = nullptr;
+    Resources::Texture scroll_texture;
 
     /* Not used, but good to keep for reference!
     enum error_message_ids {
@@ -644,7 +644,7 @@ void TravelWindow::TravelButton(const GW::Constants::MapID mapid, const int x_id
     switch (mapid) {
         case GW::Constants::MapID::The_Deep:
         case GW::Constants::MapID::Urgozs_Warren:
-            clicked |= ImGui::IconButton(text, *scroll_texture, ImVec2(w, 0));
+            clicked |= ImGui::IconButton(text, scroll_texture.Get(), ImVec2(w, 0));
             break;
         default:
             clicked |= ImGui::Button(text, ImVec2(w, 0));


### PR DESCRIPTION
D3D textures were managed with raw IDirect3DTexture9** pointers and manual Release() calls, causing multiple leaks:
- GwDatTextureModule never released textures on delete
- profession_icons and damagetype_icons were missing from Cleanup()
- HeroUnlock called delete on a COM pointer instead of Release
- GameWorldRenderer leaked shaders on error paths
- GWW textures accumulated until module termination

Introduce TBComPtr<T> for COM pointer RAII (Attach/Reset/Get, copy with AddRef, move transfers ownership). Replace the mutable-slot async pattern (LoadTexture writes into a T** that callers poll) with shared_future: LoadTexture creates a promise, enqueues a DX task that resolves it, and returns a Texture (wrapping shared_future<TBComPtr>). Callers store Texture by value and call .Get() for the raw pointer.

All Get* functions return Texture by value. The disk cache handles deduplication for wiki images. No in-memory dedup map, no shared_ptr indirection, no raw pointer storage at callsites.