### PR TITLE
Z-order interleaving between GW and TB windows

### DIFF
--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -42,6 +42,7 @@
 #include "Utils/FontLoader.h"
 #include <Utils/ToolboxUtils.h>
 #include <Utils/TextUtils.h>
+#include <Utils/Compositor.h>
 
 #include <EmbeddedResource.h>
 #include "resource.h"
@@ -166,6 +167,7 @@ namespace {
 
         GW::Render::SetResetCallback([](IDirect3DDevice9*) {
             ImGui_ImplDX9_InvalidateDeviceObjects();
+            Compositor::ReleaseDeviceResources();
         });
 
         imgui_initialized = true;
@@ -190,6 +192,7 @@ namespace {
             return true;
         }
         GW::Render::SetResetCallback(nullptr);
+        Compositor::ReleaseDeviceResources();
         FontLoader::Terminate();
         ImGui_ImplDX9_Shutdown();
         ImGui_ImplWin32_Shutdown();
@@ -480,7 +483,39 @@ namespace {
             case WM_RBUTTONDBLCLK:
             case WM_MOUSEMOVE:
             case WM_MOUSEWHEEL: {
+                // Check if mouse is over a GW window occluding a TB window.
+                // Note: io.MousePos is stale here (updated during NewFrame, not WndProc),
+                // so use the real cursor position from the OS.
+                {
+                    POINT cursor_pt;
+                    GetCursorPos(&cursor_pt);
+                    ScreenToClient(gw_window_handle, &cursor_pt);
+                    float mx = (float)cursor_pt.x, my = (float)cursor_pt.y;
+                    uint64_t tb_z = Compositor::GetHoveredTBWindowZ();
+                    if (tb_z > 0 && Compositor::IsPointOccludedByGW(mx, my, tb_z)) {
+                        io.AddMousePosEvent(-FLT_MAX, -FLT_MAX);
+                        if (Message == WM_LBUTTONDOWN || Message == WM_LBUTTONDBLCLK) {
+                            Compositor::GetUnifiedZOrder().OnGWWindowClicked(mx, my);
+                        }
+                        break;
+                    }
+                }
+
                 if (io.WantCaptureMouse && !skip_mouse_capture) {
+                    // Bump TB window z on click for unified z-order tracking
+                    if (Message == WM_LBUTTONDOWN || Message == WM_LBUTTONDBLCLK) {
+                        auto& zo = Compositor::GetUnifiedZOrder();
+                        for (auto* el : GWToolbox::GetUIElements()) {
+                            auto* win = ImGui::FindWindowByName(el->Name());
+                            if (!win || !win->Active || win->Hidden) continue;
+                            if (io.MousePos.x < win->Pos.x || io.MousePos.x > win->Pos.x + win->Size.x ||
+                                io.MousePos.y < win->Pos.y || io.MousePos.y > win->Pos.y + win->Size.y)
+                                continue;
+                            zo.OnWindowFocused(el->Name());
+                            el->unified_z_ = zo.GetZ(el->Name());
+                            break;
+                        }
+                    }
                     return true;
                 }
                 bool captured = false;
@@ -492,10 +527,11 @@ namespace {
                 if (captured) {
                     return true;
                 }
+                // Click is going to GW — bump the GW frame under cursor
+                if (Message == WM_LBUTTONDOWN || Message == WM_LBUTTONDBLCLK) {
+                    Compositor::GetUnifiedZOrder().OnGWWindowClicked(io.MousePos.x, io.MousePos.y);
+                }
             }
-                //if (!skip_mouse_capture) {
-
-                //}
             break;
 
             // keyboard messages
@@ -984,41 +1020,14 @@ void GWToolbox::Update(GW::HookStatus*)
     last_tick_count = tick;
 }
 
-void GWToolbox::Draw(IDirect3DDevice9* device)
+// Runs the ImGui frame cycle: NewFrame → element Draw → Render.
+// Called from FrCacheRenderAll_Hook (for z-interleaved compositing) or
+// from Draw() as a fallback when the hook hasn't fired.
+static void DrawImGuiFrame(IDirect3DDevice9* device)
 {
-    HookUiRoot();
-    switch (gwtoolbox_state) {
-        case GWToolboxState::DrawTerminating:
-            return DrawTerminating(device);
-        case GWToolboxState::DrawInitialising:
-            return DrawInitialising(device);
-        case GWToolboxState::Initialised:
-            break;
-        default:
-            return;
-    }
-
-    if (imgui_inifile_changed) {
-        auto& io = ImGui::GetIO();
-        io.IniFilename = imgui_inifile.bytes;
-        imgui_inifile_changed = false;
-    }
-    if (gwtoolbox_disabled) {
-        if (!ShouldDisableToolbox()) {
-            Enable();
-        }
-        return;
-    }
-    if (ShouldDisableToolbox()) {
-        Disable();
-        return;
-    }
-
-    // Draw loop
+    if (gwtoolbox_disabled) return;
     Resources::DxUpdate(device);
-
-    if (!CanRenderToolbox())
-        return;
+    if (!CanRenderToolbox()) return;
 
     ImGui_ImplDX9_NewFrame();
     ImGui_ImplWin32_NewFrame();
@@ -1047,12 +1056,39 @@ void GWToolbox::Draw(IDirect3DDevice9* device)
 
     if (GW::UI::GetIsUIDrawn()) {
         ToolboxUIElement::UpdateCachedFrameStates();
+        Compositor::HookFrCacheRender();
+        Compositor::GetUnifiedZOrder().Update();
+
+        // Per-frame occlusion: hide mouse from ImGui on frames without WndProc events.
+        // Only applies when z-interleaving is active — if hooks failed, TB renders on
+        // top so there's nothing to occlude against.
+        if (Compositor::IsHooked()) {
+            POINT cursor_pt;
+            GetCursorPos(&cursor_pt);
+            ScreenToClient(gw_window_handle, &cursor_pt);
+            float mx = (float)cursor_pt.x, my = (float)cursor_pt.y;
+            uint64_t tb_z = Compositor::GetHoveredTBWindowZ();
+            if (tb_z > 0 && Compositor::IsPointOccludedByGW(mx, my, tb_z)) {
+                io.AddMousePosEvent(-FLT_MAX, -FLT_MAX);
+            }
+        }
         std::lock_guard lock(module_management_mutex);
         // NB: Don't use an iterator here, because it could be invalidated during draw
         for (size_t i = 0; i < ui_elements_enabled.size(); i++) {
             const auto uielement = ui_elements_enabled[i];
             if (world_map_showing && !uielement->ShowOnWorldMap()) {
                 continue;
+            }
+            // Assign highest z when a TB window becomes visible
+            {
+                const bool was_visible = uielement->unified_z_ != 0;
+                if (uielement->visible && !was_visible) {
+                    auto& zo = Compositor::GetUnifiedZOrder();
+                    zo.OnWindowFocused(uielement->Name());
+                    uielement->unified_z_ = zo.GetZ(uielement->Name());
+                } else if (!uielement->visible && was_visible) {
+                    uielement->unified_z_ = 0;
+                }
             }
             uielement->UpdateLocationAgainstSnappedFrame();
             if (profiling_enabled) {
@@ -1076,11 +1112,71 @@ void GWToolbox::Draw(IDirect3DDevice9* device)
         if ((ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable) == 0)
             ImGui::ClampAllWindowsToScreen(gwtoolbox_state < GWToolboxState::DrawTerminating && ToolboxSettings::clamp_windows_to_screen);
     }
+    // Prepare ImGui overlay draw lists while the frame is still active, so that
+    // draw_fns can call ImGui functions (e.g. SetTooltip).  The cached draw lists
+    // are rendered later during compositing in FrCacheRenderAll_Hook.
+    Compositor::PrepareOverlays();
     ImGui::EndFrame();
     ImGui::Render();
-    ImGui_ImplDX9_RenderDrawData(ImGui::GetDrawData());
+    // Process pending texture uploads before rendering.
+    if (auto* draw_data = ImGui::GetDrawData(); draw_data && draw_data->Textures)
+        for (ImTextureData* tex : *draw_data->Textures)
+            if (tex->Status != ImTextureStatus_OK)
+                ImGui_ImplDX9_UpdateTexture(tex);
+}
+
+void GWToolbox::Draw(IDirect3DDevice9* device)
+{
+    HookUiRoot();
+    switch (gwtoolbox_state) {
+        case GWToolboxState::DrawTerminating:
+            return DrawTerminating(device);
+        case GWToolboxState::DrawInitialising:
+            return DrawInitialising(device);
+        case GWToolboxState::Initialised:
+            break;
+        default:
+            return;
+    }
+
+    Compositor::SetDevice(device);
+    Compositor::SetFrameDrawCallback(DrawImGuiFrame);
+
+    if (imgui_inifile_changed) {
+        auto& io = ImGui::GetIO();
+        io.IniFilename = imgui_inifile.bytes;
+        imgui_inifile_changed = false;
+    }
+    if (gwtoolbox_disabled) {
+        if (!ShouldDisableToolbox()) {
+            Enable();
+        }
+        return;
+    }
+    if (ShouldDisableToolbox()) {
+        Disable();
+        return;
+    }
+
+    // When hooked, DrawImGuiFrame runs from inside GW's render pipeline via the
+    // frame draw callback. Otherwise (hook failed or not yet installed), run it here.
+    if (!Compositor::IsHooked()) {
+        DrawImGuiFrame(device);
+    }
+
+    // Render remaining draw lists (tooltips, popups, etc.).
+    // TB windows rendered during FrCacheRenderAll_Hook have their draw lists cleared,
+    // so this only draws what's left.
+    // Gate on CanRenderToolbox: without it, stale draw data from the last in-game
+    // frame would be rendered at character select (where DrawImGuiFrame bails early
+    // without producing a new frame).
+    if (CanRenderToolbox()) {
+        if (auto* draw_data = ImGui::GetDrawData())
+            ImGui_ImplDX9_RenderDrawData(draw_data);
+    }
 
     // Update and Render additional Platform Windows
+    auto& io = ImGui::GetIO();
     if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable) {
         ImGui::UpdatePlatformWindows();
         ImGui::RenderPlatformWindowsDefault();

--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -9,6 +9,7 @@
 
 #include <GWCA/GameEntities/Map.h>
 
+#include <GWCA/Managers/ChatMgr.h>
 #include <GWCA/Managers/MapMgr.h>
 #include <GWCA/Managers/MemoryMgr.h>
 #include <GWCA/Managers/RenderMgr.h>
@@ -553,6 +554,41 @@ namespace {
             case WM_MBUTTONUP:
                 if (io.WantCaptureKeyboard || io.WantTextInput) {
                     return true; // if imgui wants them, send just to imgui (above)
+                }
+
+                // Esc closes the topmost unpinned window in unified z-order.
+                if (Message == WM_KEYDOWN && wParam == VK_ESCAPE && !GW::Chat::GetIsTyping()) {
+                    // Find topmost closeable unpinned TB window
+                    ToolboxUIElement* topmost_tb = nullptr;
+                    uint64_t topmost_tb_z = 0;
+                    for (auto* el : GWToolbox::GetUIElements()) {
+                        if (!el->IsWindow() || !el->visible || el->pinned
+                            || el->unified_z_ == 0 || !el->GetVisiblePtr())
+                            continue;
+                        if (el->unified_z_ > topmost_tb_z) {
+                            topmost_tb_z = el->unified_z_;
+                            topmost_tb = el;
+                        }
+                    }
+                    // Find topmost closeable unpinned GW dialog.
+                    // Closeable = callback flag bit 0x1; pinned = position.flags bit 0x20.
+                    uint64_t topmost_gw_z = 0;
+                    for (const auto& w : Compositor::GetUnifiedZOrder().GetGWWindows()) {
+                        if (w.frame->position.flags & 0x20) continue; // pinned
+                        bool closeable = false;
+                        for (size_t i = 0; i < w.frame->frame_callbacks.size(); i++) {
+                            if (w.frame->frame_callbacks[i].h0008 & 0x1) {
+                                closeable = true;
+                                break;
+                            }
+                        }
+                        if (closeable && w.unified_z > topmost_gw_z)
+                            topmost_gw_z = w.unified_z;
+                    }
+                    if (topmost_tb && topmost_tb_z > topmost_gw_z) {
+                        topmost_tb->visible = false;
+                        return true;
+                    }
                 }
 
                 // send input to chat commands for camera movement
@@ -1100,6 +1136,7 @@ static void DrawImGuiFrame(IDirect3DDevice9* device)
             } else {
                 uielement->Draw(device);
             }
+            uielement->DrawPinButton();
         }
 
 #ifdef _DEBUG

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -1686,11 +1686,23 @@ void InventoryManager::Terminate()
 
 bool InventoryManager::WndProc(const UINT message, const WPARAM, const LPARAM)
 {
+    // Cache hovered item on right mouse down, because GW may dehover
+    // the item (e.g. by activating the mission map behind the inventory)
+    // before the click event fires.
+    static GW::Item* cached_rclick_item = nullptr;
+
     // GW Deliberately makes a WM_MOUSEMOVE event right after right button is pressed.
     // Does this to "hide" the cursor when looking around.
     switch (message) {
+        case WM_RBUTTONDOWN:
+            cached_rclick_item = GW::Items::GetHoveredItem();
+            break;
         case WM_GW_RBUTTONCLICK: {
-            const auto item = GW::Items::GetHoveredItem();
+            // Prefer live hovered item; fall back to cached if GW dehovers
+            // (e.g. mission map behind inventory activates on mouse-down).
+            auto item = GW::Items::GetHoveredItem();
+            if (!item) item = cached_rclick_item;
+            cached_rclick_item = nullptr;
             if (!item) break;
             GW::GameThread::Enqueue([item]() {
                 // Item right clicked - spoof a click event

--- a/GWToolboxdll/ToolboxUIElement.cpp
+++ b/GWToolboxdll/ToolboxUIElement.cpp
@@ -10,6 +10,8 @@
 #include <GWCA/GameEntities/Frame.h>
 #include <Utils/ToolboxUtils.h>
 
+#include <imgui_internal.h>
+
 
 namespace {
     constexpr ImVec2 empty_imvec2 = {0, 0};
@@ -246,6 +248,10 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
         ImGui::NextSpacedElement();
         ImGui::Checkbox("Show close button", &show_closebutton);
     }
+    if (has_pinbutton) {
+        ImGui::NextSpacedElement();
+        ImGui::Checkbox("Show pin button", &show_pinbutton);
+    }
     if (can_show_in_main_window) {
         ImGui::NextSpacedElement();
         if (ImGui::Checkbox("Show in main window", &show_menubutton)) {
@@ -306,4 +312,102 @@ bool ToolboxUIElement::DrawTabButton(const bool show_icon, const bool show_text,
     }
     ImGui::PopStyleColor();
     return clicked;
+}
+
+void ToolboxUIElement::DrawPinButton()
+{
+    if (!has_pinbutton || !show_pinbutton || !has_titlebar || !show_titlebar || !visible
+        || !GetVisiblePtr())
+        return;
+
+    auto* window = ImGui::FindWindowByName(Name());
+    if (!window || !window->Active || window->Hidden || window->Collapsed)
+        return;
+
+    ImGuiContext& g = *ImGui::GetCurrentContext();
+    const auto& style = g.Style;
+    const float button_sz = g.FontSize;
+
+    // Calculate title bar rect (same as ImGui's Begin)
+    const ImRect title_bar(window->Pos, ImVec2(window->Pos.x + window->Size.x,
+                                                 window->Pos.y + g.FontSize + style.FramePadding.y * 2.0f));
+
+    // Calculate pad_r: skip close button if present
+    float pad_r = style.FramePadding.x;
+    if (GetVisiblePtr() != nullptr) {
+        pad_r += button_sz + style.ItemInnerSpacing.x; // close button
+    }
+
+    const ImVec2 pin_pos(title_bar.Max.x - window->WindowBorderSize - pad_r - button_sz,
+                          title_bar.Min.y + style.FramePadding.y);
+    const ImRect bb(pin_pos, ImVec2(pin_pos.x + button_sz, pin_pos.y + button_sz));
+
+    // Manual hit testing (no need for CurrentWindow context)
+    const auto& mouse = ImGui::GetIO().MousePos;
+    const bool hovered = mouse.x >= bb.Min.x && mouse.x <= bb.Max.x &&
+                          mouse.y >= bb.Min.y && mouse.y <= bb.Max.y;
+    if (hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+        pinned = !pinned;
+    }
+
+    // Draw button background: pressed look when pinned, raised when not.
+    auto* dl = window->DrawList;
+    if (pinned) {
+        // Pressed/depressed: dark inset background
+        dl->AddRectFilled(bb.Min, bb.Max, ImGui::GetColorU32(ImGuiCol_FrameBg));
+        dl->AddRect(bb.Min, bb.Max, ImGui::GetColorU32(ImGuiCol_Border));
+    } else if (hovered) {
+        dl->AddRectFilled(bb.Min, bb.Max, ImGui::GetColorU32(ImGui::IsMouseDown(ImGuiMouseButton_Left) ? ImGuiCol_ButtonActive : ImGuiCol_ButtonHovered));
+    }
+
+    // Draw thumbtack icon.
+    // Pinned = pointing down (pushed in), unpinned = pointing left (pulled out).
+    const ImVec2 c = bb.GetCenter();
+    const ImU32 col = ImGui::GetColorU32(ImGuiCol_Text);
+    const float s = button_sz * 0.5f;
+    const float t = 1.0f * style._MainScale;
+
+    // Thumbtack shape: flat wide head, narrow body, thin needle.
+    // All coordinates relative to center, then rotated.
+    //   head:   wide horizontal bar (top)
+    //   body:   short tapered section
+    //   needle: thin line to tip
+    const float head_half_w = s * 0.55f;  // half-width of the flat head
+    const float head_h = s * 0.15f;       // height/thickness of head
+    const float body_h = s * 0.3f;        // height of body below head
+    const float body_half_w = s * 0.2f;   // half-width of body at top
+    const float needle_h = s * 0.45f;     // needle length
+
+    if (pinned) {
+        // Pointing down
+        const float top = c.y - s * 0.45f;
+        // Head (wide bar)
+        dl->AddRectFilled({c.x - head_half_w, top}, {c.x + head_half_w, top + head_h}, col);
+        // Body (trapezoid: wide at top, narrow at bottom)
+        dl->AddTriangleFilled(
+            {c.x - body_half_w, top + head_h},
+            {c.x + body_half_w, top + head_h},
+            {c.x, top + head_h + body_h}, col);
+        // Fill the rectangular part of the body
+        dl->AddRectFilled(
+            {c.x - body_half_w, top + head_h},
+            {c.x + body_half_w, top + head_h + body_h * 0.4f}, col);
+        // Needle
+        dl->AddLine({c.x, top + head_h + body_h}, {c.x, top + head_h + body_h + needle_h}, col, t);
+    } else {
+        // Pointing left (rotated 90° CW: down becomes left)
+        const float right = c.x + s * 0.45f;
+        // Head (tall bar on the right)
+        dl->AddRectFilled({right - head_h, c.y - head_half_w}, {right, c.y + head_half_w}, col);
+        // Body (trapezoid going left)
+        dl->AddTriangleFilled(
+            {right - head_h, c.y - body_half_w},
+            {right - head_h, c.y + body_half_w},
+            {right - head_h - body_h, c.y}, col);
+        dl->AddRectFilled(
+            {right - head_h - body_h * 0.4f, c.y - body_half_w},
+            {right - head_h, c.y + body_half_w}, col);
+        // Needle
+        dl->AddLine({right - head_h - body_h, c.y}, {right - head_h - body_h - needle_h, c.y}, col, t);
+    }
 }

--- a/GWToolboxdll/ToolboxUIElement.h
+++ b/GWToolboxdll/ToolboxUIElement.h
@@ -40,6 +40,7 @@ public:
     virtual void DrawSizeAndPositionSettings();
 
     bool visible = false;
+    bool pinned = false;
     bool lock_move = false;
     bool lock_size = false;
     bool show_menubutton = false;
@@ -54,10 +55,14 @@ public:
     bool has_titlebar = false;
     bool show_titlebar = true;
     bool show_closebutton = true;
+    bool show_pinbutton = true;
+
+    void DrawPinButton();
 
 protected:
     bool can_show_in_main_window = true;
     bool has_closebutton = false;
+    bool has_pinbutton = false;
     bool is_resizable = true;
     bool is_movable = true;
 

--- a/GWToolboxdll/ToolboxUIElement.h
+++ b/GWToolboxdll/ToolboxUIElement.h
@@ -44,6 +44,7 @@ public:
     bool lock_size = false;
     bool show_menubutton = false;
     bool auto_size = false;
+    uint64_t unified_z_ = 0;
 
     bool* GetVisiblePtr()
     {

--- a/GWToolboxdll/ToolboxWindow.h
+++ b/GWToolboxdll/ToolboxWindow.h
@@ -15,6 +15,7 @@ public:
     {
         ToolboxUIElement::Initialize();
         has_closebutton = true;
+        has_pinbutton = true;
         has_titlebar = true;
     }
 
@@ -22,11 +23,15 @@ public:
     {
         ToolboxUIElement::LoadSettings(ini);
         LOAD_BOOL(show_closebutton);
+        LOAD_BOOL(pinned);
+        LOAD_BOOL(show_pinbutton);
     }
 
     void SaveSettings(ToolboxIni* ini) override
     {
         ToolboxUIElement::SaveSettings(ini);
         SAVE_BOOL(show_closebutton);
+        SAVE_BOOL(pinned);
+        SAVE_BOOL(show_pinbutton);
     }
 };

--- a/GWToolboxdll/Utils/Compositor.cpp
+++ b/GWToolboxdll/Utils/Compositor.cpp
@@ -1,0 +1,798 @@
+#include "stdafx.h"
+
+#include "Compositor.h"
+
+#include <algorithm>
+
+#include <GWCA/GameContainers/Array.h>
+#include <GWCA/Managers/MapMgr.h>
+#include <GWCA/Managers/MemoryMgr.h>
+#include <GWCA/Managers/UIMgr.h>
+#include <GWCA/Utilities/Hooker.h>
+#include <GWCA/Utilities/Scanner.h>
+
+#include <imgui.h>
+#include <imgui_internal.h>
+#include <imgui_impl_dx9.h>
+#include <D3DContainers.h>
+#include <Utils/GuiUtils.h>
+
+namespace Compositor {
+
+    // -----------------------------------------------------------------------
+    // GW internal types
+    // -----------------------------------------------------------------------
+
+    enum FrCacheEntryType : uint32_t {
+        FRCACHE_GPU_RENDER      = 0,
+        FRCACHE_FRAME_CALLBACK  = 1,
+        FRCACHE_CLIENT_VIEWPORT = 2,
+        FRCACHE_FRAME_VIEWPORT  = 3,
+    };
+
+    struct FrCacheBufferEntry {
+        FrCacheEntryType type;
+        uint32_t index;  // into FrameArray (types 1/2/3) or SecondaryArray start (type 0)
+        uint32_t param;  // model count (type 0) or other
+    };
+
+    // -----------------------------------------------------------------------
+    // Scanned globals — resolved at hook install time via GW::Scanner
+    // -----------------------------------------------------------------------
+
+    // Pointers to GW's Array<T> globals (buffer, capacity, size, param — 16 bytes each)
+    static GW::Array<FrCacheBufferEntry>* s_RenderBuffer = nullptr;
+    static GW::Array<GW::UI::Frame*>* s_FrameArray = nullptr;
+    static GW::Array<GW::UI::Frame*>* s_OverlayList = nullptr; // overlay/popup root frames
+    static void** s_GrDev_Default = nullptr;
+
+    static IDirect3DDevice9* s_device = nullptr;
+
+    // -----------------------------------------------------------------------
+    // Hook types and state
+    // -----------------------------------------------------------------------
+
+    using FrCacheRenderFn = void(__cdecl*)(uint32_t, uint32_t);
+
+    // FrCache_RenderAll — hook on the buffer processing function
+    static FrCacheRenderFn FrCacheRenderAll_Original = nullptr;
+    static FrCacheRenderFn FrCacheRenderAll_Trampoline = nullptr;
+
+    using GrDevFlushQueuesFn = bool(__fastcall*)(void*);
+    static GrDevFlushQueuesFn GrDev_FlushQueues_Fn = nullptr;
+
+    // -----------------------------------------------------------------------
+    // UnifiedZOrder
+    // -----------------------------------------------------------------------
+
+    UnifiedZOrder& GetUnifiedZOrder()
+    {
+        static UnifiedZOrder instance;
+        return instance;
+    }
+
+    void UnifiedZOrder::Update()
+    {
+        auto* root = GW::UI::GetRootFrame();
+        if (!root) return;
+
+        // Discover floating windows from the overlay list (z > 0 = floating).
+        gw_windows_.clear();
+        current_frames_.clear();
+        if (s_OverlayList && s_OverlayList->m_buffer) {
+            auto& overlays = *s_OverlayList;
+            for (uint32_t k = 0; k < overlays.size(); k++) {
+                auto* frame = overlays[k];
+                if (!frame || !frame->field1_0x0) continue; // z == 0 → not floating
+                if (!frame->IsVisible()) continue;
+
+                current_frames_.insert(frame);
+                GWWindowInfo info{};
+                info.frame = frame;
+                const auto tl = frame->position.GetTopLeftOnScreen(root);
+                const auto br = frame->position.GetBottomRightOnScreen(root);
+                info.bounds = {tl.x, tl.y, br.x, br.y};
+                // Persist z across frames — only assign once when first visible
+                auto it = gw_z_.find(frame);
+                if (it != gw_z_.end()) {
+                    info.unified_z = it->second;
+                } else {
+                    info.unified_z = next_z_++;
+                    gw_z_[frame] = info.unified_z;
+                }
+                gw_windows_.push_back(info);
+            }
+        }
+
+        // Remove stale entries (closed windows or frames from a previous map)
+        for (auto it = gw_z_.begin(); it != gw_z_.end(); ) {
+            if (!current_frames_.count(it->first))
+                it = gw_z_.erase(it);
+            else
+                ++it;
+        }
+
+        // Build composite order: merge GW windows + TB windows, sort by z
+        composite_order_.clear();
+        for (const auto& w : gw_windows_) {
+            composite_order_.push_back({w.unified_z, false, nullptr, w.frame, w.bounds});
+        }
+        for (const auto& [name, z] : tb_z_) {
+            composite_order_.push_back({z, true, name.c_str(), nullptr, {}});
+        }
+        std::sort(composite_order_.begin(), composite_order_.end(),
+                  [](const CompositeEntry& a, const CompositeEntry& b) { return a.z < b.z; });
+    }
+
+    void UnifiedZOrder::OnWindowFocused(const char* tb_name)
+    {
+        tb_z_[tb_name] = next_z_++;
+    }
+
+    uint64_t UnifiedZOrder::GetZ(const char* tb_name) const
+    {
+        auto it = tb_z_.find(tb_name);
+        return it != tb_z_.end() ? it->second : 0;
+    }
+
+    void UnifiedZOrder::OnGWWindowClicked(float x, float y)
+    {
+        // Find the topmost GW window (highest GW z) under the cursor.
+        // The overlay list can contain parent containers that overlap their
+        // children — only bump the frontmost one.
+        GWWindowInfo* topmost = nullptr;
+        for (auto& w : gw_windows_) {
+            if (!w.bounds.ContainsPoint(x, y)) continue;
+            if (!topmost || w.frame->field1_0x0 > topmost->frame->field1_0x0)
+                topmost = &w;
+        }
+        if (topmost) {
+            topmost->unified_z = next_z_++;
+            gw_z_[topmost->frame] = topmost->unified_z;
+        }
+    }
+
+    uint64_t UnifiedZOrder::GetTopTBWindowZAtPoint(float x, float y) const
+    {
+        uint64_t best_z = 0;
+        for (const auto& [name, z] : tb_z_) {
+            auto* win = ImGui::FindWindowByName(name.c_str());
+            if (!win || !win->Active || win->Hidden) continue;
+            if (x >= win->Pos.x && x <= win->Pos.x + win->Size.x &&
+                y >= win->Pos.y && y <= win->Pos.y + win->Size.y) {
+                if (z > best_z) best_z = z;
+            }
+        }
+        return best_z;
+    }
+
+    // -----------------------------------------------------------------------
+    // Frame draw callback — invoked from FrCacheRenderAll_Hook before compositing
+    // -----------------------------------------------------------------------
+
+    static FrameDrawCallback s_frame_draw_callback = nullptr;
+    static bool s_hook_failed = false;
+
+    // -----------------------------------------------------------------------
+    // D3D rendering helpers
+    // -----------------------------------------------------------------------
+
+    struct D3DImGuiVertex { float pos[3]; D3DCOLOR col; float uv[2]; };
+    #define D3DFVF_IMGUI (D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1)
+    #ifndef IMGUI_USE_BGRA_PACKED_COLOR
+    #define IMGUI_COL_TO_DX9_ARGB(_COL) (((_COL) & 0xFF00FF00) | (((_COL) & 0xFF0000) >> 16) | (((_COL) & 0xFF) << 16))
+    #else
+    #define IMGUI_COL_TO_DX9_ARGB(_COL) (_COL)
+    #endif
+
+    // Set up D3D state for ImGui-style rendering (no state block management).
+    static void SetupImGuiD3DState(IDirect3DDevice9* device)
+    {
+        device->SetPixelShader(nullptr);
+        device->SetVertexShader(nullptr);
+        device->SetRenderState(D3DRS_FILLMODE, D3DFILL_SOLID);
+        device->SetRenderState(D3DRS_SHADEMODE, D3DSHADE_GOURAUD);
+        device->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+        device->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+        device->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
+        device->SetRenderState(D3DRS_ZENABLE, FALSE);
+        device->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
+        device->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD);
+        device->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
+        device->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
+        device->SetRenderState(D3DRS_SCISSORTESTENABLE, TRUE);
+        device->SetRenderState(D3DRS_FOGENABLE, FALSE);
+        device->SetRenderState(D3DRS_LIGHTING, FALSE);
+        device->SetRenderState(D3DRS_STENCILENABLE, FALSE);
+        device->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
+        device->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
+        device->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+        device->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_MODULATE);
+        device->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+        device->SetTextureStageState(0, D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+        device->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
+        device->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
+        device->SetSamplerState(0, D3DSAMP_MINFILTER, D3DTEXF_LINEAR);
+        device->SetSamplerState(0, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
+        device->SetFVF(D3DFVF_IMGUI);
+
+        const auto& io = ImGui::GetIO();
+        float L = 0.5f, R = io.DisplaySize.x + 0.5f;
+        float T = 0.5f, B = io.DisplaySize.y + 0.5f;
+        D3DMATRIX proj = { { {
+            2.0f/(R-L), 0, 0, 0,  0, 2.0f/(T-B), 0, 0,
+            0, 0, 0.5f, 0,  (L+R)/(L-R), (T+B)/(B-T), 0.5f, 1.0f,
+        } } };
+        D3DMATRIX identity = { { { 1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1 } } };
+        device->SetTransform(D3DTS_WORLD, &identity);
+        device->SetTransform(D3DTS_VIEW, &identity);
+        device->SetTransform(D3DTS_PROJECTION, &proj);
+
+        D3DVIEWPORT9 vp = {0, 0, (DWORD)io.DisplaySize.x, (DWORD)io.DisplaySize.y, 0, 1};
+        device->SetViewport(&vp);
+    }
+
+    // Render an ImDrawList directly. Assumes SetupImGuiD3DState was already called.
+    static void RenderImDrawListRaw(IDirect3DDevice9* device, ImDrawList* draw_list)
+    {
+        if (!draw_list || draw_list->CmdBuffer.Size == 0 || draw_list->VtxBuffer.Size == 0) return;
+
+        const int vtx_count = draw_list->VtxBuffer.Size;
+        static std::vector<D3DImGuiVertex> vertices;
+        vertices.resize(vtx_count);
+        for (int i = 0; i < vtx_count; i++) {
+            const auto& src = draw_list->VtxBuffer[i];
+            auto& dst = vertices[i];
+            dst.pos[0] = src.pos.x; dst.pos[1] = src.pos.y; dst.pos[2] = 0;
+            dst.col = IMGUI_COL_TO_DX9_ARGB(src.col);
+            dst.uv[0] = src.uv.x; dst.uv[1] = src.uv.y;
+        }
+
+        for (int cmd_i = 0; cmd_i < draw_list->CmdBuffer.Size; cmd_i++) {
+            const auto& cmd = draw_list->CmdBuffer[cmd_i];
+            if (cmd.ElemCount == 0) continue;
+            const RECT scissor = {
+                (LONG)cmd.ClipRect.x, (LONG)cmd.ClipRect.y,
+                (LONG)cmd.ClipRect.z, (LONG)cmd.ClipRect.w,
+            };
+            device->SetScissorRect(&scissor);
+            ImTextureID tex_id = cmd.TexRef._TexData ? cmd.TexRef._TexData->TexID : cmd.TexRef._TexID;
+            device->SetTexture(0, tex_id != ImTextureID_Invalid
+                ? static_cast<IDirect3DTexture9*>((void*)(intptr_t)tex_id) : nullptr);
+            device->DrawIndexedPrimitiveUP(D3DPT_TRIANGLELIST, 0, vtx_count,
+                cmd.ElemCount / 3,
+                draw_list->IdxBuffer.Data + cmd.IdxOffset,
+                sizeof(ImDrawIdx) == 2 ? D3DFMT_INDEX16 : D3DFMT_INDEX32,
+                vertices.data(), sizeof(D3DImGuiVertex));
+        }
+    }
+
+    // Render a TB window and all its children directly to the backbuffer.
+    // Assumes SetupImGuiD3DState was already called. Clears draw lists after rendering.
+    static void RenderTBWindowDirect(IDirect3DDevice9* device, const char* name)
+    {
+        auto* win = ImGui::FindWindowByName(name);
+        if (!win || !win->Active || win->Hidden) return;
+        auto& ctx = *ImGui::GetCurrentContext();
+        for (int j = 0; j < ctx.Windows.Size; j++) {
+            auto* child = ctx.Windows[j];
+            if (!child->Active || child->Hidden) continue;
+            if (child->Flags & (ImGuiWindowFlags_Tooltip | ImGuiWindowFlags_Popup)) continue;
+            auto* p = child;
+            while (p && p != win) p = p->ParentWindow;
+            if (p != win) continue;
+            RenderImDrawListRaw(device, child->DrawList);
+            child->DrawList->CmdBuffer.resize(0);
+        }
+    }
+
+    void RenderImGuiWindow(IDirect3DDevice9* device, const char* window_name)
+    {
+        if (!device || !window_name) return;
+        SetupImGuiD3DState(device);
+        RenderTBWindowDirect(device, window_name);
+    }
+
+    // -----------------------------------------------------------------------
+    // Overlay callbacks — modules register these, composited at the right z
+    // -----------------------------------------------------------------------
+
+    struct OverlayCallbackEntry {
+        const wchar_t* gw_frame_label = nullptr;
+        OverlayRenderCallback callback;
+        std::function<void()> prepare_fn; // called during ImGui frame (before EndFrame)
+        int priority = 0;              // lower renders first within same frame
+        GW::UI::Frame* resolved_frame = nullptr; // cached per frame
+        bool rendered = false;
+    };
+
+    static std::vector<OverlayCallbackEntry> s_overlay_callbacks;
+
+    void RegisterOverlayCallback(const wchar_t* gw_frame_label, OverlayRenderCallback callback, int priority)
+    {
+        s_overlay_callbacks.push_back({gw_frame_label, std::move(callback), {}, priority});
+        std::stable_sort(s_overlay_callbacks.begin(), s_overlay_callbacks.end(),
+            [](const auto& a, const auto& b) { return a.priority < b.priority; });
+    }
+
+    void RegisterImGuiOverlay(const wchar_t* gw_frame_label, ImGuiOverlayCallback draw_fn, int priority)
+    {
+        // The draw_fn may call ImGui functions (e.g. SetTooltip) that require an
+        // active frame scope.  We split into two phases:
+        //   prepare_fn — runs during the ImGui frame (before EndFrame), builds the
+        //                ImDrawList and allows ImGui calls.
+        //   callback   — runs during compositing, renders the cached draw list.
+        auto cached_dl = std::make_shared<ImDrawList>(nullptr);
+
+        auto prepare = [gw_frame_label, draw_fn, cached_dl]() {
+            cached_dl->_Data = ImGui::GetDrawListSharedData();
+            cached_dl->_ResetForNewFrame();
+            cached_dl->PushTexture(ImGui::GetIO().Fonts->TexRef);
+            if (gw_frame_label) {
+                auto* root = GW::UI::GetRootFrame();
+                auto* frame = GW::UI::GetFrameByLabel(gw_frame_label);
+                if (frame && root) {
+                    auto tl = frame->position.GetContentTopLeft(root);
+                    auto br = frame->position.GetContentBottomRight(root);
+                    cached_dl->PushClipRect({tl.x, tl.y}, {br.x, br.y});
+                } else {
+                    cached_dl->PushClipRectFullScreen();
+                }
+            } else {
+                cached_dl->PushClipRectFullScreen();
+            }
+            draw_fn(*cached_dl);
+        };
+
+        auto render = [cached_dl](IDirect3DDevice9* device) {
+            if (cached_dl->CmdBuffer.Size == 0 || cached_dl->VtxBuffer.Size == 0) return;
+            SetupImGuiD3DState(device);
+            RenderImDrawListRaw(device, cached_dl.get());
+        };
+
+        OverlayCallbackEntry entry;
+        entry.gw_frame_label = gw_frame_label;
+        entry.callback = std::move(render);
+        entry.prepare_fn = std::move(prepare);
+        entry.priority = priority;
+        s_overlay_callbacks.push_back(std::move(entry));
+        std::stable_sort(s_overlay_callbacks.begin(), s_overlay_callbacks.end(),
+            [](const auto& a, const auto& b) { return a.priority < b.priority; });
+    }
+
+    void PrepareOverlays()
+    {
+        for (auto& cb : s_overlay_callbacks) {
+            if (cb.prepare_fn) cb.prepare_fn();
+        }
+    }
+
+
+    static void ResetOverlayCallbacks()
+    {
+        for (auto& cb : s_overlay_callbacks) {
+            cb.resolved_frame = cb.gw_frame_label
+                ? GW::UI::GetFrameByLabel(cb.gw_frame_label) : nullptr;
+            cb.rendered = false;
+        }
+    }
+
+    bool IsPointOccludedByGW(float x, float y, uint64_t tb_z)
+    {
+        if (tb_z == 0) return false;
+        // TB widgets render on top of all GW content when the world map is showing.
+        if (GW::UI::GetIsWorldMapShowing()) return false;
+        auto& zo = GetUnifiedZOrder();
+        for (const auto& w : zo.GetGWWindows()) {
+            if (w.unified_z > tb_z && w.bounds.ContainsPoint(x, y))
+                return true;
+        }
+        return false;
+    }
+
+    uint64_t GetHoveredTBWindowZ()
+    {
+        auto& zo = GetUnifiedZOrder();
+        // Check hovered window
+        auto* hovered = ImGui::GetCurrentContext()->HoveredWindow;
+        if (hovered) {
+            while (hovered->ParentWindow) hovered = hovered->ParentWindow;
+            uint64_t z = zo.GetZ(hovered->Name);
+            if (z > 0) return z;
+        }
+        // Check active window (for in-progress drags)
+        auto* active = ImGui::GetCurrentContext()->ActiveIdWindow;
+        if (active) {
+            while (active->ParentWindow) active = active->ParentWindow;
+            uint64_t z = zo.GetZ(active->Name);
+            if (z > 0) return z;
+        }
+        // Geometric fallback: when we previously hid the mouse from ImGui (set to
+        // -FLT_MAX), HoveredWindow gets cleared next frame. Without this fallback
+        // the occlusion check fails every other frame, causing one-frame hover
+        // flicker. Resolve the real cursor position and hit-test TB windows directly.
+        auto& io = ImGui::GetIO();
+        float mx = io.MousePos.x, my = io.MousePos.y;
+        if (mx == -FLT_MAX) {
+            POINT pt;
+            if (!GetCursorPos(&pt)) return 0;
+            HWND hwnd = GW::MemoryMgr::GetGWWindowHandle();
+            if (!hwnd) return 0;
+            ScreenToClient(hwnd, &pt);
+            mx = (float)pt.x;
+            my = (float)pt.y;
+        }
+        return zo.GetTopTBWindowZAtPoint(mx, my);
+    }
+
+    // -----------------------------------------------------------------------
+    // FrCacheRenderAll hook — re-implements buffer processing with TB injection
+    // -----------------------------------------------------------------------
+
+    // Flush GW's GPU command queue so enqueued commands become D3D calls.
+    // Only safe when device->m_queueFlushing == 3 (GR_QUEUES).
+    static void FlushGWCommandQueue()
+    {
+        if (!GrDev_FlushQueues_Fn || !s_GrDev_Default) return;
+        auto* device = *s_GrDev_Default;
+        if (!device) return;
+        // Check m_queueFlushing at device+0x1CC — must be 3 to flush safely
+        int queue_state = *reinterpret_cast<int*>(reinterpret_cast<uintptr_t>(device) + 0x1CC);
+        if (queue_state == 3) {
+            GrDev_FlushQueues_Fn(device);
+        }
+    }
+
+    // Manages a single D3D state block for GW<->TB transitions during compositing.
+    // EnterTBState saves GW state (once) and sets up ImGui rendering state.
+    // EnterGWState restores the saved GW state.
+    struct StateTransition {
+        IDirect3DDevice9* device = nullptr;
+        IDirect3DStateBlock9* sb = nullptr;
+        bool in_tb_state = false;
+
+        void Init(IDirect3DDevice9* dev) { device = dev; }
+
+        void EnterTBState() {
+            if (in_tb_state) return;
+            FlushGWCommandQueue();
+            if (!sb)
+                device->CreateStateBlock(D3DSBT_ALL, &sb);
+            if (sb) sb->Capture(); // re-capture current GW state each time
+            SetupImGuiD3DState(device);
+            in_tb_state = true;
+        }
+
+        void EnterGWState() {
+            if (!in_tb_state) return;
+            if (sb) sb->Apply();
+            in_tb_state = false;
+        }
+
+        void Release() {
+            if (sb) { if (in_tb_state) sb->Apply(); sb->Release(); sb = nullptr; }
+            in_tb_state = false;
+        }
+    };
+
+    // Run all matching overlay callbacks. Caller manages state transitions.
+    static void RunOverlayCallbacks(StateTransition& st,
+        std::function<bool(OverlayCallbackEntry&)> predicate)
+    {
+        for (auto& cb : s_overlay_callbacks) {
+            if (cb.rendered) continue;
+            if (!predicate(cb)) continue;
+            st.EnterTBState();
+            cb.callback(st.device);
+            cb.rendered = true;
+        }
+    }
+
+    void __cdecl FrCacheRenderAll_Hook(uint32_t param_1, uint32_t param_2)
+    {
+        GW::Hook::EnterHook();
+
+        // Run the TB draw callback so ImGui draw lists are ready for
+        // compositing. BuildRenderList has already finished at this point
+        // (called by the original FrCache_Render before RenderAll).
+        if (s_frame_draw_callback && s_device) {
+            s_frame_draw_callback(s_device);
+        }
+
+        auto& zo = GetUnifiedZOrder();
+        const auto& composite = zo.GetCompositeOrder();
+
+        // Skip z-interleaving when the world map is showing. The world map
+        // renders via the ZSort layer which sits above all overlays in the
+        // buffer. TB widgets that ShowOnWorldMap() render after all GW content.
+        if (GW::UI::GetIsWorldMapShowing() || composite.empty() || !s_device) {
+            FrCacheRenderAll_Trampoline(param_1, param_2);
+            // Still run base-UI overlay callbacks (e.g. world map annotations)
+            if (s_device) {
+                StateTransition st;
+                st.Init(s_device);
+                RunOverlayCallbacks(st, [](OverlayCallbackEntry& cb) {
+                    return !cb.gw_frame_label;
+                });
+                st.Release();
+            }
+            ResetOverlayCallbacks();
+            GW::Hook::LeaveHook();
+            return;
+        }
+
+        // Pre-scan the buffer for popup boundaries.  Only use type 2/3
+        // (viewport) entries as boundaries — NOT type 1 (callback).
+        //
+        // Reason: the trampoline's local viewport variables are uninitialized
+        // at function entry and only set by type 2/3 entries.  If a segment
+        // starts with a type 1 callback, the callback receives stack garbage
+        // as viewport parameters (whatever prior functions left on the stack).
+        // By restricting boundaries to viewport entries, the trampoline's
+        // first action is always to set the viewport locals, avoiding the
+        // uninitialized-variable issue.
+        auto& buffer = *s_RenderBuffer;
+        auto& frames = *s_FrameArray;
+
+        struct PopupBoundary { uint32_t buf_idx; GW::UI::Frame* frame; uint64_t z; };
+        static std::vector<PopupBoundary> boundaries;
+        boundaries.clear();
+        GW::UI::Frame* last_popup = nullptr;
+
+        for (uint32_t i = 0; i < buffer.size(); i++) {
+            const auto& entry = buffer[i];
+            if (entry.type != FRCACHE_CLIENT_VIEWPORT && entry.type != FRCACHE_FRAME_VIEWPORT)
+                continue;
+            if (entry.index >= frames.size()) continue;
+            auto* frame = frames[entry.index];
+            if (!frame || !(frame->field92_0x190 & 0x20) || frame == last_popup) continue;
+            // Find this popup frame in the composite order
+            for (const auto& ce : composite) {
+                if (!ce.is_tb && ce.gw_frame == frame) {
+                    boundaries.push_back({i, frame, ce.z});
+                    last_popup = frame;
+                    break;
+                }
+            }
+        }
+
+        // Process the buffer in segments, calling the trampoline for each
+        // segment and injecting TB content at popup boundaries.
+        auto* original_buffer = buffer.m_buffer;
+        auto original_size = buffer.m_size;
+
+        static std::vector<bool> tb_drawn;
+        tb_drawn.assign(composite.size(), false);
+        bool base_overlays_rendered = false;
+        GW::UI::Frame* current_floating = nullptr;
+        StateTransition st;
+        st.Init(s_device);
+        uint32_t seg_start = 0;
+
+        for (const auto& boundary : boundaries) {
+            // Let GW process entries [seg_start, boundary.buf_idx) via trampoline
+            if (boundary.buf_idx > seg_start) {
+                st.EnterGWState();
+                buffer.m_buffer = original_buffer + seg_start;
+                buffer.m_size = boundary.buf_idx - seg_start;
+                FrCacheRenderAll_Trampoline(param_1, param_2);
+            }
+
+            // Before the first popup: render base UI overlays AND any
+            // frame-specific overlays for non-popup frames.
+            if (!base_overlays_rendered) {
+                base_overlays_rendered = true;
+                RunOverlayCallbacks(st, [](OverlayCallbackEntry& cb) {
+                    if (!cb.gw_frame_label) return true; // base UI
+                    auto* frame = GW::UI::GetFrameByLabel(cb.gw_frame_label);
+                    bool is_popup = frame && (frame->field92_0x190 & 0x20);
+                    return !is_popup; // non-popup overlays render with base UI
+                });
+            }
+
+            // Render callbacks for the PREVIOUS popup (its content just finished)
+            if (current_floating) {
+                RunOverlayCallbacks(st, [current_floating](OverlayCallbackEntry& cb) {
+                    if (!cb.gw_frame_label) return false;
+                    return GW::UI::GetFrameByLabel(cb.gw_frame_label) == current_floating;
+                });
+            }
+
+            // Render TB windows with z < popup_z directly to the backbuffer
+            for (size_t ci = 0; ci < composite.size(); ci++) {
+                if (tb_drawn[ci] || !composite[ci].is_tb || composite[ci].z >= boundary.z)
+                    continue;
+                st.EnterTBState();
+                RenderTBWindowDirect(s_device, composite[ci].tb_name);
+                tb_drawn[ci] = true;
+            }
+
+            current_floating = boundary.frame;
+            seg_start = boundary.buf_idx;
+        }
+
+        // Process remaining entries after the last boundary
+        st.EnterGWState();
+        buffer.m_buffer = original_buffer + seg_start;
+        buffer.m_size = original_size - seg_start;
+        FrCacheRenderAll_Trampoline(param_1, param_2);
+
+        // Restore original buffer state
+        buffer.m_buffer = original_buffer;
+        buffer.m_size = original_size;
+
+        // Render any callbacks/overlays that weren't rendered during popup processing.
+        if (s_device) {
+            RunOverlayCallbacks(st, [](OverlayCallbackEntry& cb) {
+                if (cb.gw_frame_label) {
+                    auto* frame = GW::UI::GetFrameByLabel(cb.gw_frame_label);
+                    if (!frame || !frame->IsVisible())
+                        return false;
+                }
+                return true;
+            });
+        }
+
+        // Render any TB windows not yet drawn
+        for (size_t ci = 0; ci < composite.size(); ci++) {
+            if (tb_drawn[ci] || !composite[ci].is_tb) continue;
+            st.EnterTBState();
+            RenderTBWindowDirect(s_device, composite[ci].tb_name);
+            tb_drawn[ci] = true;
+        }
+
+        // Restore GW state and release the state block
+        st.Release();
+
+        ResetOverlayCallbacks();
+        GW::Hook::LeaveHook();
+    }
+
+    // -----------------------------------------------------------------------
+    // Device management
+    // -----------------------------------------------------------------------
+
+    void SetDevice(IDirect3DDevice9* device)
+    {
+        if (s_device != device) {
+            ReleaseDeviceResources();
+        }
+        s_device = device;
+    }
+
+    void ReleaseDeviceResources()
+    {
+        if (FrCacheRenderAll_Original) {
+            GW::Hook::DisableHooks(FrCacheRenderAll_Original);
+            GW::Hook::RemoveHook(FrCacheRenderAll_Original);
+            FrCacheRenderAll_Original = nullptr;
+            FrCacheRenderAll_Trampoline = nullptr;
+        }
+        s_frame_draw_callback = nullptr;
+        s_hook_failed = false;
+        s_RenderBuffer = nullptr;
+        s_FrameArray = nullptr;
+        s_OverlayList = nullptr;
+        s_GrDev_Default = nullptr;
+    }
+
+    // -----------------------------------------------------------------------
+    // Hook installation
+    // -----------------------------------------------------------------------
+
+    bool IsHooked()
+    {
+        return FrCacheRenderAll_Original != nullptr;
+    }
+
+    bool HookFrCacheRender()
+    {
+        if (FrCacheRenderAll_Original) return true;
+        if (s_hook_failed) return false;
+
+        // ---- Scan for anchor functions via assertions and string references ----
+
+        // FrCache_RenderAll: asserts "frame" in FrCache.cpp at line 0x9e (case 2).
+        // Assertion is ~0x120 bytes into the function, so extend scan range.
+        auto render_all_addr = GW::Scanner::ToFunctionStart(
+            GW::Scanner::FindAssertion("FrCache.cpp", "frame", 0x9e, 0), 0x200);
+        if (!render_all_addr) {
+            Log::Warning("Compositor: failed to find FrCache_RenderAll, z-interleaving disabled");
+            s_hook_failed = true;
+            return false;
+        }
+
+        // FrCache_Render: only caller of FrCache_RenderAll — scan backward for CALL to it
+        uintptr_t render_addr = 0;
+        for (auto a = render_all_addr - 5; a > render_all_addr - 0x100; a--) {
+            if (*reinterpret_cast<uint8_t*>(a) == 0xE8) {
+                if (GW::Scanner::FunctionFromNearCall(a) == render_all_addr) {
+                    render_addr = GW::Scanner::ToFunctionStart(a);
+                    break;
+                }
+            }
+        }
+        if (!render_addr) {
+            Log::Warning("Compositor: failed to find FrCache_Render, z-interleaving disabled");
+            s_hook_failed = true;
+            return false;
+        }
+
+        // GrDev_FlushQueues: asserts "m_queueFlushing == GR_QUEUES" in GrDev.cpp
+        auto flush_queues_addr = GW::Scanner::ToFunctionStart(
+            GW::Scanner::FindAssertion("GrDev.cpp", "m_queueFlushing == GR_QUEUES", 0, 0));
+        GrDev_FlushQueues_Fn = reinterpret_cast<GrDevFlushQueuesFn>(flush_queues_addr);
+
+        // ---- Extract globals from FrCache_Render ----
+
+        // FrCache_Render starts with: CMP dword ptr [RenderFrameList.m_size], 0
+        // Bytes at offset +3: 83 3D [addr32] 00
+        // The 4-byte address at render_addr+5 is RenderFrameList.m_size.
+        // The Array<T> structs are consecutive (16 bytes each):
+        //   RenderFrameList, FrameArray, SecondaryArray, RenderBuffer, ZSortList, OverlayList
+        auto frame_list_size_addr = *reinterpret_cast<uintptr_t*>(render_addr + 5);
+        auto frame_list_base = frame_list_size_addr - 8; // m_size is at +8 in Array<T>
+        s_FrameArray = reinterpret_cast<GW::Array<GW::UI::Frame*>*>(frame_list_base + 0x10);
+        s_RenderBuffer = reinterpret_cast<GW::Array<FrCacheBufferEntry>*>(frame_list_base + 0x30);
+        s_OverlayList = reinterpret_cast<GW::Array<GW::UI::Frame*>*>(frame_list_base + 0x50);
+
+        // GrDev_Default: FrCache_SetViewport loads the device global early in its
+        // body. We find SetViewport via its assertion but only need the global,
+        // not the function pointer.
+        auto set_viewport_addr = GW::Scanner::ToFunctionStart(
+            GW::Scanner::FindAssertion("GrDev.cpp", "viewport.x0 >= 0", 0, 0));
+        if (set_viewport_addr) {
+            for (auto a = set_viewport_addr; a < set_viewport_addr + 0x80; a++) {
+                auto b = *reinterpret_cast<uint8_t*>(a);
+                if (b == 0xA1) { // MOV EAX, [addr32]
+                    auto addr = *reinterpret_cast<uintptr_t*>(a + 1);
+                    if (GW::Scanner::IsValidPtr(addr)) {
+                        s_GrDev_Default = reinterpret_cast<void**>(addr);
+                        break;
+                    }
+                }
+                if (b == 0x8B && (*reinterpret_cast<uint8_t*>(a + 1) & 0xC7) == 0x05) {
+                    auto addr = *reinterpret_cast<uintptr_t*>(a + 2);
+                    if (GW::Scanner::IsValidPtr(addr)) {
+                        s_GrDev_Default = reinterpret_cast<void**>(addr);
+                        break;
+                    }
+                }
+            }
+        }
+
+        // ---- Verify all pointers resolved ----
+#ifdef _DEBUG
+        ASSERT(GrDev_FlushQueues_Fn);
+        ASSERT(s_RenderBuffer);
+        ASSERT(s_FrameArray);
+        ASSERT(s_GrDev_Default);
+#endif
+        if (!GrDev_FlushQueues_Fn ||
+            !s_RenderBuffer || !s_FrameArray || !s_GrDev_Default) {
+            Log::Warning("Compositor: one or more function pointers failed to resolve, z-interleaving disabled");
+            s_hook_failed = true;
+            return false;
+        }
+
+        // ---- Install hooks ----
+
+        FrCacheRenderAll_Original = reinterpret_cast<FrCacheRenderFn>(render_all_addr);
+        GW::Hook::CreateHook(reinterpret_cast<void**>(&FrCacheRenderAll_Original),
+                              FrCacheRenderAll_Hook,
+                              reinterpret_cast<void**>(&FrCacheRenderAll_Trampoline));
+        GW::Hook::EnableHooks(FrCacheRenderAll_Original);
+
+        return true;
+    }
+
+    // -----------------------------------------------------------------------
+    // Frame draw callback management
+    // -----------------------------------------------------------------------
+
+    void SetFrameDrawCallback(FrameDrawCallback callback)
+    {
+        s_frame_draw_callback = callback;
+    }
+
+}

--- a/GWToolboxdll/Utils/Compositor.h
+++ b/GWToolboxdll/Utils/Compositor.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <vector>
+#include <unordered_map>
+#include <unordered_set>
+#include <string>
+#include <functional>
+#include <d3d9.h>
+
+#include <GWCA/Managers/UIMgr.h>
+
+namespace Compositor {
+
+    struct ScreenRect {
+        float left, top, right, bottom;
+
+        bool Overlaps(const ScreenRect& other) const {
+            return left < other.right && right > other.left &&
+                   top < other.bottom && bottom > other.top;
+        }
+
+        bool ContainsPoint(float x, float y) const {
+            return x >= left && x <= right && y >= top && y <= bottom;
+        }
+
+        bool IsValid() const { return right > left && bottom > top; }
+    };
+
+    // Unified z-order tracker for TB (ImGui) and GW windows.
+    class UnifiedZOrder {
+    public:
+        void Update();
+        void OnWindowFocused(const char* tb_name);
+        uint64_t GetZ(const char* tb_name) const;
+        void OnGWWindowClicked(float x, float y);
+
+        struct GWWindowInfo {
+            GW::UI::Frame* frame;
+            ScreenRect bounds;
+            uint64_t unified_z;
+        };
+
+        // Merged z-order entry for compositing
+        struct CompositeEntry {
+            uint64_t z;
+            bool is_tb;              // true=TB window, false=GW window
+            const char* tb_name;     // if TB
+            GW::UI::Frame* gw_frame; // if GW
+            ScreenRect bounds;
+        };
+
+        // Build the merged z-order list for the current frame.
+        const std::vector<CompositeEntry>& GetCompositeOrder() const { return composite_order_; }
+
+        const std::vector<GWWindowInfo>& GetGWWindows() const { return gw_windows_; }
+
+        // Geometric hit-test: find the topmost (highest z) TB window at the given point.
+        uint64_t GetTopTBWindowZAtPoint(float x, float y) const;
+
+    private:
+        uint64_t next_z_ = 1;
+        std::unordered_map<std::string, uint64_t> tb_z_;
+        std::unordered_map<GW::UI::Frame*, uint64_t> gw_z_; // persistent z per GW overlay frame
+        std::unordered_set<GW::UI::Frame*> current_frames_;  // reused each frame
+        std::vector<GWWindowInfo> gw_windows_;
+        std::vector<CompositeEntry> composite_order_;
+    };
+
+    UnifiedZOrder& GetUnifiedZOrder();
+
+    // Install hooks on GW's render pipeline.
+    // Returns true if hooks are active, false if scanning failed (renders TB on top).
+    bool HookFrCacheRender();
+
+    // Returns true if the render pipeline hooks are installed and active.
+    bool IsHooked();
+
+    // Store D3D device for use during hooks.
+    void SetDevice(IDirect3DDevice9* device);
+
+    // Register a callback that runs the ImGui frame cycle (NewFrame through Render).
+    // Called from FrCacheRender_Hook before GW's render pass so draw lists are fresh.
+    using FrameDrawCallback = void(*)(IDirect3DDevice9*);
+    void SetFrameDrawCallback(FrameDrawCallback callback);
+
+    // Release all D3D resources (call on device reset).
+    void ReleaseDeviceResources();
+
+    // Register an overlay callback for a specific GW frame (or nullptr for base UI).
+    // Lower priority renders first within the same GW frame.
+    // Callbacks persist across frames — register once during Initialize.
+    using OverlayRenderCallback = std::function<void(IDirect3DDevice9*)>;
+    void RegisterOverlayCallback(const wchar_t* gw_frame_label, OverlayRenderCallback callback, int priority = 0);
+
+    // Convenience: register an ImGui-style overlay. The draw function receives a
+    // draw list that is automatically clipped to the GW frame bounds and rendered.
+    using ImGuiOverlayCallback = std::function<void(ImDrawList&)>;
+    void RegisterImGuiOverlay(const wchar_t* gw_frame_label, ImGuiOverlayCallback draw_fn, int priority = 0);
+
+    // Run the prepare phase of ImGui overlay callbacks.  Must be called during the
+    // ImGui frame (before EndFrame) so that draw_fns can use ImGui functions like
+    // SetTooltip.  The resulting draw lists are cached and rendered later during
+    // compositing.
+    void PrepareOverlays();
+
+    // Render a named ImGui window's draw list directly to the backbuffer, then clear it
+    // so the normal TB compositing skips it. Sets up ImGui D3D state; expects the caller
+    // (or the compositing loop) to manage the outer state block.
+    void RenderImGuiWindow(IDirect3DDevice9* device, const char* window_name);
+
+    // Check if a screen point is occluded by a GW window that's above the given TB window.
+    // Returns true if the point is over a GW floating window with higher z than tb_z.
+    bool IsPointOccludedByGW(float x, float y, uint64_t tb_z);
+
+    // Find the z-value of the TB window under the cursor (from ImGui hover/active state).
+    // Returns 0 if no tracked TB window is under the cursor.
+    uint64_t GetHoveredTBWindowZ();
+}

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -8,6 +8,7 @@
 #include <GWCA/GameEntities/Camera.h>
 #include <GWCA/Packets/StoC.h>
 
+
 #include <GWCA/GameEntities/Agent.h>
 #include <GWCA/GameEntities/Hero.h>
 #include <GWCA/GameEntities/Party.h>
@@ -633,7 +634,6 @@ namespace {
         //           is rotated.
         // -------------------------------------------------------------------------
         ImDrawList* draw_list = ImGui::GetBackgroundDrawList();
-
         // Single font with dynamic scaling to the desired cardinal size.
         ImFont* font = FontLoader::GetFont();
         const float render_size = cardinal_font_size;

--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -1,5 +1,7 @@
 #include "stdafx.h"
 
+#include <map>
+
 #include <GWCA/Context/GameplayContext.h>
 #include <GWCA/GameEntities/Agent.h>
 #include <GWCA/Managers/AgentMgr.h>
@@ -16,6 +18,7 @@
 #include <Utils/ToolboxUtils.h>
 #include <GWCA/Context/WorldContext.h>
 #include <D3DContainers.h>
+#include <Utils/Compositor.h>
 
 namespace {
     bool draw_all_terrain_lines = false;
@@ -160,6 +163,12 @@ namespace {
         GW::Hook::EnterHook();
         if (message->message_id == GW::UI::UIMessage::kDestroyFrame) mission_map_frame = nullptr;
 
+        // Set a breakpoint on the next line and add condition: message->message_id == 0x35
+        if (message->message_id == GW::UI::UIMessage::kRenderFrame_0x31) {
+            volatile int break_here = 1; // <-- breakpoint here, then check Call Stack
+            (void)break_here;
+        }
+
         OnMissionMap_UICallback_Ret(message, wparam, lparam);
         if (message->message_id == GW::UI::UIMessage::kInitFrame) mission_map_frame = GW::UI::GetFrameById(message->frame_id);
         GW::Hook::LeaveHook();
@@ -287,6 +296,30 @@ namespace {
     }
 } // namespace
 
+void MissionMapWidget::Initialize()
+{
+    ToolboxWidget::Initialize();
+    Compositor::RegisterImGuiOverlay(L"MapWindow", [this](ImDrawList& draw_list) {
+        if (!visible || !render_ready || !mission_map_frame || !mission_map_frame->IsVisible()) return;
+        const auto& lines = Minimap::Instance().custom_renderer.GetLines();
+        const auto map_id = GW::Map::GetMapID();
+        const auto player_pos = GW::PlayerMgr::GetPlayerPosition();
+        for (const auto& line : lines) {
+            if (!line->visible) continue;
+            if (!line->draw_on_mission_map && !(draw_all_minimap_lines && line->draw_on_minimap) && !(draw_all_terrain_lines && line->draw_on_terrain)) continue;
+            if (line->map != map_id) continue;
+            float sx1, sy1, sx2, sy2;
+            if (line->from_player_pos && player_pos) {
+                g2s.Project(player_pos->x, player_pos->y, sx1, sy1);
+            } else {
+                g2s.Project(line->p1.x, line->p1.y, sx1, sy1);
+            }
+            g2s.Project(line->p2.x, line->p2.y, sx2, sy2);
+            draw_list.AddLine({sx1, sy1}, {sx2, sy2}, line->color, 2.0f);
+        }
+    });
+}
+
 void MissionMapWidget::LoadSettings(ToolboxIni* ini)
 {
     ToolboxWidget::LoadSettings(ini);
@@ -301,11 +334,9 @@ void MissionMapWidget::SaveSettings(ToolboxIni* ini)
     SAVE_BOOL(draw_all_minimap_lines);
 }
 
-void MissionMapWidget::Draw(IDirect3DDevice9* dx_device)
+void MissionMapWidget::Draw(IDirect3DDevice9*)
 {
     if (!visible || !GW::Map::GetIsMapLoaded() || !mission_map_frame || !mission_map_frame->IsVisible()) return;
-
-    SubmitVertexBuffers(dx_device);
     HookMissionMapFrame();
 }
 

--- a/GWToolboxdll/Widgets/MissionMapWidget.h
+++ b/GWToolboxdll/Widgets/MissionMapWidget.h
@@ -27,6 +27,7 @@ public:
     [[nodiscard]] const char* Name() const override { return "Mission Map"; }
     [[nodiscard]] const char* Icon() const override { return ICON_FA_GLOBE; }
 
+    void Initialize() override;
     void LoadSettings(ToolboxIni*) override;
     void SaveSettings(ToolboxIni*) override;
     void Draw(IDirect3DDevice9* pDevice) override;

--- a/GWToolboxdll/Widgets/SkillMonitorWidget.cpp
+++ b/GWToolboxdll/Widgets/SkillMonitorWidget.cpp
@@ -246,7 +246,8 @@ void SkillMonitorWidget::Draw(IDirect3DDevice9*)
 
     if (ImGui::Begin(Name(), &visible, GetWinFlags())) {
         const auto draw_list = ImGui::GetWindowDrawList();
-
+        GW::UI::Frame* cast_party_frame = nullptr;
+        GetPartyWindowHealthBars(&cast_party_frame);
         for (auto& [agent_id, party_slot] : party_indeces_by_agent_id) {
 
             if (party_slot >= pets_start_idx && party_slot < allies_start_idx)

--- a/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
+++ b/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
@@ -15,6 +15,7 @@
 #include <ImGuiAddons.h>
 #include <Timer.h>
 #include <Modules/QuestModule.h>
+#include <Utils/Compositor.h>
 #include <Utils/ToolboxUtils.h>
 #include <Widgets/MissionMapWidget.h>
 #include <Widgets/VanquishMapOverlayWidget.h>
@@ -149,6 +150,8 @@ namespace {
         }
         return false;
     }
+
+    const D3DMATRIX IDENTITY_MATRIX = {{1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f}};
 
     bool IsFrontierEdge(int idx)
     {
@@ -839,9 +842,9 @@ namespace {
         compass_circle = D3DCircle({0.f, 0.f}, COMPASS_RANGE, COMPASS_CIRCLE_THICKNESS_PX * cached_px_to_game, (DWORD)vq_color_compass, COMPASS_CIRCLE_SEGMENTS);
     }
 
-    void DrawEnemyCountLabel()
+    void DrawEnemyCountLabel(ImDrawList& draw_list)
     {
-        if (!should_draw) return;
+        if (!should_draw || !MissionMapWidget::IsRenderReady()) return;
 
         const auto mm_top_left = MissionMapWidget::GetTopLeft();
         const auto mm_bottom_right = MissionMapWidget::GetBottomRight();
@@ -875,12 +878,11 @@ namespace {
         const float btn_size = ImGui::GetTextLineHeight() + 12.0f;
         const ImVec2 text_pos(mm_top_left.x + PADDING + btn_size, mm_bottom_right.y - ImGui::GetTextLineHeight() - PADDING);
 
-        auto* draw_list = ImGui::GetBackgroundDrawList();
-        draw_list->AddText({text_pos.x + 1, text_pos.y + 1}, IM_COL32(0, 0, 0, 220), label);
-        draw_list->AddText({text_pos.x - 1, text_pos.y - 1}, IM_COL32(0, 0, 0, 220), label);
-        draw_list->AddText({text_pos.x + 1, text_pos.y - 1}, IM_COL32(0, 0, 0, 220), label);
-        draw_list->AddText({text_pos.x - 1, text_pos.y + 1}, IM_COL32(0, 0, 0, 220), label);
-        draw_list->AddText(text_pos, IM_COL32(255, 255, 255, 255), label);
+        draw_list.AddText({text_pos.x + 1, text_pos.y + 1}, IM_COL32(0, 0, 0, 220), label);
+        draw_list.AddText({text_pos.x - 1, text_pos.y - 1}, IM_COL32(0, 0, 0, 220), label);
+        draw_list.AddText({text_pos.x + 1, text_pos.y - 1}, IM_COL32(0, 0, 0, 220), label);
+        draw_list.AddText({text_pos.x - 1, text_pos.y + 1}, IM_COL32(0, 0, 0, 220), label);
+        draw_list.AddText(text_pos, IM_COL32(255, 255, 255, 255), label);
     }
 
 
@@ -896,42 +898,87 @@ namespace {
         nav_marker_hidden = false;
     }
 
-    void OnMissionMapDraw(IDirect3DDevice9* dx_device)
-    {
-        if (!should_draw) return;
-
-        const auto& gameToScreen = MissionMapWidget::GetGameToScreenMatrix();
-
-        inaccessible_area_and_borders.Render(dx_device);
-        fog_buffer.Render(dx_device);
-        frontier_border.Render(dx_device);
-        enemy_vertex_buffer.Render(dx_device);
-
-        if (!compass_circle.empty()) {
-            if (const auto* player = GW::Agents::GetControlledCharacter()) {
-                D3DMATRIX compassMatrix = gameToScreen;
-                compassMatrix._41 = roundf(gameToScreen._41 + player->pos.x * gameToScreen._11 + player->pos.y * gameToScreen._21);
-                compassMatrix._42 = roundf(gameToScreen._42 + player->pos.x * gameToScreen._12 + player->pos.y * gameToScreen._22);
-                dx_device->SetTransform(D3DTS_WORLD, &compassMatrix);
-                compass_circle.Render(dx_device);
-                dx_device->SetTransform(D3DTS_WORLD, &gameToScreen);
-            }
-        }
-    }
 } // namespace
 
 void VanquishMapOverlayWidget::Initialize()
 {
     ToolboxWidget::Initialize();
-    MissionMapWidget::AddDrawCallback(&OnMissionMapDraw);
     MissionMapWidget::AddContextMenuCallback(&VanquishMapOverlayWidget::ContextMenuItems);
     QuestModule::AddCustomMarkerChangedCallback(&OnCustomMarkerChanged);
+    Compositor::RegisterOverlayCallback(L"MapWindow",
+        [this](IDirect3DDevice9* device) { RenderMissionMapOverlay(device); });
+    Compositor::RegisterImGuiOverlay(L"MapWindow",
+        [this](ImDrawList& draw_list) { DrawEnemyCountLabel(draw_list); }, 2);
+    Compositor::RegisterOverlayCallback(L"MapWindow",
+        [](IDirect3DDevice9* device) { Compositor::RenderImGuiWindow(device, "##vq_toggle"); }, 2);
+}
+
+void VanquishMapOverlayWidget::RenderMissionMapOverlay(IDirect3DDevice9* device)
+{
+    if (!visible || !should_draw || !MissionMapWidget::IsRenderReady() || !ToolboxUtils::IsExplorable()) return;
+
+    const auto gameToScreen = MissionMapWidget::GetGameToScreenMatrix();
+    const auto mm_top_left = MissionMapWidget::GetTopLeft();
+    const auto mm_bottom_right = MissionMapWidget::GetBottomRight();
+
+    const D3DStateGuard guard(device);
+
+    device->SetPixelShader(nullptr);
+    device->SetVertexShader(nullptr);
+    device->SetTexture(0, nullptr);
+    device->SetRenderState(D3DRS_SCISSORTESTENABLE, TRUE);
+    device->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
+    device->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
+    device->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
+    device->SetRenderState(D3DRS_LIGHTING, FALSE);
+    device->SetRenderState(D3DRS_ZENABLE, FALSE);
+    device->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+    device->SetRenderState(D3DRS_STENCILENABLE, FALSE);
+    device->SetRenderState(D3DRS_FOGENABLE, FALSE);
+    device->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
+    device->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_SELECTARG1);
+    device->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_DIFFUSE);
+    device->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG1);
+    device->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_DIFFUSE);
+
+    RECT scissorRect;
+    scissorRect.left = static_cast<LONG>(floorf(mm_top_left.x));
+    scissorRect.top = static_cast<LONG>(floorf(mm_top_left.y));
+    scissorRect.right = static_cast<LONG>(ceilf(mm_bottom_right.x));
+    scissorRect.bottom = static_cast<LONG>(ceilf(mm_bottom_right.y));
+    device->SetScissorRect(&scissorRect);
+
+    const auto& io = ImGui::GetIO();
+    D3DVIEWPORT9 vp = {0, 0, (DWORD)io.DisplaySize.x, (DWORD)io.DisplaySize.y, 0, 1};
+    device->SetViewport(&vp);
+    const D3DMATRIX ortho = MakeOrthoProjection(io.DisplaySize.x, io.DisplaySize.y);
+
+    device->SetFVF(D3DFVF_XYZ | D3DFVF_DIFFUSE);
+    device->SetTransform(D3DTS_WORLD, &gameToScreen);
+    device->SetTransform(D3DTS_VIEW, &IDENTITY_MATRIX);
+    device->SetTransform(D3DTS_PROJECTION, &ortho);
+
+    inaccessible_area_and_borders.Render(device);
+    fog_buffer.Render(device);
+    frontier_border.Render(device);
+    enemy_vertex_buffer.Render(device);
+
+    if (!compass_circle.empty()) {
+        if (const auto* player = GW::Agents::GetControlledCharacter()) {
+            D3DMATRIX compassMatrix = gameToScreen;
+            compassMatrix._41 = roundf(gameToScreen._41 + player->pos.x * gameToScreen._11 + player->pos.y * gameToScreen._21);
+            compassMatrix._42 = roundf(gameToScreen._42 + player->pos.x * gameToScreen._12 + player->pos.y * gameToScreen._22);
+            device->SetTransform(D3DTS_WORLD, &compassMatrix);
+            compass_circle.Render(device);
+        }
+    }
 }
 
 void VanquishMapOverlayWidget::Draw(IDirect3DDevice9*)
 {
+    // Create the toggle button ImGui window — its draw list is rendered at the
+    // MapWindow z-level by the overlay callback registered in Initialize.
     DrawVanquishToggleButton();
-    DrawEnemyCountLabel();
 }
 
 void VanquishMapOverlayWidget::DrawVanquishToggleButton()
@@ -1037,7 +1084,6 @@ void VanquishMapOverlayWidget::Update(float)
 void VanquishMapOverlayWidget::Terminate()
 {
     ToolboxWidget::Terminate();
-    MissionMapWidget::RemoveDrawCallback(&OnMissionMapDraw);
     MissionMapWidget::RemoveContextMenuCallback(&VanquishMapOverlayWidget::ContextMenuItems);
     QuestModule::RemoveCustomMarkerChangedCallback(&OnCustomMarkerChanged);
 

--- a/GWToolboxdll/Widgets/VanquishMapOverlayWidget.h
+++ b/GWToolboxdll/Widgets/VanquishMapOverlayWidget.h
@@ -35,6 +35,9 @@ public:
 
     static void GetTrackedEnemyCounts(int& alive, int& stale);
     static bool IsOverlayActive();
+
+private:
+    void RenderMissionMapOverlay(IDirect3DDevice9* device);
     static bool IsNavigating();
     static void StopNavigating();
     static bool ContextMenuItems();


### PR DESCRIPTION
- Click-to-raise works across both GW and Toolbox windows
- GW popups can appear above Toolbox windows and vice versa
- Unpinned Toolbox windows close with Escape (most-recently-focused first)
- Thumbtack pin button in each Toolbox title bar

<img width="3840" height="2160" alt="gw764" src="https://github.com/user-attachments/assets/9d03f17d-c081-46bc-9806-ad80a7518af2" />