### PR TITLE
feat: expose MinimapRenderer through plugin_base

### DIFF
--- a/GWToolboxdll/MinimapPlugin.h
+++ b/GWToolboxdll/MinimapPlugin.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <Windows.h>
+#include <d3d9.h>
+#include <GWCA/GameContainers/GamePos.h>
+#include <RectF.h>
+
+#ifndef GWTOOLBOXDLL_MINIMAP_EXPORT
+#  ifdef GWToolboxdll_EXPORTS
+#    define GWTOOLBOXDLL_MINIMAP_EXPORT __declspec(dllexport)
+#  else
+#    define GWTOOLBOXDLL_MINIMAP_EXPORT __declspec(dllimport)
+#  endif
+#endif
+
+// Context structure that encapsulates all rendering parameters
+struct MinimapRenderContext : RectF {
+    // Position and size
+    ImVec2 anchor_point = {}; // Center of minimap - this may not necessarily be the center point of the clipping rect
+
+    // Camera/view parameters
+    GW::Vec2f translation = {}; // World-space translation (for panning)
+    float zoom_scale = 1.f; // Zoom level (scale factor)
+    float rotation = 1.5708f; // Map rotation in radians
+
+    float base_scale = 1.f; // The size (in px) of the base scale to use before zooming. Minimap sets this to size.x
+
+    // Visual options
+    bool circular_map = false; // Whether to render as circle or square
+    bool draw_center_marker = false; // Whether to draw center marker when panned
+    D3DCOLOR background_color = D3DCOLOR_ARGB(50, 0, 0, 0); // Background color (or 0 to use renderer's default)
+    D3DCOLOR foreground_color = D3DCOLOR_ARGB(0xff, 0xe0, 0xe0, 0xe0); // Foreground color (or 0 to use renderer's default)
+    D3DCOLOR shadow_color = 0; // Drop shadow for foreground color
+    D3DCOLOR cardinal_color = 0;
+
+    bool draw_ranges = false;
+
+    RECT rect() const
+    {
+        return {static_cast<LONG>(top_left.x), static_cast<LONG>(top_left.y), static_cast<LONG>(bottom_right.x), static_cast<LONG>(bottom_right.y)};
+    }
+};
+
+// subclass this structure and register an instance to have plugins draw extra stuff on a minimap
+// Vtable layout (do not change): slot 0 = ~MinimapRenderer, slot 1 = RenderMinimap.
+class MinimapRenderer {
+public:
+    MinimapRenderer() = default;
+    virtual ~MinimapRenderer() = default;
+
+    // minimap holds pointers to registered renderers, so move is forbidden
+    MinimapRenderer(const MinimapRenderer&) = delete;
+    MinimapRenderer(MinimapRenderer&&) = delete;
+    MinimapRenderer& operator=(const MinimapRenderer&) = delete;
+    MinimapRenderer& operator=(MinimapRenderer&&) = delete;
+
+    // implement this to draw your data on the minimap
+    // the view matrix is set up to transform game world positions to minimap appropriately, make sure to restore it if you touch it
+    // the world matrix is undefined and can be left in any state
+    virtual void RenderMinimap(IDirect3DDevice9* device, const MinimapRenderContext& context) = 0;
+
+    GWTOOLBOXDLL_MINIMAP_EXPORT static void RegisterRenderer(MinimapRenderer* renderer);
+    GWTOOLBOXDLL_MINIMAP_EXPORT static void UnregisterRenderer(MinimapRenderer* renderer);
+};

--- a/GWToolboxdll/RectF.h
+++ b/GWToolboxdll/RectF.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <Windows.h>
+#include <imgui.h>
+
+struct RectF {
+    ImVec2 top_left;
+    ImVec2 bottom_right;
+
+    constexpr RectF(const RECT& rect)
+        : top_left({static_cast<float>(rect.left), static_cast<float>(rect.top)}),
+          bottom_right({static_cast<float>(rect.right), static_cast<float>(rect.bottom)}) {}
+
+    constexpr RectF(const ImVec2& _top_left, const ImVec2& _bottom_right)
+        : top_left(_top_left), bottom_right(_bottom_right) {}
+
+    RectF() = default;
+
+    ImVec2 size() const
+    {
+        return {width(), height()};
+    }
+
+    float width() const
+    {
+        return bottom_right.x - top_left.x;
+    }
+
+    float height() const
+    {
+        return bottom_right.y - top_left.y;
+    }
+
+    void move_to(const ImVec2& new_top_left)
+    {
+        const auto diff_x = new_top_left.x - top_left.x;
+        const auto diff_y = new_top_left.y - top_left.y;
+        top_left.x += diff_x;
+        top_left.y += diff_y;
+        bottom_right.x += diff_x;
+        bottom_right.y += diff_y;
+    }
+
+    void resize(const ImVec2& new_size)
+    {
+        const auto old_size = size();
+        const auto diff_x = new_size.x - old_size.x;
+        const auto diff_y = new_size.y - old_size.y;
+        bottom_right.x += diff_x;
+        bottom_right.y += diff_y;
+    }
+
+    bool contains(const ImVec2& point) const
+    {
+        return point.x >= top_left.x && point.x <= bottom_right.x &&
+               point.y >= top_left.y && point.y <= bottom_right.y;
+    }
+};

--- a/GWToolboxdll/Utils/GuiUtils.h
+++ b/GWToolboxdll/Utils/GuiUtils.h
@@ -4,64 +4,11 @@
 #include <ImGuiAddons.h>
 #include <nlohmann/json.hpp>
 #include <ToolboxIni.h>
+#include <RectF.h>
 
 namespace GW::Constants {
     enum class Language;
 }
-
-struct RectF {
-    ImVec2 top_left;
-    ImVec2 bottom_right;
-
-    constexpr RectF(const RECT& rect)
-        : top_left({static_cast<float>(rect.left), static_cast<float>(rect.top)}),
-          bottom_right({static_cast<float>(rect.right), static_cast<float>(rect.bottom)}) {}
-
-    constexpr RectF(const ImVec2& _top_left, const ImVec2& _bottom_right)
-        : top_left(_top_left), bottom_right(_bottom_right) {}
-
-    ImVec2 size() const
-    {
-        return {width(), height()};
-    }
-
-    float width() const
-    {
-        return bottom_right.x - top_left.x;
-    }
-
-    float height() const
-    {
-        return bottom_right.y - top_left.y;
-    }
-
-    void move_to(const ImVec2& new_top_left)
-    {
-        const auto diff_x = new_top_left.x - top_left.x;
-        const auto diff_y = new_top_left.y - top_left.y;
-        top_left.x += diff_x;
-        top_left.y += diff_y;
-        bottom_right.x += diff_x;
-        bottom_right.y += diff_y;
-    }
-
-    void resize(const ImVec2& new_size)
-    {
-        const auto old_size = size();
-        const auto diff_x = new_size.x - old_size.x;
-        const auto diff_y = new_size.y - old_size.y;
-        bottom_right.x += diff_x;
-        bottom_right.y += diff_y;
-    }
-
-    bool contains(const ImVec2& point) const
-    {
-        return point.x >= top_left.x && point.x <= bottom_right.x &&
-               point.y >= top_left.y && point.y <= bottom_right.y;
-    }
-
-    RectF() = default;
-};
 
 
 namespace GuiUtils {

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -1481,6 +1481,16 @@ void Minimap::UnregisterRenderer(MinimapRenderer* renderer)
     }
 }
 
+void MinimapRenderer::RegisterRenderer(MinimapRenderer* renderer)
+{
+    Minimap::RegisterRenderer(renderer);
+}
+
+void MinimapRenderer::UnregisterRenderer(MinimapRenderer* renderer)
+{
+    Minimap::UnregisterRenderer(renderer);
+}
+
 bool Minimap::ShouldMarkersDrawOnMap()
 {
     const auto map_has_outpost_and_explorable = [](const GW::Constants::MapID map_id) {

--- a/GWToolboxdll/Widgets/Minimap/Minimap.h
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.h
@@ -8,6 +8,7 @@
 #include "gwtoolboxdll_export.h"
 
 #include <Utils/GuiUtils.h>
+#include <MinimapPlugin.h>
 
 #include <Widgets/Minimap/AgentRenderer.h>
 #include <Widgets/Minimap/CustomRenderer.h>
@@ -17,52 +18,6 @@
 #include <Widgets/Minimap/PmapRenderer.h>
 #include <Widgets/Minimap/RangeRenderer.h>
 #include <Widgets/Minimap/SymbolsRenderer.h>
-
-// Context structure that encapsulates all rendering parameters
-struct MinimapRenderContext : RectF {
-    // Position and size
-    ImVec2 anchor_point; // Center of minimap - this may not necessarily be the center point of the clipping rect
-
-    // Camera/view parameters
-    GW::Vec2f translation; // World-space translation (for panning)
-    float zoom_scale = 1.f; // Zoom level (scale factor)
-    float rotation = 1.5708f; // Map rotation in radians
-
-    float base_scale = 1.f; // The size (in px) of the base scale to use before zooming. Minimap sets this to size.x
-
-    // Visual options
-    bool circular_map = false; // Whether to render as circle or square
-    bool draw_center_marker = false; // Whether to draw center marker when panned
-    D3DCOLOR background_color = D3DCOLOR_ARGB(50, 0, 0, 0); // Background color (or 0 to use renderer's default)
-    D3DCOLOR foreground_color = D3DCOLOR_ARGB(0xff, 0xe0, 0xe0, 0xe0); // Foreground color (or 0 to use renderer's default)
-    D3DCOLOR shadow_color = 0; // Drop shadow for foreground color
-    D3DCOLOR cardinal_color = 0;
-
-    bool draw_ranges = false;
-
-    RECT rect() const
-    {
-        return {static_cast<LONG>(top_left.x), static_cast<LONG>(top_left.y), static_cast<LONG>(bottom_right.x), static_cast<LONG>(bottom_right.y)};
-    }
-};
-
-// subclass this structure and register an instance to have plugins draw extra stuff on a minimap
-class GWTOOLBOXDLL_EXPORT MinimapRenderer {
-public:
-    MinimapRenderer() = default;
-    virtual ~MinimapRenderer() = default;
-
-    // minimap holds pointers to registered renderers, so move is forbidden
-    MinimapRenderer(const MinimapRenderer&) = delete;
-    MinimapRenderer(MinimapRenderer&&) = delete;
-    MinimapRenderer& operator=(const MinimapRenderer&) = delete;
-    MinimapRenderer& operator=(MinimapRenderer&&) = delete;
-
-    // implement this to draw your data on the minimap
-    // the view matrix is set up to transform game world positions to minimap appropriately, make sure to restore it if you touch it
-    // the world matrix is undefined and can be left in any state
-    virtual void RenderMinimap(IDirect3DDevice9* device, const MinimapRenderContext& context) = 0;
-};
 
 class Minimap final : public ToolboxWidget {
     Minimap()
@@ -104,9 +59,6 @@ public:
     // Setup projection matrix for a given context
     static void RenderSetupProjection(IDirect3DDevice9* device, const MinimapRenderContext& context);
 
-    GWTOOLBOXDLL_EXPORT static void RegisterRenderer(MinimapRenderer* renderer);
-    GWTOOLBOXDLL_EXPORT static void UnregisterRenderer(MinimapRenderer* renderer);
-
     bool FlagHeros(LPARAM lParam);
     bool OnMouseDown(UINT Message, WPARAM wParam, LPARAM lParam);
     [[nodiscard]] bool OnMouseDblClick(UINT Message, WPARAM wParam, LPARAM lParam) const;
@@ -141,6 +93,9 @@ public:
     [[nodiscard]] static bool IsActive();
 
 private:
+    friend class MinimapRenderer;
+    static void RegisterRenderer(MinimapRenderer* renderer);
+    static void UnregisterRenderer(MinimapRenderer* renderer);
     [[nodiscard]] bool IsInside(int x, int y) const;
     // returns true if the map is visible, valid, not loading, etc
 

--- a/cmake/gwtoolboxdll_plugins.cmake
+++ b/cmake/gwtoolboxdll_plugins.cmake
@@ -7,7 +7,9 @@ target_sources(plugin_base INTERFACE
     "plugins/Base/PluginUtils.h"
     "plugins/Base/PluginUtils.cpp"
     "plugins/Base/ToolboxUIPlugin.h"
-    "plugins/Base/ToolboxUIPlugin.cpp")
+    "plugins/Base/ToolboxUIPlugin.cpp"
+    "GWToolboxdll/RectF.h"
+    "GWToolboxdll/MinimapPlugin.h")
 target_include_directories(plugin_base INTERFACE
     "plugins/Base"
     "GWToolboxdll" # careful here, we only get access to exported and header functions!


### PR DESCRIPTION
I have a number of out-of-tree plugins and a couple of them draw on the Minimap, currently by replicating the d3d state that GWToolbox sets up and cleaning up after themselves which is cumbersome and doesn't detect some user-applied transformations like minimap rotation state, etc. I wanted to switch to the new `MinimapRenderer` approach from [17191bcb](https://github.com/gwdevhub/GWToolboxpp/commit/17191bcb) but quickly found out that it would not work unless I pull my plugins in-tree and/or build all of GWToolboxdll which would nuke my build time. I know there are other out-of-tree plugins out there as well that could benefit from this.

**Cause:**

`Minimap.h` depends on `gwtoolboxdll_export.h` which is cmake-generated and only exists in the build directory. Out-of-tree plugins couldn't use `MinimapRenderer` without building GWToolboxdll first (which pulls many dependencies and SDKs, significantly slowing down build time for out-of-tree plugins).

The goal is to not have to pull `Minimap.h` in plugins extending the Minimap anymore.

**Changes:**

- Add `GWToolboxdll/RectF.h`: RectF extracted from `GuiUtils.h` into a standalone header with no heavy dependencies
- Add `GWToolboxdll/MinimapPlugin.h`: `RectF`, `MinimapRenderContext` and `MinimapRenderer` with a self-contained export macro; `RegisterRenderer/UnregisterRenderer` are dllexported statics on `MinimapRenderer`, defined in `Minimap.cpp`. Minimap::RegisterRenderer/UnregisterRenderer are now private, accessible only via `MinimapRenderer`.
- `plugin_base`: expose `RectF.h` and `MinimapPlugin.h` via target_sources
- `anchor_point` and `Translation` are zero-initialized by default

**Result:**

Plugins can import `MinimapPlugin.h` (from `plugin_base` which doesn't require GWToolboxdll to be built) and go:
```c++
#include <MinimapPlugin.h> // ships in source tree, no build-tree dependency

class MyRenderer : public MinimapRenderer {
public:
    void RenderMinimap(IDirect3DDevice9* device, const MinimapRenderContext& ctx) override {
        // draw stuff
    }
};

class MyPlugin : public ToolboxPlugin {
    MyRenderer renderer;
    void Initialize(...) override {
        MinimapRenderer::RegisterRenderer(&renderer);
    }
    void SignalTerminate() override {
        MinimapRenderer::UnregisterRenderer(&renderer);
    }
};
```