### PR TITLE
Fix FavorTracker text color and hide setting not persisting

### DIFF
--- a/GWToolboxdll/Widgets/FavorTracker.cpp
+++ b/GWToolboxdll/Widgets/FavorTracker.cpp
@@ -245,6 +245,8 @@ void FavorTracker::LoadSettings(ToolboxIni* ini)
 {
     ToolboxWidget::LoadSettings(ini);
     LOAD_FLOAT(text_size);
+    LOAD_COLOR(text_color);
+    LOAD_BOOL(hide_if_no_favor);
     LOAD_BOOL(enabled);
     LOAD_BOOL(play_sound_on_favor);
     LOAD_UINT(favor_sound_file_id);
@@ -254,6 +256,8 @@ void FavorTracker::SaveSettings(ToolboxIni* ini)
 {
     ToolboxWidget::SaveSettings(ini);
     SAVE_FLOAT(text_size);
+    SAVE_COLOR(text_color);
+    SAVE_BOOL(hide_if_no_favor);
     SAVE_BOOL(enabled);
     SAVE_BOOL(play_sound_on_favor);
     SAVE_UINT(favor_sound_file_id);


### PR DESCRIPTION
Fixes #1934

The `text_color` and `hide_if_no_favor` settings in the Favor Tracker widget were missing LOAD_COLOR/SAVE_COLOR and LOAD_BOOL/SAVE_BOOL calls, causing them to reset on every restart.

Generated with [Claude Code](https://claude.ai/code)