### PR TITLE
Friend Minimap so it can reach AgentRenderer::profession_colors

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
@@ -20,6 +20,7 @@ namespace GW {
 using Color = uint32_t;
 
 class AgentRenderer : public D3DVertexBuffer {
+    friend class Minimap;
     static constexpr int num_triangles = 32;
 
 public:


### PR DESCRIPTION
The new boss profession color hue wheels live in Minimap settings but the array is in the private section of AgentRenderer. Declare Minimap a friend so the settings UI can bind directly to the array entries.