### PR TITLE
Re-enable Obfuscator module

### DIFF
--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -102,7 +102,7 @@
 #include "ToolboxSettings.h"
 
 
-#define USE_OBFUSCATOR _DEBUG
+#define USE_OBFUSCATOR 1
 #if USE_OBFUSCATOR
 #include <Modules/Obfuscator.h>
 #endif


### PR DESCRIPTION
Re-enables the Obfuscator module for all build configurations by changing `#define USE_OBFUSCATOR _DEBUG` to `#define USE_OBFUSCATOR 1` in ToolboxSettings.cpp.

The module files were already in the Modules/ directory and compiled, but were excluded from the optional modules list in release builds.

Closes #1843

Generated with [Claude Code](https://claude.ai/code)