### PR TITLE
Title Tracker: show rank, next-tier tooltip, broader auto-show

### DIFF
--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -157,6 +157,37 @@ namespace GW {
             return {};
         }
 
+        std::vector<GW::Constants::TitleID> GetTitlesForMap(GW::Constants::MapID map_id)
+        {
+            using namespace GW::Constants;
+
+            const auto map_info = GW::Map::GetMapInfo(map_id);
+            if (!map_info) return {};
+
+            // EotN regions: show all five Masters of the North related titles
+            switch (map_info->region) {
+                case GW::Region::Region_CharrHomelands:
+                case GW::Region::Region_TarnishedCoast:
+                case GW::Region::Region_FarShiverpeaks:
+                case GW::Region::Region_DepthsOfTyria:
+                    return {TitleID::Asuran, TitleID::Deldrimor, TitleID::Norn, TitleID::Vanguard, TitleID::MasterOfTheNorth};
+                case GW::Region::Region_Kurzick:
+                case GW::Region::Region_Luxon:
+                    return {TitleID::Kurzick, TitleID::Luxon};
+            }
+
+            switch (map_info->continent) {
+                case GW::Continent::Cantha:
+                    return {TitleID::Kurzick, TitleID::Luxon};
+                case GW::Continent::Elona:
+                    return {TitleID::Sunspear};
+                case GW::Continent::RealmOfTorment:
+                    return {TitleID::Lightbringer};
+            }
+
+            return {};
+        }
+
         GW::Constants::TitleID GetTitleForMap(GW::Constants::MapID map_id)
         {
             switch (map_id) {

--- a/GWToolboxdll/Utils/ToolboxUtils.h
+++ b/GWToolboxdll/Utils/ToolboxUtils.h
@@ -134,6 +134,7 @@ namespace GW {
         GW::Array<GW::MapProp*>* GetMapProps();
         bool GetMapWorldMapBounds(GW::AreaInfo* map, ImRect* out);
         std::vector<GW::Constants::TitleID> GetBountyTitlesForMap(GW::Constants::MapID map_id);
+        std::vector<GW::Constants::TitleID> GetTitlesForMap(GW::Constants::MapID map_id);
         GW::Constants::TitleID GetTitleForMap(GW::Constants::MapID map_id);
 
         bool IsFestivalOutpost(const GW::Constants::MapID map_id);

--- a/GWToolboxdll/Widgets/TitleTrackerWidget.cpp
+++ b/GWToolboxdll/Widgets/TitleTrackerWidget.cpp
@@ -43,9 +43,11 @@ namespace {
         GW::Constants::TitleID title_id;
         GuiUtils::EncString title_label;
         GuiUtils::EncString tier_label;
+        GuiUtils::EncString next_tier_label;
         std::unique_ptr<GuiUtils::EncString> overlay_label; // Because this can change quickly, we may need to recycle it faster than the frame rate can handle
         float percent = 0.f;
         float secondary_percent = 0.f;
+        uint32_t current_rank = 0;
         std::unique_ptr<GuiUtils::EncString> secondary_label;
         bool show = false;
         TitleProgress(GW::Constants::TitleID _title_id) : title_id(_title_id) {
@@ -216,7 +218,7 @@ namespace {
         std::ranges::sort(title_progress_by_title, [](TitleProgress* t1, TitleProgress* t2) {
             return t1->title_label.string() < t2->title_label.string();
         });
-        title_for_bounty = automatically_show_title_progress_for_current_map ? GW::Map::GetBountyTitlesForMap(GW::Map::GetMapID()) : std::vector<GW::Constants::TitleID>();
+        title_for_bounty = automatically_show_title_progress_for_current_map ? GW::Map::GetTitlesForMap(GW::Map::GetMapID()) : std::vector<GW::Constants::TitleID>();
     }
 
     void TitleProgress::RefreshProgress()
@@ -302,6 +304,13 @@ namespace {
         }
         const auto& current_tier = w->title_tiers[title_info->current_title_tier_index];
         tier_label.reset(current_tier.tier_name_enc);
+        current_rank = current_tier.tier_number;
+        if (title_info->points_needed_next_rank != 0xFFFFFFFF &&
+            w->title_tiers.size() > title_info->next_title_tier_index) {
+            next_tier_label.reset(w->title_tiers[title_info->next_title_tier_index].tier_name_enc);
+        } else {
+            next_tier_label.reset(nullptr);
+        }
     }
 
 
@@ -402,7 +411,9 @@ void TitleTrackerWidget::Draw(IDirect3DDevice9*)
             if (p->overlay_label->encoded().empty()) continue;
             // Get strings from EncString
             const auto& title_text = p->title_label.string();
-            const auto& sub_title_text = p->tier_label.string();
+            auto sub_title_text = p->tier_label.string();
+            if (p->current_rank > 0)
+                sub_title_text += std::format(" ({})", p->current_rank);
             const auto& overlay_text = p->overlay_label->string();
 
             // Draw title label (left aligned) and sub-title label (right aligned) on same line
@@ -464,7 +475,13 @@ void TitleTrackerWidget::Draw(IDirect3DDevice9*)
                 draw_list->AddText({overlay_pos.x + 1.f, overlay_pos.y + 1.f}, progress_overlay_label_color, overlay_text.c_str());
             }
             if (ImGui::IsMouseHoveringRect(bar_pos, bar_pos_max)) {
-                auto label = std::format("{}\n{}\n{}",p->title_label.string(),p->tier_label.string(),p->overlay_label->string());
+                auto label = std::format("{}\n{}\n{}", p->title_label.string(), sub_title_text, p->overlay_label->string());
+                if (!p->next_tier_label.encoded().empty()) {
+                    const auto title_info = GW::PlayerMgr::GetTitleTrack(p->title_id);
+                    if (title_info && title_info->points_needed_next_rank != 0xFFFFFFFF) {
+                        label += std::format("\nNext: {} at {}", p->next_tier_label.string(), title_info->points_needed_next_rank);
+                    }
+                }
                 if (!p->secondary_label->encoded().empty()) {
                     label += "\n\n";
                     label += p->secondary_label->string();


### PR DESCRIPTION
Re-applies the features from #1898 onto current dev.

- `GW::Map::GetTitlesForMap`: broader region/continent matching for auto-show; EotN regions return all 5 MotN titles, Cantha returns Kurzick+Luxon, Elona returns Sunspear, Realm of Torment returns Lightbringer
- Rank number suffix on tier label (e.g. "Asuran Hero (5)")
- "Next: <tier name> at <points>" in hover tooltip when not at max rank

Refs #1694

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/gwdevhub/GWToolboxpp/actions/runs/25362027507) | [Branch](https://github.com/gwdevhub/GWToolboxpp/tree/claude/pr-1898-20260505-0648