### PR TITLE
Configurable boss profession colors on minimap

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.cpp
@@ -201,6 +201,24 @@ void AgentRenderer::LoadSettings(const ToolboxIni* ini, const char* section)
     LOAD_COLOR(color_ally_minion);
     LOAD_COLOR(color_ally_dead);
     LOAD_BOOL(boss_colors);
+    {
+        constexpr const char* keys[] = {
+            nullptr, // None
+            "color_profession_warrior",
+            "color_profession_ranger",
+            "color_profession_monk",
+            "color_profession_necromancer",
+            "color_profession_mesmer",
+            "color_profession_elementalist",
+            "color_profession_assassin",
+            "color_profession_ritualist",
+            "color_profession_paragon",
+            "color_profession_dervish",
+        };
+        for (size_t i = 1; i < _countof(keys); ++i) {
+            profession_colors[i] = Colors::Load(ini, Name(), keys[i], profession_colors[i]);
+        }
+    }
     LOAD_BOOL(show_quest_npcs_on_minimap);
 
 #ifdef _DEBUG
@@ -301,6 +319,24 @@ void AgentRenderer::SaveSettings(ToolboxIni* ini, const char* section) const
 
     SAVE_BOOL(show_hidden_npcs);
     SAVE_BOOL(boss_colors);
+    {
+        constexpr const char* keys[] = {
+            nullptr, // None
+            "color_profession_warrior",
+            "color_profession_ranger",
+            "color_profession_monk",
+            "color_profession_necromancer",
+            "color_profession_mesmer",
+            "color_profession_elementalist",
+            "color_profession_assassin",
+            "color_profession_ritualist",
+            "color_profession_paragon",
+            "color_profession_dervish",
+        };
+        for (size_t i = 1; i < _countof(keys); ++i) {
+            Colors::Save(ini, Name(), keys[i], profession_colors[i]);
+        }
+    }
     SAVE_BOOL(show_quest_npcs_on_minimap);
     SaveCustomAgents();
 }

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -1113,6 +1113,33 @@ void Minimap::DrawSettingsInternal()
     ImGui::StartSpacedElements(300.f);
     ImGui::NextSpacedElement();
     ImGui::Checkbox("Show boss by profession color on minimap", &agent_renderer.boss_colors);
+    if (agent_renderer.boss_colors) {
+        ImGui::Indent();
+        if (ImGui::TreeNodeEx("Boss profession colors", ImGuiTreeNodeFlags_FramePadding)) {
+            constexpr uint32_t color_flags = ImGuiColorEditFlags_NoInputs;
+            static const char* prof_names[] = {
+                nullptr,        // 0 = None, hidden
+                "Warrior",      // 1
+                "Ranger",       // 2
+                "Monk",         // 3
+                "Necromancer",  // 4
+                "Mesmer",       // 5
+                "Elementalist", // 6
+                "Assassin",     // 7
+                "Ritualist",    // 8
+                "Paragon",      // 9
+                "Dervish",      // 10
+            };
+            ImGui::StartSpacedElements(180.f);
+            for (size_t i = 1; i < _countof(prof_names); ++i) {
+                ImGui::NextSpacedElement();
+                Colors::DrawSettingHueWheel(prof_names[i], &agent_renderer.profession_colors[i], color_flags);
+            }
+            ImGui::TreePop();
+        }
+        ImGui::Unindent();
+        ImGui::StartSpacedElements(300.f);
+    }
     ImGui::NextSpacedElement();
     ImGui::Checkbox("Show hidden NPCs", &agent_renderer.show_hidden_npcs);
     ImGui::ShowHelp("Show NPCs that aren't usually visible on the minimap\ne.g. minipets, invisible NPCs");


### PR DESCRIPTION
## Summary
The boss profession color palette on the minimap was hard-coded as a 10-element array. Several pairs of professions (Mesmer/Assassin, Necromancer/Ranger, etc.) ended up using similar enough colors that bosses are hard to tell apart at a glance.

Expose the array through the minimap settings as a per-profession hue wheel beneath the existing "Show boss by profession color on minimap" checkbox, and persist each color to `config.ini`. Defaults are unchanged.

## Test plan
- [ ] Open Minimap settings, expand "Boss profession colors", change e.g. Mesmer to a distinctive color, confirm bosses with that profession render with the new color
- [ ] `/tb save` + restart, confirm setting persists
- [ ] Untick "Show boss by profession color on minimap", confirm the color group hides

Closes #1711

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo6qnHxyVrRdgwgY7ZRNnu)_