### PR TITLE
More EncString clean-up

### DIFF
--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -284,7 +284,7 @@ namespace {
         {
             const auto title_info = GW::PlayerMgr::GetTitleData(title);
             if (title_info)
-                name.reset(title_info->name_id);
+                name = GuiUtils::EncString(title_info->name_id);
         };
         GW::Constants::TitleID title;
         GuiUtils::EncString name;
@@ -592,8 +592,7 @@ namespace {
 
     std::unique_ptr<GuiUtils::EncString> MakePrefLabel(uint32_t enc_string_id)
     {
-        auto label = std::make_unique<GuiUtils::EncString>(enc_string_id, false);
-        label->language(GW::Constants::Language::English);
+        auto label = std::make_unique<GuiUtils::EncString>(enc_string_id, false, GW::Constants::Language::English);
         label->SetSanitiseCallback([](std::wstring s) {
             return TextUtils::RemovePunctuation(TextUtils::RemoveDiacritics(TextUtils::ToSlug(s)));
         });
@@ -602,8 +601,7 @@ namespace {
 
     std::unique_ptr<GuiUtils::EncString> MakePrefLabel(const wchar_t* enc_string)
     {
-        auto label = std::make_unique<GuiUtils::EncString>(enc_string, false);
-        label->language(GW::Constants::Language::English);
+        auto label = std::make_unique<GuiUtils::EncString>(enc_string, false, GW::Constants::Language::English);
         label->SetSanitiseCallback([](std::wstring s) {
             return TextUtils::RemovePunctuation(TextUtils::RemoveDiacritics(TextUtils::ToSlug(s)));
         });
@@ -2053,8 +2051,8 @@ void ChatCommands::QuestPing::Init()
     const auto* quest = GW::QuestMgr::GetActiveQuest();
     if (quest) {
         quest_id = quest->quest_id;
-        name.reset(quest->name);
-        objectives.reset(quest->objectives);
+        name = GuiUtils::EncString(quest->name);
+        objectives = GuiUtils::EncString(quest->objectives);
     }
 }
 
@@ -2073,13 +2071,13 @@ void ChatCommands::QuestPing::Update()
             swprintf(print_buf, _countof(print_buf), L" - %s", m.get<1>().to_string().c_str());
             GW::Chat::SendChat('#', print_buf);
         }
-        objectives.reset(nullptr);
+        objectives = GuiUtils::EncString();
     }
     if (!name.wstring().empty()) {
         wchar_t url_buf[64];
         swprintf(url_buf, _countof(url_buf), L"%SGame_link:Quest_%d", GuiUtils::WikiUrl(L"").c_str(), quest_id);
         GW::Chat::SendChat('#', url_buf);
-        name.reset(nullptr);
+        name = GuiUtils::EncString();
     }
 }
 

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -667,7 +667,7 @@ namespace {
             pref_map.emplace_back(GW::UI::FlagPreference::AlwaysShowAllyNames, L"\x108\x107Show Ally Names\x1");
             pref_map.emplace_back(GW::UI::FlagPreference::EnableGamepad, L"\x108\x107" "Enable Gamepad\x1");
             for (const auto& it : pref_map) {
-                it.label->wstring();
+                it.label->StartDecode();
             }
         }
         return pref_map;
@@ -2024,7 +2024,7 @@ void ChatCommands::Update(const float delta)
             }
             auto dtn = new DecodedTitleName(static_cast<GW::Constants::TitleID>(i));
             title_names.push_back(dtn);
-            dtn->name.string(); // Trigger decode for sorting.
+            dtn->name.StartDecode();
         }
     }
     else if (!title_names_sorted) {

--- a/GWToolboxdll/Modules/DialogModule.cpp
+++ b/GWToolboxdll/Modules/DialogModule.cpp
@@ -80,7 +80,7 @@ namespace {
         dialog_buttons.clear();
         dialog_button_messages.clear();
 
-        dialog_body.reset(nullptr);
+        dialog_body = GuiUtils::EncString();
         dialog_info = {};
     }
 
@@ -159,7 +159,7 @@ void DialogModule::OnPostUIMessage(const GW::HookStatus* status, const GW::UI::U
                 return; // Dialog closed.
             }
             dialog_info = *new_dialog_info;
-            dialog_body.reset(dialog_info.message_enc);
+            dialog_body = GuiUtils::EncString(dialog_info.message_enc);
             dialog_info.message_enc = (wchar_t*)dialog_body.encoded().data();
             GW::UI::AsyncDecodeStr(dialog_info.message_enc, OnDialogBodyDecoded);
         }

--- a/GWToolboxdll/Modules/DiscordModule.cpp
+++ b/GWToolboxdll/Modules/DiscordModule.cpp
@@ -632,7 +632,7 @@ namespace {
 
             if (show_location_info) {
                 // Details
-                map_name_decoded.reset(m->name_id);
+                map_name_decoded = GuiUtils::EncString(m->name_id, true, GW::Constants::Language::English);
                 if (map_name_decoded.wstring().empty()) {
                     return; // Map name not decoded yet.
                 }
@@ -731,8 +731,6 @@ void DiscordModule::Initialize()
     activities_events.on_activity_join = OnJoinParty;           // Need to join party
     params.network_events = &network_events;
     network_events.on_message = OnNetworkMessage;
-
-    map_name_decoded.language(GW::Constants::Language::English);
 
     const GW::UI::UIMessage ui_messages[] = {GW::UI::UIMessage::kMapLoaded,           GW::UI::UIMessage::kPartyAddPlayer, GW::UI::UIMessage::kPartyRemovePlayer, GW::UI::UIMessage::kPartyAddHenchman,
                                              GW::UI::UIMessage::kPartyRemoveHenchman, GW::UI::UIMessage::kPartyAddHero,   GW::UI::UIMessage::kPartyRemoveHero};

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -2904,14 +2904,13 @@ bool PendingItem::set(const InventoryManager::Item* item)
     quantity = item->quantity;
     uses = item->GetUses();
     bag = item->bag ? item->bag->bag_id() : GW::Constants::Bag::None;
-    name->reset(item->complete_name_enc ? item->complete_name_enc : item->name_enc);
-    single_item_name->reset(item->single_item_name);
+    *name = GuiUtils::EncString(item->complete_name_enc ? item->complete_name_enc : item->name_enc);
+    *single_item_name = GuiUtils::EncString(item->single_item_name);
     // NB: This doesn't work for inscriptions; gww doesn't have a page per inscription.
-    wiki_name->reset(ItemDescriptionHandler::GetItemEncNameWithoutMods(item).c_str());
-    wiki_name->language(GW::Constants::Language::English);
+    *wiki_name = GuiUtils::EncString(ItemDescriptionHandler::GetItemEncNameWithoutMods(item).c_str(), true, GW::Constants::Language::English);
     const auto plural_item_enc = std::format(L"\xa35\x101\x100\x10a{}\x1", item->name_enc);
-    plural_item_name->reset(plural_item_enc.c_str());
-    desc->reset(ItemDescriptionHandler::GetItemDescription(item).c_str());
+    *plural_item_name = GuiUtils::EncString(plural_item_enc.c_str());
+    *desc = GuiUtils::EncString(ItemDescriptionHandler::GetItemDescription(item).c_str());
     return true;
 }
 

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -2237,7 +2237,7 @@ void InventoryManager::Draw(IDirect3DDevice9*)
                     ImGui::SetTooltip("%s", pi->desc->string().c_str());
                 }
                 ImGui::SameLine(longest_item_name_length + wiki_btn_width);
-                pi->wiki_name->wstring();
+                pi->wiki_name->StartDecode();
                 if (ImGui::Button("Wiki", ImVec2(wiki_btn_width, 0))) {
                     GuiUtils::SearchWiki(pi->wiki_name->wstring());
                 }
@@ -2482,7 +2482,7 @@ bool InventoryManager::DrawItemContextMenu(const bool open)
     }
 
 
-    context_item.wiki_name->wstring();
+    context_item.wiki_name->StartDecode();
     if (wiki_link_on_context_menu && ImGui::Button("Guild Wars Wiki", size)) {
         ImGui::CloseCurrentPopup();
         GuiUtils::SearchWiki(context_item.wiki_name->wstring());
@@ -2506,7 +2506,7 @@ bool InventoryManager::DrawItemContextMenu(const bool open)
         }
     }
     if (context_item_actual->name_enc && *context_item_actual->name_enc && context_item_actual->IsSalvagable(true,false)) {
-        context_item.single_item_name->string(); // Pre-decode
+        context_item.single_item_name->StartDecode();
         const auto identifier = context_item_actual->name_enc;
         bool flagged = block_from_being_salvaged.contains(identifier);
         if (ImGui::Button(!flagged ? "Hide this when salvaging" : "Show this when salvaging", size)) {
@@ -2522,7 +2522,7 @@ bool InventoryManager::DrawItemContextMenu(const bool open)
         }
     }
     if (context_item_actual->model_id && context_item_actual->value) {
-        context_item.single_item_name->string(); // Pre-decode
+        context_item.single_item_name->StartDecode();
         const auto identifier = context_item_actual->model_id;
         bool flagged = hide_from_merchant_items.contains(identifier);
         if (ImGui::Button(!flagged ? "Hide this when selling" : "Show this when selling", size)) {

--- a/GWToolboxdll/Modules/ItemDrops.cpp
+++ b/GWToolboxdll/Modules/ItemDrops.cpp
@@ -88,8 +88,7 @@ namespace {
     GuiUtils::EncString* GetItemName(const wchar_t* enc_string) {
         if (!enc_string) return nullptr;
         if (!cached_item_names.contains(enc_string)) {
-            auto enc_str = std::make_unique<GuiUtils::EncString>(enc_string);
-            enc_str->language(GW::Constants::Language::English);
+            auto enc_str = std::make_unique<GuiUtils::EncString>(enc_string, true, GW::Constants::Language::English);
             cached_item_names[enc_string] = std::move(enc_str);
         }
         return cached_item_names[enc_string].get();

--- a/GWToolboxdll/Modules/ItemDrops.cpp
+++ b/GWToolboxdll/Modules/ItemDrops.cpp
@@ -742,7 +742,7 @@ ItemDrops::PendingDrop::PendingDrop(GW::Item* _item)
     value = item->value;
     map_id = GW::Map::GetMapID();
     icon = Resources::GetItemImage(item);
-    Resources::GetMapName(map_id)->wstring();
+    Resources::GetMapName(map_id)->StartDecode();
 
     const wchar_t* item_name_pt = L"\x101";
     if (item->single_item_name && *item->single_item_name) {
@@ -756,7 +756,7 @@ ItemDrops::PendingDrop::PendingDrop(GW::Item* _item)
     item_name_enc = new wchar_t[len + 1];
     wcscpy(item_name_enc, item_name_pt);
 
-    ::GetItemName(item_name_enc)->wstring(); // Trigger decode.
+    ::GetItemName(item_name_enc)->StartDecode();
 
     time(&system_time);
 

--- a/GWToolboxdll/Unused/FavorTrackerModule.cpp
+++ b/GWToolboxdll/Unused/FavorTrackerModule.cpp
@@ -69,19 +69,18 @@ namespace {
         if (is_active && !was_active && play_sound_on_favor && favor_sound_file_id && TIMER_DIFF(initialised_at) > 3000) {
             AudioSettings::PlaySoundFileId(favor_sound_file_id);
         }
-        favor_enc_str.language(GW::UI::GetTextLanguage());
         if (favor_minutes_remaining > 0) {
             wchar_t buf[3];
             ASSERT(GW::UI::UInt32ToEncStr(favor_minutes_remaining, buf, _countof(buf)));
-            favor_enc_str.reset(std::format(L"\x8102\x223f\x101{}", buf).c_str(), false);
+            favor_enc_str = GuiUtils::EncString(std::format(L"\x8102\x223f\x101{}", buf).c_str(), false, GW::UI::GetTextLanguage());
         }
         else if (achievements_needed_for_favor > 0) {
             wchar_t buf[3];
             ASSERT(GW::UI::UInt32ToEncStr(achievements_needed_for_favor, buf, _countof(buf)));
-            favor_enc_str.reset(std::format(L"\x8102\x2240\x101{}", buf).c_str(),false);
+            favor_enc_str = GuiUtils::EncString(std::format(L"\x8102\x2240\x101{}", buf).c_str(), false, GW::UI::GetTextLanguage());
         }
         else {
-            favor_enc_str.reset(L"\x101", false);
+            favor_enc_str = GuiUtils::EncString(L"\x101", false, GW::UI::GetTextLanguage());
         }
     }
 

--- a/GWToolboxdll/Unused/InventoryOverlayWidget.cpp
+++ b/GWToolboxdll/Unused/InventoryOverlayWidget.cpp
@@ -106,7 +106,7 @@ void InventoryOverlayWidget::Draw(IDirect3DDevice9*)
             const ImVec2 text_pos = { top_left.x + x_offset, top_left.y };
             ImGui::GetBackgroundDrawList()->AddText(text_pos, text_color, item_id_str.c_str());
             if (ImGui::IsMouseHoveringRect(top_left, bottom_right, false)) {
-                info->name.reset(item->name_enc);
+                info->name = GuiUtils::EncString(item->name_enc);
                 ImGui::SetTooltip("%s", info->name.string().c_str());
             }
         }

--- a/GWToolboxdll/Utils/EncString.cpp
+++ b/GWToolboxdll/Utils/EncString.cpp
@@ -4,6 +4,7 @@
 #include <GWCA/Managers/UIMgr.h>
 #include <GWCA/Managers/GameThreadMgr.h>
 
+#include <Defines.h>
 #include <Utils/EncString.h>
 #include <Utils/TextUtils.h>
 
@@ -17,63 +18,58 @@ void EncString::AbandonDecode()
     }
 }
 
-EncString* EncString::reset(const uint32_t enc_string_id, const bool sanitise)
+EncString::EncString(const uint32_t enc_string_id, const bool sanitise, const GW::Constants::Language language)
+    : should_sanitise(sanitise), language_id(language)
 {
-    if (enc_string_id && encoded_ws.length()) {
-        const uint32_t this_id = GW::UI::EncStrToUInt32(encoded_ws.c_str());
-        if (this_id == enc_string_id) {
-            return this;
-        }
-    }
-    reset(nullptr, sanitise);
     if (enc_string_id) {
         wchar_t out[8] = {0};
-        if (!GW::UI::UInt32ToEncStr(enc_string_id, out, _countof(out))) {
-            return this;
-        }
-        encoded_ws = out;
+        if (GW::UI::UInt32ToEncStr(enc_string_id, out, _countof(out)))
+            encoded_ws = out;
     }
-    return this;
 }
 
-EncString* EncString::language(const GW::Constants::Language l)
+EncString::EncString(EncString&& other) noexcept
+    : encoded_ws(std::move(other.encoded_ws))
+    , decoded_ws(std::move(other.decoded_ws))
+    , decoded_s(std::move(other.decoded_s))
+    , decoded(other.decoded)
+    , should_sanitise(other.should_sanitise)
+    , sanitise_cb(std::move(other.sanitise_cb))
+    , language_id(other.language_id)
+    , pending_ctx_(other.pending_ctx_)
 {
-    if (language_id == l) {
-        return this;
-    }
-    AbandonDecode();
-    language_id = l;
-    decoded_ws.clear();
-    decoded_s.clear();
-    decoded = false;
-    return this;
+    if (pending_ctx_) pending_ctx_->owner = this;
+    other.pending_ctx_ = nullptr;
+    other.decoded = false;
 }
 
-EncString* EncString::reset(const wchar_t* enc_string, const bool sanitise)
+EncString& EncString::operator=(EncString&& other) noexcept
 {
-    if (enc_string && wcscmp(enc_string, encoded_ws.c_str()) == 0) {
-        return this;
+    if (this != &other) {
+        AbandonDecode();
+        encoded_ws = std::move(other.encoded_ws);
+        decoded_ws = std::move(other.decoded_ws);
+        decoded_s = std::move(other.decoded_s);
+        decoded = other.decoded;
+        should_sanitise = other.should_sanitise;
+        sanitise_cb = std::move(other.sanitise_cb);
+        language_id = other.language_id;
+        pending_ctx_ = other.pending_ctx_;
+        if (pending_ctx_) pending_ctx_->owner = this;
+        other.pending_ctx_ = nullptr;
+        other.decoded = false;
     }
-    AbandonDecode();
-    encoded_ws.clear();
-    decoded_ws.clear();
-    decoded_s.clear();
-    decoded = false;
-    should_sanitise = sanitise;
-    if (enc_string) {
-        encoded_ws = enc_string;
-    }
-    return this;
+    return *this;
 }
 
-void EncString::decode() const
+void EncString::StartDecode() const
 {
     if (!decoded && !pending_ctx_ && !encoded_ws.empty()) {
-        pending_ctx_ = new DecodeContext{const_cast<EncString*>(this)};
+        pending_ctx_ = new DecodeContext{const_cast<EncString*>(this), encoded_ws};
         auto* ctx = pending_ctx_;
         GW::GameThread::Enqueue([ctx] {
             if (ctx->owner) {
-                GW::UI::AsyncDecodeStr(ctx->owner->encoded_ws.c_str(), OnStringDecoded, ctx, ctx->owner->language_id);
+                GW::UI::AsyncDecodeStr(ctx->encoded_copy.c_str(), OnStringDecoded, ctx, ctx->owner->language_id);
             } else {
                 delete ctx;
             }
@@ -83,7 +79,7 @@ void EncString::decode() const
 
 const std::wstring& EncString::wstring() const
 {
-    decode();
+    StartDecode();
     return decoded_ws;
 }
 
@@ -118,7 +114,7 @@ void EncString::OnStringDecoded(void* param, const wchar_t* decoded)
 
 const std::string& EncString::string() const
 {
-    decode();
+    StartDecode();
     if (decoded && !decoded_ws.empty() && decoded_s.empty()) {
         decoded_s = TextUtils::WStringToString(decoded_ws);
     }

--- a/GWToolboxdll/Utils/EncString.cpp
+++ b/GWToolboxdll/Utils/EncString.cpp
@@ -15,7 +15,6 @@ void EncString::AbandonDecode()
         pending_ctx_->owner = nullptr;
         pending_ctx_ = nullptr;
     }
-    decoding = false;
 }
 
 EncString* EncString::reset(const uint32_t enc_string_id, const bool sanitise)
@@ -60,7 +59,7 @@ EncString* EncString::reset(const wchar_t* enc_string, const bool sanitise)
     decoded_ws.clear();
     decoded_s.clear();
     decoded = false;
-    sanitised = !sanitise;
+    should_sanitise = sanitise;
     if (enc_string) {
         encoded_ws = enc_string;
     }
@@ -69,8 +68,7 @@ EncString* EncString::reset(const wchar_t* enc_string, const bool sanitise)
 
 void EncString::decode() const
 {
-    if (!decoded && !decoding && !encoded_ws.empty()) {
-        decoding = true;
+    if (!decoded && !pending_ctx_ && !encoded_ws.empty()) {
         pending_ctx_ = new DecodeContext{const_cast<EncString*>(this)};
         auto* ctx = pending_ctx_;
         GW::GameThread::Enqueue([ctx] {
@@ -86,20 +84,7 @@ void EncString::decode() const
 const std::wstring& EncString::wstring() const
 {
     decode();
-    sanitise();
     return decoded_ws;
-}
-
-void EncString::sanitise() const
-{
-    if (!sanitised && !decoded_ws.empty()) {
-        sanitised = true;
-        if (sanitise_cb) {
-            decoded_ws = sanitise_cb(std::move(decoded_ws));
-        } else {
-            decoded_ws = TextUtils::StripTags(TextUtils::Replace(decoded_ws, L"<brx>", L"\n"));
-        }
-    }
 }
 
 EncString::~EncString()
@@ -117,18 +102,24 @@ void EncString::OnStringDecoded(void* param, const wchar_t* decoded)
     auto* self = ctx->owner;
     self->pending_ctx_ = nullptr;
     if (decoded && decoded[0]) {
-        self->decoded_ws = decoded;
+        if (self->should_sanitise) {
+            if (self->sanitise_cb) {
+                self->decoded_ws = self->sanitise_cb(decoded);
+            } else {
+                self->decoded_ws = TextUtils::StripTags(TextUtils::Replace(decoded, L"<brx>", L"\n"));
+            }
+        } else {
+            self->decoded_ws = decoded;
+        }
     }
     self->decoded = true;
-    self->decoding = false;
     delete ctx;
 }
 
 const std::string& EncString::string() const
 {
     decode();
-    sanitise();
-    if (sanitised && !decoded_ws.empty() && decoded_s.empty()) {
+    if (decoded && !decoded_ws.empty() && decoded_s.empty()) {
         decoded_s = TextUtils::WStringToString(decoded_ws);
     }
     return decoded_s;

--- a/GWToolboxdll/Utils/EncString.cpp
+++ b/GWToolboxdll/Utils/EncString.cpp
@@ -67,11 +67,11 @@ EncString* EncString::reset(const wchar_t* enc_string, const bool sanitise)
     return this;
 }
 
-void EncString::decode()
+void EncString::decode() const
 {
     if (!decoded && !decoding && !encoded_ws.empty()) {
         decoding = true;
-        pending_ctx_ = new DecodeContext{this};
+        pending_ctx_ = new DecodeContext{const_cast<EncString*>(this)};
         auto* ctx = pending_ctx_;
         GW::GameThread::Enqueue([ctx] {
             if (ctx->owner) {
@@ -83,14 +83,14 @@ void EncString::decode()
     }
 }
 
-std::wstring& EncString::wstring()
+const std::wstring& EncString::wstring() const
 {
     decode();
     sanitise();
     return decoded_ws;
 }
 
-void EncString::sanitise()
+void EncString::sanitise() const
 {
     if (!sanitised && !decoded_ws.empty()) {
         sanitised = true;
@@ -124,9 +124,10 @@ void EncString::OnStringDecoded(void* param, const wchar_t* decoded)
     delete ctx;
 }
 
-std::string& EncString::string()
+const std::string& EncString::string() const
 {
-    wstring();
+    decode();
+    sanitise();
     if (sanitised && !decoded_ws.empty() && decoded_s.empty()) {
         decoded_s = TextUtils::WStringToString(decoded_ws);
     }

--- a/GWToolboxdll/Utils/EncString.h
+++ b/GWToolboxdll/Utils/EncString.h
@@ -15,11 +15,9 @@ namespace GuiUtils {
         std::wstring encoded_ws;
         mutable std::wstring decoded_ws;
         mutable std::string decoded_s;
-        mutable bool decoding = false;
         mutable bool decoded = false;
-        mutable bool sanitised = false;
+        bool should_sanitise = true;
         SanitiseCallback sanitise_cb;
-        void sanitise() const;
         void decode() const;
         GW::Constants::Language language_id = static_cast<GW::Constants::Language>(0xff);
         static void OnStringDecoded(void* param, const wchar_t* decoded);
@@ -28,14 +26,9 @@ namespace GuiUtils {
         void AbandonDecode();
 
     public:
-        // Set the language for decoding this encoded string. If the language has changed, resets the decoded result. Returns this for chaining.
         EncString* language(GW::Constants::Language l);
-        [[nodiscard]] bool IsDecoding() const { return decoding && decoded_ws.empty(); };
-        // Recycle this EncString by passing a new encoded string id to decode.
-        // Set sanitise to true to automatically remove guild tags etc from the string
+        [[nodiscard]] bool IsDecoding() const { return pending_ctx_ && decoded_ws.empty(); };
         EncString* reset(uint32_t enc_string_id = 0, bool sanitise = true);
-        // Recycle this EncString by passing a new string to decode.
-        // Set sanitise to true to automatically remove guild tags etc from the string
         EncString* reset(const wchar_t* enc_string = nullptr, bool sanitise = true);
         [[nodiscard]] const std::wstring& wstring() const;
         [[nodiscard]] const std::string& string() const;

--- a/GWToolboxdll/Utils/EncString.h
+++ b/GWToolboxdll/Utils/EncString.h
@@ -13,32 +13,35 @@ namespace GuiUtils {
         };
 
         std::wstring encoded_ws;
-        std::wstring decoded_ws;
-        std::string decoded_s;
-        bool decoding = false;
-        bool decoded = false;
-        bool sanitised = false;
+        mutable std::wstring decoded_ws;
+        mutable std::string decoded_s;
+        mutable bool decoding = false;
+        mutable bool decoded = false;
+        mutable bool sanitised = false;
         SanitiseCallback sanitise_cb;
-        void sanitise();
-        void decode();
+        void sanitise() const;
+        void decode() const;
         GW::Constants::Language language_id = static_cast<GW::Constants::Language>(0xff);
         static void OnStringDecoded(void* param, const wchar_t* decoded);
 
-        DecodeContext* pending_ctx_ = nullptr;
+        mutable DecodeContext* pending_ctx_ = nullptr;
         void AbandonDecode();
 
     public:
         // Set the language for decoding this encoded string. If the language has changed, resets the decoded result. Returns this for chaining.
         EncString* language(GW::Constants::Language l);
-        bool IsDecoding() const { return decoding && decoded_ws.empty(); };
+        [[nodiscard]] bool IsDecoding() const { return decoding && decoded_ws.empty(); };
         // Recycle this EncString by passing a new encoded string id to decode.
         // Set sanitise to true to automatically remove guild tags etc from the string
         EncString* reset(uint32_t enc_string_id = 0, bool sanitise = true);
         // Recycle this EncString by passing a new string to decode.
         // Set sanitise to true to automatically remove guild tags etc from the string
         EncString* reset(const wchar_t* enc_string = nullptr, bool sanitise = true);
-        std::wstring& wstring();
-        std::string& string();
+        [[nodiscard]] const std::wstring& wstring() const;
+        [[nodiscard]] const std::string& string() const;
+
+        // Kick off async decode without waiting for the result.
+        void StartDecode() const { decode(); }
 
         // Set a custom sanitise callback. Replaces the default tag-stripping.
         void SetSanitiseCallback(SanitiseCallback cb) { sanitise_cb = std::move(cb); }

--- a/GWToolboxdll/Utils/EncString.h
+++ b/GWToolboxdll/Utils/EncString.h
@@ -7,9 +7,14 @@ namespace GW::Constants {
 namespace GuiUtils {
     using SanitiseCallback = std::function<std::wstring(std::wstring)>;
 
+    // Thread safety: EncString relies on all construction, destruction, and
+    // decode callbacks running on the game thread. The DecodeContext poisons
+    // the owner pointer on destruction so a late callback is a harmless no-op,
+    // but there is no mutex — concurrent access from other threads is unsafe.
     class EncString final {
         struct DecodeContext {
             EncString* owner;
+            std::wstring encoded_copy;
         };
 
         std::wstring encoded_ws;
@@ -18,7 +23,6 @@ namespace GuiUtils {
         mutable bool decoded = false;
         bool should_sanitise = true;
         SanitiseCallback sanitise_cb;
-        void decode() const;
         GW::Constants::Language language_id = static_cast<GW::Constants::Language>(0xff);
         static void OnStringDecoded(void* param, const wchar_t* decoded);
 
@@ -26,15 +30,11 @@ namespace GuiUtils {
         void AbandonDecode();
 
     public:
-        EncString* language(GW::Constants::Language l);
         [[nodiscard]] bool IsDecoding() const { return pending_ctx_ && decoded_ws.empty(); };
-        EncString* reset(uint32_t enc_string_id = 0, bool sanitise = true);
-        EncString* reset(const wchar_t* enc_string = nullptr, bool sanitise = true);
         [[nodiscard]] const std::wstring& wstring() const;
         [[nodiscard]] const std::string& string() const;
 
-        // Kick off async decode without waiting for the result.
-        void StartDecode() const { decode(); }
+        void StartDecode() const;
 
         // Set a custom sanitise callback. Replaces the default tag-stripping.
         void SetSanitiseCallback(SanitiseCallback cb) { sanitise_cb = std::move(cb); }
@@ -44,18 +44,22 @@ namespace GuiUtils {
             return encoded_ws;
         };
 
-        EncString(const wchar_t* enc_string = nullptr, const bool sanitise = true)
+        EncString() = default;
+
+        explicit EncString(const wchar_t* enc_string, bool sanitise = true,
+            GW::Constants::Language language = static_cast<GW::Constants::Language>(0xff))
+            : should_sanitise(sanitise), language_id(language)
         {
-            reset(enc_string, sanitise);
+            if (enc_string) encoded_ws = enc_string;
         }
 
-        EncString(const uint32_t enc_string, const bool sanitise = true)
-        {
-            reset(enc_string, sanitise);
-        }
+        explicit EncString(uint32_t enc_string_id, bool sanitise = true,
+            GW::Constants::Language language = static_cast<GW::Constants::Language>(0xff));
 
         EncString(const EncString&) = delete;
         EncString& operator=(const EncString&) = delete;
+        EncString(EncString&& other) noexcept;
+        EncString& operator=(EncString&& other) noexcept;
         ~EncString();
     };
 }

--- a/GWToolboxdll/Widgets/ActiveQuestWidget.cpp
+++ b/GWToolboxdll/Widgets/ActiveQuestWidget.cpp
@@ -90,14 +90,14 @@ void ActiveQuestWidget::Update(float)
         active_quest_id = qid;
 
         if (const auto quest = GW::QuestMgr::GetQuest(qid)) {
-            active_quest_name.reset(quest->name);
+            active_quest_name = GuiUtils::EncString(quest->name);
             active_quest_objectives = QuestModule::ParseQuestObjectives(qid);
         }
         else if (static_cast<int32_t>(qid) == -1) {
             // Mission objectives
             const auto world_context = GW::GetWorldContext();
             const auto area_info = GW::Map::GetCurrentMapInfo();
-            active_quest_name.reset(area_info && area_info->name_id ? area_info->name_id : 3);
+            active_quest_name = GuiUtils::EncString(area_info && area_info->name_id ? area_info->name_id : 3);
 
             active_quest_objectives.clear();
 
@@ -116,7 +116,7 @@ void ActiveQuestWidget::Update(float)
             }
         }
         else {
-            active_quest_name.reset(1);
+            active_quest_name = GuiUtils::EncString(1);
             active_quest_objectives.clear();
         }
     }

--- a/GWToolboxdll/Widgets/BondsWidget.cpp
+++ b/GWToolboxdll/Widgets/BondsWidget.cpp
@@ -44,7 +44,7 @@ namespace {
         {
             // Because AvialableBond is used statically in toolbox, we need to explicitly call this function in the render loop - otherwise GetSkillConstantData won't be called at the right time.
             if (const auto skill = GW::SkillbarMgr::GetSkillConstantData(skill_id)) {
-                skill_name.reset(skill->name);
+                skill_name = GuiUtils::EncString(skill->name);
             }
         }
     };

--- a/GWToolboxdll/Widgets/FavorTracker.cpp
+++ b/GWToolboxdll/Widgets/FavorTracker.cpp
@@ -81,19 +81,18 @@ namespace {
         if (is_active && !was_active && play_sound_on_favor && favor_sound_file_id && TIMER_DIFF(initialised_at) > 3000) {
             AudioSettings::PlaySoundFileId(favor_sound_file_id);
         }
-        favor_enc_str.language(GW::UI::GetTextLanguage());
         if (favor_minutes_remaining > 0) {
             wchar_t buf[3];
             ASSERT(GW::UI::UInt32ToEncStr(favor_minutes_remaining, buf, _countof(buf)));
-            favor_enc_str.reset(std::format(L"\x8102\x223f\x101{}", buf).c_str(), false);
+            favor_enc_str = GuiUtils::EncString(std::format(L"\x8102\x223f\x101{}", buf).c_str(), false, GW::UI::GetTextLanguage());
         }
         else if (achievements_needed_for_favor > 0) {
             wchar_t buf[3];
             ASSERT(GW::UI::UInt32ToEncStr(achievements_needed_for_favor, buf, _countof(buf)));
-            favor_enc_str.reset(std::format(L"\x8102\x2240\x101{}", buf).c_str(), false);
+            favor_enc_str = GuiUtils::EncString(std::format(L"\x8102\x2240\x101{}", buf).c_str(), false, GW::UI::GetTextLanguage());
         }
         else {
-            favor_enc_str.reset(L"\x101", false);
+            favor_enc_str = GuiUtils::EncString(L"\x101", false, GW::UI::GetTextLanguage());
         }
     }
 

--- a/GWToolboxdll/Widgets/SnapsToPartyWindow.cpp
+++ b/GWToolboxdll/Widgets/SnapsToPartyWindow.cpp
@@ -120,8 +120,8 @@ bool SnapsToPartyWindow::FetchPartyInfo()
             party_names_by_index.push_back(std::make_unique<GuiUtils::EncString>());
         }
         auto* str = party_names_by_index[party_agent_ids_by_index.size() - 1].get();
-        str->reset(enc_name ? enc_name : GW::Agents::GetAgentEncName(agent_id))
-            ->wstring(); // Trigger decode
+        str->reset(enc_name ? enc_name : GW::Agents::GetAgentEncName(agent_id));
+        str->StartDecode();
         };
 
     for (const auto& player : info->players) {

--- a/GWToolboxdll/Widgets/SnapsToPartyWindow.cpp
+++ b/GWToolboxdll/Widgets/SnapsToPartyWindow.cpp
@@ -120,7 +120,7 @@ bool SnapsToPartyWindow::FetchPartyInfo()
             party_names_by_index.push_back(std::make_unique<GuiUtils::EncString>());
         }
         auto* str = party_names_by_index[party_agent_ids_by_index.size() - 1].get();
-        str->reset(enc_name ? enc_name : GW::Agents::GetAgentEncName(agent_id));
+        *str = GuiUtils::EncString(enc_name ? enc_name : GW::Agents::GetAgentEncName(agent_id));
         str->StartDecode();
         };
 

--- a/GWToolboxdll/Widgets/TitleTrackerWidget.cpp
+++ b/GWToolboxdll/Widgets/TitleTrackerWidget.cpp
@@ -293,7 +293,7 @@ namespace {
         if (!w) return;
         const auto title_data = GW::PlayerMgr::GetTitleData(title_id);
         if (title_data) {
-            title_label.reset(title_data->name_id);
+            title_label = GuiUtils::EncString(title_data->name_id);
 
         }
         const auto title_info = GW::PlayerMgr::GetTitleTrack(title_id);
@@ -301,7 +301,7 @@ namespace {
             return;
         }
         const auto& current_tier = w->title_tiers[title_info->current_title_tier_index];
-        tier_label.reset(current_tier.tier_name_enc);
+        tier_label = GuiUtils::EncString(current_tier.tier_name_enc);
     }
 
 

--- a/GWToolboxdll/Widgets/WorldMapWidget.cpp
+++ b/GWToolboxdll/Widgets/WorldMapWidget.cpp
@@ -258,7 +258,7 @@ namespace {
         const auto quest_id = static_cast<GW::Constants::QuestID>(reinterpret_cast<uint32_t>(wparam));
         const auto quest = GW::QuestMgr::GetQuest(quest_id);
         if (!quest) return false;
-        if (!hovered_quest_name.IsDecoding()) hovered_quest_name.reset(quest->name);
+        if (!hovered_quest_name.IsDecoding()) hovered_quest_name = GuiUtils::EncString(quest->name);
         ImGui::TextUnformatted(hovered_quest_name.string().c_str());
 
         ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0, 0));
@@ -1183,7 +1183,7 @@ void WorldMapWidget::Draw(IDirect3DDevice9*)
     if (hovered_quest_id != GW::Constants::QuestID::None) {
         if (const auto hovered_quest = GW::QuestMgr::GetQuest(hovered_quest_id)) {
             static GuiUtils::EncString quest_name;
-            if (!quest_name.IsDecoding()) quest_name.reset(hovered_quest->name);
+            if (!quest_name.IsDecoding()) quest_name = GuiUtils::EncString(hovered_quest->name);
             ImGui::SetTooltip("%s", quest_name.string().c_str());
         }
     }

--- a/GWToolboxdll/Windows/ArmoryWindow.cpp
+++ b/GWToolboxdll/Windows/ArmoryWindow.cpp
@@ -910,7 +910,7 @@ namespace GWArmory {
                         if (!(item && IsWeapon(item->type))) continue;
                         if (pending_items.contains(item->model_file_id)) continue;
                         pending_decodes[item->model_file_id] = std::make_unique<GuiUtils::EncString>(item->name_enc);
-                        pending_decodes[item->model_file_id]->string(); // Trigger decode
+                        pending_decodes[item->model_file_id]->StartDecode();
                         pending_items[item->model_file_id] = item;
                     }
                 }

--- a/GWToolboxdll/Windows/BuildsWindow.cpp
+++ b/GWToolboxdll/Windows/BuildsWindow.cpp
@@ -638,7 +638,7 @@ namespace {
                 if (ImGui::IsItemHovered()) {
                     const GW::Skill* s = GW::SkillbarMgr::GetSkillConstantData(skills[i]);
                     if (s) {
-                        preferred_skill_order_tooltip.reset(s->name);
+                        preferred_skill_order_tooltip = GuiUtils::EncString(s->name);
                         ImGui::SetTooltip("%s", preferred_skill_order_tooltip.string().c_str());
                     }
                 }

--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -795,7 +795,7 @@ Mission::Mission(const MapID _outpost,
     map_to = outpost;
     const GW::AreaInfo* map_info = GW::Map::GetMapInfo(outpost);
     if (map_info) {
-        name.reset(map_info->name_id);
+        name = GuiUtils::EncString(map_info->name_id);
     }
 };
 
@@ -1096,8 +1096,7 @@ ItemAchievement::ItemAchievement(const size_t _encoded_name_index, const wchar_t
     : PvESkill(SkillID::No_Skill)
 {
     encoded_name_index = _encoded_name_index;
-    name.language(Language::English);
-    name.reset(encoded_name);
+    name = GuiUtils::EncString(encoded_name, true, Language::English);
 }
 
 const char* ItemAchievement::Name()
@@ -1151,7 +1150,7 @@ PvESkill::PvESkill(const SkillID _skill_id)
     if (_skill_id != SkillID::No_Skill) {
         const auto skill = GW::SkillbarMgr::GetSkillConstantData(skill_id);
         if (skill) {
-            name.reset(skill->name);
+            name = GuiUtils::EncString(skill->name);
             profession = skill->profession;
         }
     }
@@ -1244,7 +1243,7 @@ FactionsPvESkill::FactionsPvESkill(const SkillID skill_id)
         buf.resize(wcslen(buf.data()) + 4, 0);
         GW::UI::UInt32ToEncStr(faction_id, buf.data() + buf.size() - 4, 4);
         buf.resize(wcslen(buf.data()) + 1, 0);
-        name.reset(buf.c_str());
+        name = GuiUtils::EncString(buf.c_str());
     }
 };
 
@@ -3254,12 +3253,12 @@ void UnlockedPvPItemUpgrade::LoadStrings()
     if (name.encoded().empty()) {
         wchar_t* tmp;
         if (GW::Items::GetPvPItemUpgradeEncodedName(encoded_name_index, &tmp)) {
-            name.reset(tmp);
+            name = GuiUtils::EncString(tmp);
             name.StartDecode();
         }
     }
     if (single_item_name.encoded().empty()) {
-        single_item_name.reset(info->name_id);
+        single_item_name = GuiUtils::EncString(info->name_id);
         single_item_name.StartDecode();
     }
 }

--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -3255,12 +3255,12 @@ void UnlockedPvPItemUpgrade::LoadStrings()
         wchar_t* tmp;
         if (GW::Items::GetPvPItemUpgradeEncodedName(encoded_name_index, &tmp)) {
             name.reset(tmp);
-            name.wstring();
+            name.StartDecode();
         }
     }
     if (single_item_name.encoded().empty()) {
         single_item_name.reset(info->name_id);
-        single_item_name.wstring();
+        single_item_name.StartDecode();
     }
 }
 

--- a/GWToolboxdll/Windows/DailyQuestsWindow.cpp
+++ b/GWToolboxdll/Windows/DailyQuestsWindow.cpp
@@ -820,7 +820,8 @@ namespace {
         for (auto& entry : w->quest_log) {
             if (entry.name && !quest_log_names.contains(entry.quest_id)) {
                 auto enc_string = std::make_unique<GuiUtils::EncString>();
-                enc_string->reset(entry.name)->language(GW::Constants::Language::English)->wstring();
+                enc_string->reset(entry.name)->language(GW::Constants::Language::English);
+                enc_string->StartDecode();
                 quest_log_names[entry.quest_id] = std::move(enc_string);
             }
             if (!processing && quest_log_names[entry.quest_id]->IsDecoding()) {
@@ -1708,8 +1709,8 @@ void DailyQuests::QuestData::Decode(bool force)
         name_translated->reset(enc_name.c_str());
         name_english->reset(enc_name.c_str());
     }
-    name_translated->wstring();
-    name_english->wstring();
+    name_translated->StartDecode();
+    name_english->StartDecode();
     GetMapName();
 }
 

--- a/GWToolboxdll/Windows/DailyQuestsWindow.cpp
+++ b/GWToolboxdll/Windows/DailyQuestsWindow.cpp
@@ -819,8 +819,7 @@ namespace {
         bool processing = false;
         for (auto& entry : w->quest_log) {
             if (entry.name && !quest_log_names.contains(entry.quest_id)) {
-                auto enc_string = std::make_unique<GuiUtils::EncString>();
-                enc_string->reset(entry.name)->language(GW::Constants::Language::English);
+                auto enc_string = std::make_unique<GuiUtils::EncString>(entry.name, true, GW::Constants::Language::English);
                 enc_string->StartDecode();
                 quest_log_names[entry.quest_id] = std::move(enc_string);
             }
@@ -1695,19 +1694,17 @@ void DailyQuests::QuestData::Decode(bool force)
     if (name_translated && name_english && !force) return;
     if (!name_translated) name_translated = std::make_unique<GuiUtils::EncString>(nullptr, false);
     if (!name_english) name_english = std::make_unique<GuiUtils::EncString>(nullptr, false);
-    name_english->language(GW::Constants::Language::English);
-    name_translated->language(GW::UI::GetTextLanguage());
 
     if (enc_name.empty()) {
         const auto map_info = GW::Map::GetMapInfo(map_id);
         if (map_info && map_info->name_id) {
-            name_translated->reset(map_info->name_id);
-            name_english->reset(map_info->name_id);
+            *name_translated = GuiUtils::EncString(map_info->name_id, true, GW::UI::GetTextLanguage());
+            *name_english = GuiUtils::EncString(map_info->name_id, true, GW::Constants::Language::English);
         }
     }
     else {
-        name_translated->reset(enc_name.c_str());
-        name_english->reset(enc_name.c_str());
+        *name_translated = GuiUtils::EncString(enc_name.c_str(), true, GW::UI::GetTextLanguage());
+        *name_english = GuiUtils::EncString(enc_name.c_str(), true, GW::Constants::Language::English);
     }
     name_translated->StartDecode();
     name_english->StartDecode();

--- a/GWToolboxdll/Windows/EnemyWindow.cpp
+++ b/GWToolboxdll/Windows/EnemyWindow.cpp
@@ -35,11 +35,9 @@ namespace {
     {
         const auto enc_name = GW::Agents::GetAgentEncName(agent_id);
         if (!agent_names_by_id.contains(agent_id)) {
-            agent_names_by_id[agent_id] = std::make_unique<GuiUtils::EncString>();
+            agent_names_by_id[agent_id] = std::make_unique<GuiUtils::EncString>(enc_name);
         }
-        auto* enc_string = agent_names_by_id[agent_id].get();
-        enc_string->reset(enc_name);
-        return enc_string->string();
+        return agent_names_by_id[agent_id]->string();
     }
 
     struct EnemyInfo {

--- a/GWToolboxdll/Windows/EnemyWindow.cpp
+++ b/GWToolboxdll/Windows/EnemyWindow.cpp
@@ -31,7 +31,7 @@ namespace {
 
     std::unordered_map<uint32_t, std::unique_ptr<GuiUtils::EncString>> agent_names_by_id;
 
-    std::string& GetAgentName(uint32_t agent_id)
+    const std::string& GetAgentName(uint32_t agent_id)
     {
         const auto enc_name = GW::Agents::GetAgentEncName(agent_id);
         if (!agent_names_by_id.contains(agent_id)) {
@@ -163,7 +163,7 @@ namespace {
                 ImGui::ProgressBar(living->hp, ImVec2(-1, 0), "");
                 ImGui::PopStyleColor();
 
-                std::string* skill_name = nullptr;
+                const std::string* skill_name = nullptr;
 
                 if (enemy_info.last_skill != GW::Constants::SkillID::No_Skill) {
                     const auto skill_data = GW::SkillbarMgr::GetSkillConstantData(enemy_info.last_skill);

--- a/GWToolboxdll/Windows/GWMarketWindow.cpp
+++ b/GWToolboxdll/Windows/GWMarketWindow.cpp
@@ -118,7 +118,7 @@ namespace {
     }
 
 
-    std::string* GetAttributeName(GW::Constants::Attribute attribute)
+    const std::string* GetAttributeName(GW::Constants::Attribute attribute)
     {
         const auto attrib_data = GW::SkillbarMgr::GetAttributeConstantData(attribute);
         if (attrib_data) {
@@ -1595,20 +1595,20 @@ namespace {
             if (item->complete_name_enc && *item->complete_name_enc) {
                 decoded_complete_name->language(GW::Constants::Language::English);
                 decoded_complete_name->reset(item->complete_name_enc, false);
-                decoded_complete_name->string();
+                decoded_complete_name->StartDecode();
             }
 
             decoded_name = std::make_unique<GuiUtils::EncString>();
             decoded_name->language(GW::Constants::Language::English);
             decoded_name->reset(item->name_enc, true);
-            decoded_name->string();
+            decoded_name->StartDecode();
 
             decoded_desc = std::make_unique<GuiUtils::EncString>();
             decoded_desc->reset(nullptr, false);
             if (item->info_string && *item->info_string) {
                 decoded_desc->language(GW::Constants::Language::English);
                 decoded_desc->reset(item->info_string, false);
-                decoded_desc->string();
+                decoded_desc->StartDecode();
             }
         }
         ~PendingAddToSell() = default;

--- a/GWToolboxdll/Windows/GWMarketWindow.cpp
+++ b/GWToolboxdll/Windows/GWMarketWindow.cpp
@@ -1591,24 +1591,21 @@ namespace {
 
             item_id = item->item_id;
 
-            decoded_complete_name = std::make_unique<GuiUtils::EncString>();
             if (item->complete_name_enc && *item->complete_name_enc) {
-                decoded_complete_name->language(GW::Constants::Language::English);
-                decoded_complete_name->reset(item->complete_name_enc, false);
+                decoded_complete_name = std::make_unique<GuiUtils::EncString>(item->complete_name_enc, false, GW::Constants::Language::English);
                 decoded_complete_name->StartDecode();
+            } else {
+                decoded_complete_name = std::make_unique<GuiUtils::EncString>();
             }
 
-            decoded_name = std::make_unique<GuiUtils::EncString>();
-            decoded_name->language(GW::Constants::Language::English);
-            decoded_name->reset(item->name_enc, true);
+            decoded_name = std::make_unique<GuiUtils::EncString>(item->name_enc, true, GW::Constants::Language::English);
             decoded_name->StartDecode();
 
-            decoded_desc = std::make_unique<GuiUtils::EncString>();
-            decoded_desc->reset(nullptr, false);
             if (item->info_string && *item->info_string) {
-                decoded_desc->language(GW::Constants::Language::English);
-                decoded_desc->reset(item->info_string, false);
+                decoded_desc = std::make_unique<GuiUtils::EncString>(item->info_string, false, GW::Constants::Language::English);
                 decoded_desc->StartDecode();
+            } else {
+                decoded_desc = std::make_unique<GuiUtils::EncString>();
             }
         }
         ~PendingAddToSell() = default;

--- a/GWToolboxdll/Windows/GuildWarsPreferencesWindow.cpp
+++ b/GWToolboxdll/Windows/GuildWarsPreferencesWindow.cpp
@@ -131,7 +131,7 @@ namespace {
         WindowPreference(const GW::UI::WindowID _window_id, const GW::UI::WindowPosition* _position)
             : window_id(_window_id), position(*_position)
         {
-            name.reset(GetWindowNameID(window_id));
+            name = GuiUtils::EncString(GetWindowNameID(window_id));
         }
     };
 

--- a/GWToolboxdll/Windows/Hotkeys.cpp
+++ b/GWToolboxdll/Windows/Hotkeys.cpp
@@ -59,7 +59,7 @@ namespace {
             return true;
         bool waiting = false;
         for (const auto& it : HotkeyGWKey::control_labels) {
-            (it.second->string());
+            it.second->StartDecode();
             if (it.second->IsDecoding()) {
                 waiting = true;
                 break;

--- a/GWToolboxdll/Windows/Hotkeys.cpp
+++ b/GWToolboxdll/Windows/Hotkeys.cpp
@@ -882,8 +882,8 @@ HotkeyEquipItemAttributes::HotkeyEquipItemAttributes(const uint32_t _model_id, c
 HotkeyEquipItemAttributes* HotkeyEquipItemAttributes::set(const uint32_t _model_id, const wchar_t* _name_enc, const wchar_t* _info_string, const GW::ItemModifier* _mod_struct, const size_t _mod_struct_size)
 {
     model_id = _model_id;
-    enc_name.reset(_name_enc);
-    enc_desc.reset(_info_string);
+    enc_name = GuiUtils::EncString(_name_enc);
+    enc_desc = GuiUtils::EncString(_info_string);
     if (mod_struct) {
         delete mod_struct;
         mod_struct = nullptr;
@@ -2061,9 +2061,7 @@ namespace {
                                 merc_agent_ids[m] = heroes[i].agent_id;
                                 const wchar_t* enc = GW::Agents::GetAgentEncName(heroes[i].agent_id);
                                 if (enc) {
-                                    if (!merc_enc_names[m])
-                                        merc_enc_names[m] = std::make_unique<GuiUtils::EncString>();
-                                    merc_enc_names[m]->reset(enc);
+                                    merc_enc_names[m] = std::make_unique<GuiUtils::EncString>(enc);
                                 }
                             }
                             if (merc_enc_names[m]) {

--- a/GWToolboxdll/Windows/Hotkeys.h
+++ b/GWToolboxdll/Windows/Hotkeys.h
@@ -135,10 +135,10 @@ public:
     GuiUtils::EncString enc_desc;
     GW::ItemModifier* mod_struct = nullptr;
     uint32_t mod_struct_size = 0;
-    std::string& name() { return enc_name.string(); }
-    std::wstring& name_ws() { return enc_name.wstring(); }
-    std::string& desc() { return enc_desc.string(); }
-    std::wstring& desc_ws() { return enc_desc.wstring(); }
+    const std::string& name() { return enc_name.string(); }
+    const std::wstring& name_ws() { return enc_name.wstring(); }
+    const std::string& desc() { return enc_desc.string(); }
+    const std::wstring& desc_ws() { return enc_desc.wstring(); }
 };
 
 class HotkeyEquipItem : public TBHotkey {

--- a/GWToolboxdll/Windows/InfoWindow.cpp
+++ b/GWToolboxdll/Windows/InfoWindow.cpp
@@ -209,7 +209,7 @@ namespace {
         if (!skill) {
             return;
         }
-        name->reset(skill->name);
+        *name = GuiUtils::EncString(skill->name);
         static char info_id[16];
         snprintf(info_id, _countof(info_id), "skill_info_%d", skill->skill_id);
         ImGui::PushID(info_id);
@@ -283,7 +283,7 @@ namespace {
         if (!item) {
             return;
         }
-        name->reset(item->single_item_name);
+        *name = GuiUtils::EncString(item->single_item_name);
         static char slot[8] = "-";
         if (item->bag) {
             snprintf(slot, _countof(slot), "%d/%d", item->bag->index + 1, item->slot + 1);
@@ -379,7 +379,7 @@ namespace {
                 if (player->active_title_tier) {
                     const GW::TitleTier& tier = GW::GetGameContext()->world->title_tiers[player->active_title_tier];
                     static GuiUtils::EncString title_enc_string;
-                    title_enc_string.reset(tier.tier_name_enc);
+                    title_enc_string = GuiUtils::EncString(tier.tier_name_enc);
                     InfoField("Current Title", "%s", title_enc_string.string().c_str());
                 }
                 ImGui::PopID();

--- a/GWToolboxdll/Windows/PartyStatisticsWindow.cpp
+++ b/GWToolboxdll/Windows/PartyStatisticsWindow.cpp
@@ -60,7 +60,7 @@ namespace {
             : id(_id)
         {
             name = GetSkillName(id);
-            name->wstring();
+            name->StartDecode();
         }
 
         GW::Constants::SkillID id = static_cast<GW::Constants::SkillID>(0);
@@ -73,7 +73,7 @@ namespace {
             : name_enc(_name_enc), agent_id(_agent_id), party_idx(_party_idx)
         {
             name.reset(name_enc.c_str());
-            name.wstring();
+            name.StartDecode();
         }
 
         std::wstring name_enc;

--- a/GWToolboxdll/Windows/PartyStatisticsWindow.cpp
+++ b/GWToolboxdll/Windows/PartyStatisticsWindow.cpp
@@ -72,7 +72,7 @@ namespace {
         PartyMember(const wchar_t* _name_enc, const uint32_t _agent_id, const uint32_t _party_idx)
             : name_enc(_name_enc), agent_id(_agent_id), party_idx(_party_idx)
         {
-            name.reset(name_enc.c_str());
+            name = GuiUtils::EncString(name_enc.c_str());
             name.StartDecode();
         }
 

--- a/GWToolboxdll/Windows/TargetInfoWindow.cpp
+++ b/GWToolboxdll/Windows/TargetInfoWindow.cpp
@@ -81,8 +81,7 @@ namespace {
         AgentInfo(const wchar_t* _name)
         {
             state = TargetInfoState::DecodingName;
-            name.language(GW::Constants::Language::English);
-            name.reset(_name);
+            name = GuiUtils::EncString(_name, true, GW::Constants::Language::English);
             name.StartDecode();
         }
 
@@ -292,9 +291,7 @@ namespace {
                 const auto skill_data = GW::SkillbarMgr::GetSkillConstantData((GW::Constants::SkillID)i);
                 if (!(skill_data && skill_data->name && skill_ids_by_name_id.find(skill_data->name) == skill_ids_by_name_id.end()))
                     continue;
-                auto enc = std::make_unique<GuiUtils::EncString>();
-                enc->language(GW::Constants::Language::English);
-                enc->reset(skill_data->name);
+                auto enc = std::make_unique<GuiUtils::EncString>(skill_data->name, true, GW::Constants::Language::English);
                 enc->StartDecode();
                 skill_ids_by_name_id[skill_data->name] = enc.get();
                 skill_names_by_id[(GW::Constants::SkillID)i] = std::move(enc);

--- a/GWToolboxdll/Windows/TargetInfoWindow.cpp
+++ b/GWToolboxdll/Windows/TargetInfoWindow.cpp
@@ -83,7 +83,7 @@ namespace {
             state = TargetInfoState::DecodingName;
             name.language(GW::Constants::Language::English);
             name.reset(_name);
-            name.wstring();
+            name.StartDecode();
         }
 
         void ParseContent()
@@ -295,7 +295,7 @@ namespace {
                 auto enc = std::make_unique<GuiUtils::EncString>();
                 enc->language(GW::Constants::Language::English);
                 enc->reset(skill_data->name);
-                enc->wstring();
+                enc->StartDecode();
                 skill_ids_by_name_id[skill_data->name] = enc.get();
                 skill_names_by_id[(GW::Constants::SkillID)i] = std::move(enc);
             }

--- a/GWToolboxdll/Windows/TravelWindow.cpp
+++ b/GWToolboxdll/Windows/TravelWindow.cpp
@@ -66,7 +66,7 @@ namespace {
                 enc_name = std::make_unique<GuiUtils::EncString>(map_info->name_id);
                 if (search_in_english)
                     enc_name->language(GW::Constants::Language::English);
-                enc_name->wstring();
+                enc_name->StartDecode();
             }
         }
 

--- a/GWToolboxdll/Windows/TravelWindow.cpp
+++ b/GWToolboxdll/Windows/TravelWindow.cpp
@@ -63,9 +63,7 @@ namespace {
                 name = new char[1];
             }
             else {
-                enc_name = std::make_unique<GuiUtils::EncString>(map_info->name_id);
-                if (search_in_english)
-                    enc_name->language(GW::Constants::Language::English);
+                enc_name = std::make_unique<GuiUtils::EncString>(map_info->name_id, true, search_in_english ? GW::Constants::Language::English : GW::UI::GetTextLanguage());
                 enc_name->StartDecode();
             }
         }


### PR DESCRIPTION
**Make EncString::wstring/string const and nodiscard**

Lazy-eval members (`decoded_ws`, `decoded_s`, `decoding`, `decoded`, `sanitised`, `pending_ctx_`) are now mutable so `wstring()`/`string()` can be `const`. Both are marked `[[nodiscard]]`.

Add `StartDecode()` for fire-and-forget decode triggering, replacing ~18 callsites that called `wstring()`/`string()` and discarded the
result. Fix const-ref mismatches in Hotkeys.h, EnemyWindow.cpp, and GWMarketWindow.cpp.

**Simplify EncString state: remove decoding and sanitised flags**

Replace the `decoding` flag with `pending_ctx_` nullity check. Sanitise eagerly in `OnStringDecoded` instead of lazily in `wstring()`, removing the `sanitised` flag. Store `should_sanitise` as a configuration bool set by `reset()`. Only decoded remains as mutable state.

**Remove EncString::reset, language, and decode; add move semantics**

Remove `reset()` in favour of move-assigning a fresh `EncString`. Remove `language()` - the language is now a constructor parameter.
Fold `decode()` into `StartDecode()` as the single entry point. Add move constructor/assignment that transfer any in-flight decode.
Store a copy of the encoded string in `DecodeContext` so GW's async decode buffer outlives the `EncString`.