### PR TITLE
Add profession filter checkbox to Hero Builds window

### DIFF
--- a/GWToolboxdll/Modules/DiscordModule.cpp
+++ b/GWToolboxdll/Modules/DiscordModule.cpp
@@ -146,19 +146,6 @@ namespace {
         "Swat",
         "Dev Region"
     };
-    const char* profession_names[] = {
-        "No Profession",
-        "Warrior",
-        "Ranger",
-        "Monk",
-        "Necromancer",
-        "Mesmer",
-        "Elementalist",
-        "Assassin",
-        "Ritualist",
-        "Paragon",
-        "Dervish"
-    };
 
     const char* map_languages[] = {
         "English",
@@ -627,7 +614,7 @@ namespace {
 
             if (show_character_info) {
                 sprintf(activity.assets.small_image, "profession_%d_512px", a->primary);
-                sprintf(activity.assets.small_text, "%S (%s)", GW::GetGameContext()->character->player_name, profession_names[std::to_underlying(a->primary)]);
+                sprintf(activity.assets.small_text, "%S (%s)", GW::GetGameContext()->character->player_name, ToolboxUtils::GetProfessionName(static_cast<GW::Constants::Profession>(a->primary)).c_str());
             }
 
             if (show_location_info) {

--- a/GWToolboxdll/Modules/DiscordModule.cpp
+++ b/GWToolboxdll/Modules/DiscordModule.cpp
@@ -614,7 +614,7 @@ namespace {
 
             if (show_character_info) {
                 sprintf(activity.assets.small_image, "profession_%d_512px", a->primary);
-                sprintf(activity.assets.small_text, "%S (%s)", GW::GetGameContext()->character->player_name, ToolboxUtils::GetProfessionName(static_cast<GW::Constants::Profession>(a->primary)).c_str());
+                sprintf(activity.assets.small_text, "%S (%s)", GW::GetGameContext()->character->player_name, ToolboxUtils::GetProfessionName(static_cast<GW::Constants::Profession>(a->primary))->string().c_str());
             }
 
             if (show_location_info) {

--- a/GWToolboxdll/Modules/ObserverModule.cpp
+++ b/GWToolboxdll/Modules/ObserverModule.cpp
@@ -2638,9 +2638,9 @@ ObserverModule::ObservableAgent::ObservableAgent(ObserverModule& parent, const G
     GW::UI::AsyncDecodeStr(GW::Agents::GetAgentEncName(&agent_living), &_raw_name_w);
 
     if (primary != GW::Constants::Profession::None) {
-        std::string prof = GetProfessionAcronym(primary);
+        std::string prof = ToolboxUtils::GetProfessionAcronym(primary)->string();
         if (secondary != GW::Constants::Profession::None) {
-            const std::string s_prof = GetProfessionAcronym(secondary);
+            const std::string s_prof = ToolboxUtils::GetProfessionAcronym(secondary)->string();
             prof = prof + "/" + s_prof;
         }
         profession = prof;

--- a/GWToolboxdll/Modules/PartyWindowModule.cpp
+++ b/GWToolboxdll/Modules/PartyWindowModule.cpp
@@ -478,7 +478,7 @@ namespace {
 
     const std::string GetProfessionName(uint8_t prof)
     {
-        return GW::Constants::GetProfessionAcronym(static_cast<GW::Constants::Profession>(prof));
+        return ToolboxUtils::GetProfessionAcronym(static_cast<GW::Constants::Profession>(prof))->string();
     }
 
     bool OverridePartySortOrder(bool _override = true)
@@ -725,9 +725,9 @@ namespace {
 
             // Primary profession combo
             ImGui::SetNextItemWidth(120.0f * fontScale);
-            if (ImGui::BeginCombo("##primary", GW::Constants::GetProfessionAcronym(static_cast<GW::Constants::Profession>(primary)))) {
+            if (ImGui::BeginCombo("##primary", ToolboxUtils::GetProfessionAcronym(static_cast<GW::Constants::Profession>(primary))->string().c_str())) {
                 for (uint8_t prof = 0; prof <= 10; prof++) {
-                    if (ImGui::Selectable(GW::Constants::GetProfessionAcronym(static_cast<GW::Constants::Profession>(prof)), primary == prof)) {
+                    if (ImGui::Selectable(ToolboxUtils::GetProfessionAcronym(static_cast<GW::Constants::Profession>(prof))->string().c_str(), primary == prof)) {
                         primary = prof;
                         edit_profession_order[i] = (static_cast<uint16_t>(primary) << 8) | secondary;
                     }
@@ -741,9 +741,9 @@ namespace {
 
             // Secondary profession combo
             ImGui::SetNextItemWidth(120.0f * fontScale);
-            if (ImGui::BeginCombo("##secondary", GW::Constants::GetProfessionAcronym(static_cast<GW::Constants::Profession>(secondary)))) {
+            if (ImGui::BeginCombo("##secondary", ToolboxUtils::GetProfessionAcronym(static_cast<GW::Constants::Profession>(secondary))->string().c_str())) {
                 for (uint8_t prof = 0; prof <= 10; prof++) {
-                    if (ImGui::Selectable(GW::Constants::GetProfessionAcronym(static_cast<GW::Constants::Profession>(prof)), secondary == prof)) {
+                    if (ImGui::Selectable(ToolboxUtils::GetProfessionAcronym(static_cast<GW::Constants::Profession>(prof))->string().c_str(), secondary == prof)) {
                         secondary = prof;
                         edit_profession_order[i] = (static_cast<uint16_t>(primary) << 8) | secondary;
                     }

--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -100,7 +100,7 @@
 #include <Widgets/TitleTrackerWidget.h>
 #include <Widgets/FavorTracker.h>
 #include "ToolboxSettings.h"
-
+#include <Utils/ToolboxUtils.h>
 
 #define USE_OBFUSCATOR 1
 #if USE_OBFUSCATOR
@@ -397,11 +397,11 @@ void ToolboxSettings::Update(float)
         std::wstring prof_string;
         if (me) {
             prof_string += L" - ";
-            prof_string += GetWProfessionAcronym(
-                static_cast<GW::Constants::Profession>(me->primary));
+            prof_string += ToolboxUtils::GetProfessionAcronym(
+                static_cast<GW::Constants::Profession>(me->primary))->wstring();
             prof_string += L"-";
-            prof_string += GetWProfessionAcronym(
-                static_cast<GW::Constants::Profession>(me->secondary));
+            prof_string += ToolboxUtils::GetProfessionAcronym(
+                static_cast<GW::Constants::Profession>(me->secondary))->wstring();
         }
 
         SYSTEMTIME localtime;

--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -1418,11 +1418,17 @@ namespace ToolboxUtils {
         return original;
     }
 
-    std::string GetProfessionName(const GW::Constants::Profession profession)
+    GuiUtils::EncString* GetProfessionName(const GW::Constants::Profession profession)
     {
         const auto idx = static_cast<size_t>(profession);
-        if (idx >= std::size(GW::EncStrings::Profession)) return "";
-        const auto* enc = Resources::DecodeStringId(GW::EncStrings::Profession[idx]);
-        return enc ? enc->string() : "";
+        const auto str_id = idx < std::size(GW::EncStrings::Profession) ? GW::EncStrings::Profession[idx] : 1u;
+        return Resources::DecodeStringId(str_id);
+    }
+
+    GuiUtils::EncString* GetProfessionAcronym(const GW::Constants::Profession profession)
+    {
+        const auto idx = static_cast<size_t>(profession);
+        const auto str_id = idx < std::size(GW::EncStrings::ProfessionAcronym) ? GW::EncStrings::ProfessionAcronym[idx] : 1u;
+        return Resources::DecodeStringId(str_id);
     }
 } // namespace ToolboxUtils

--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -1417,4 +1417,12 @@ namespace ToolboxUtils {
 
         return original;
     }
+
+    std::string GetProfessionName(const GW::Constants::Profession profession)
+    {
+        const auto idx = static_cast<size_t>(profession);
+        if (idx >= std::size(GW::EncStrings::Profession)) return "";
+        const auto* enc = Resources::DecodeStringId(GW::EncStrings::Profession[idx]);
+        return enc ? enc->string() : "";
+    }
 } // namespace ToolboxUtils

--- a/GWToolboxdll/Utils/ToolboxUtils.h
+++ b/GWToolboxdll/Utils/ToolboxUtils.h
@@ -284,4 +284,6 @@ namespace ToolboxUtils {
     GW::Friend* GetFriend(const wchar_t* account, const wchar_t* playing, GW::FriendType type, GW::FriendStatus status);
 
     std::wstring ShorthandItemDescription(GW::Item* item);
+
+    std::string GetProfessionName(GW::Constants::Profession profession);
 };

--- a/GWToolboxdll/Utils/ToolboxUtils.h
+++ b/GWToolboxdll/Utils/ToolboxUtils.h
@@ -209,6 +209,10 @@ namespace GW {
     }
 }
 
+namespace GuiUtils {
+    class EncString;
+}
+
 namespace ToolboxUtils {
 
     // Helper function to limit some functions to only check every n frames
@@ -285,5 +289,6 @@ namespace ToolboxUtils {
 
     std::wstring ShorthandItemDescription(GW::Item* item);
 
-    std::string GetProfessionName(GW::Constants::Profession profession);
+    GuiUtils::EncString* GetProfessionName(GW::Constants::Profession profession);
+    GuiUtils::EncString* GetProfessionAcronym(GW::Constants::Profession profession);
 };

--- a/GWToolboxdll/Widgets/PartyDamage.cpp
+++ b/GWToolboxdll/Widgets/PartyDamage.cpp
@@ -17,6 +17,7 @@
 #include <Modules/ToolboxSettings.h>
 #include <Widgets/PartyDamage.h>
 #include <Utils/TextUtils.h>
+#include <Utils/ToolboxUtils.h>
 
 constexpr const wchar_t* INI_FILENAME = L"healthlog.ini";
 constexpr const char* IniSection = "health";
@@ -235,8 +236,8 @@ void PartyDamage::WriteDamageOf(size_t index, uint32_t rank)
     if (has_damage && has_healing) {
         swprintf_s(buffer, buffer_size, L"#%2d ~ %ls/%ls %ls ~ Dmg: %3.2f%% (%d) ~ Heal: %3.2f%% (%d)",
                    rank,
-                   GetWProfessionAcronym(damage[index].primary),
-                   GetWProfessionAcronym(damage[index].secondary),
+                   ToolboxUtils::GetProfessionAcronym(damage[index].primary)->wstring().c_str(),
+                   ToolboxUtils::GetProfessionAcronym(damage[index].secondary)->wstring().c_str(),
                    damage[index].name.c_str(),
                    GetPercentageOfTotal(damage[index].damage),
                    damage[index].damage,
@@ -246,8 +247,8 @@ void PartyDamage::WriteDamageOf(size_t index, uint32_t rank)
     else if (has_damage) {
         swprintf_s(buffer, buffer_size, L"#%2d ~ %ls/%ls %ls ~ Dmg: %3.2f%% (%d)",
                    rank,
-                   GetWProfessionAcronym(damage[index].primary),
-                   GetWProfessionAcronym(damage[index].secondary),
+                   ToolboxUtils::GetProfessionAcronym(damage[index].primary)->wstring().c_str(),
+                   ToolboxUtils::GetProfessionAcronym(damage[index].secondary)->wstring().c_str(),
                    damage[index].name.c_str(),
                    GetPercentageOfTotal(damage[index].damage),
                    damage[index].damage);
@@ -255,8 +256,8 @@ void PartyDamage::WriteDamageOf(size_t index, uint32_t rank)
     else if (has_healing) {
         swprintf_s(buffer, buffer_size, L"#%2d ~ %ls/%ls %ls ~ Heal: %3.2f%% (%d)",
                    rank,
-                   GetWProfessionAcronym(damage[index].primary),
-                   GetWProfessionAcronym(damage[index].secondary),
+                   ToolboxUtils::GetProfessionAcronym(damage[index].primary)->wstring().c_str(),
+                   ToolboxUtils::GetProfessionAcronym(damage[index].secondary)->wstring().c_str(),
                    damage[index].name.c_str(),
                    GetPercentageOfTotalHealing(damage[index].healing),
                    damage[index].healing);

--- a/GWToolboxdll/Windows/ArmoryWindow.cpp
+++ b/GWToolboxdll/Windows/ArmoryWindow.cpp
@@ -321,35 +321,6 @@ namespace GWArmory {
         }
     }
 
-    const char* GetProfessionName(const GW::Constants::Profession prof)
-    {
-        switch (prof) {
-            case GW::Constants::Profession::None:
-                return "None";
-            case GW::Constants::Profession::Warrior:
-                return "Warrior";
-            case GW::Constants::Profession::Ranger:
-                return "Ranger";
-            case GW::Constants::Profession::Monk:
-                return "Monk";
-            case GW::Constants::Profession::Necromancer:
-                return "Necromancer";
-            case GW::Constants::Profession::Mesmer:
-                return "Mesmer";
-            case GW::Constants::Profession::Elementalist:
-                return "Elementalist";
-            case GW::Constants::Profession::Assassin:
-                return "Assassin";
-            case GW::Constants::Profession::Ritualist:
-                return "Ritualist";
-            case GW::Constants::Profession::Paragon:
-                return "Paragon";
-            case GW::Constants::Profession::Dervish:
-                return "Dervish";
-            default:
-                return "Unknown Profession";
-        }
-    }
 
     GW::Constants::Profession GetAgentProfession(GW::AgentLiving* agent)
     {
@@ -1242,7 +1213,7 @@ void ArmoryWindow::Draw(IDirect3DDevice9*)
     ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowSize(ImVec2(350, 208), ImGuiCond_FirstUseEver);
     if (ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
-        ImGui::Text("Profession: %s", GetProfessionName(current_profession));
+        ImGui::Text("Profession: %s", ToolboxUtils::GetProfessionName(current_profession).c_str());
 
         ImGui::SameLine();
         ImGui::Checkbox("Use same colour for all pieces", &use_global_color);

--- a/GWToolboxdll/Windows/ArmoryWindow.cpp
+++ b/GWToolboxdll/Windows/ArmoryWindow.cpp
@@ -1213,7 +1213,7 @@ void ArmoryWindow::Draw(IDirect3DDevice9*)
     ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowSize(ImVec2(350, 208), ImGuiCond_FirstUseEver);
     if (ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
-        ImGui::Text("Profession: %s", ToolboxUtils::GetProfessionName(current_profession).c_str());
+        ImGui::Text("Profession: %s", ToolboxUtils::GetProfessionName(current_profession)->string().c_str());
 
         ImGui::SameLine();
         ImGui::Checkbox("Use same colour for all pieces", &use_global_color);

--- a/GWToolboxdll/Windows/BuildsWindow.cpp
+++ b/GWToolboxdll/Windows/BuildsWindow.cpp
@@ -154,7 +154,7 @@ namespace {
             build->code = build_code;
         }
 
-        build->name = std::format("{}/{}", GetProfessionAcronym(skill_template.primary), GetProfessionAcronym(skill_template.secondary));
+        build->name = std::format("{}/{}", ToolboxUtils::GetProfessionAcronym(skill_template.primary)->string(), ToolboxUtils::GetProfessionAcronym(skill_template.secondary)->string());
 
 
         // Try to generate a name based on the elite skill or primary profession
@@ -293,7 +293,7 @@ namespace {
         const auto prof = static_cast<GW::Constants::Profession>(GW::Agents::GetControlledCharacter()->primary);
         const bool is_skill_template = DecodeSkillTemplate(t, build_name);
         if (is_skill_template && t.primary != prof) {
-            Log::Error("Invalid profession for %s (%s)", build_name, GetProfessionAcronym(t.primary));
+            Log::Error("Invalid profession for %s (%s)", build_name, ToolboxUtils::GetProfessionAcronym(t.primary)->string().c_str());
             return nullptr;
         }
         const std::string tbuild_ws = tbuild_name ? TextUtils::ToLower(tbuild_name) : "";

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -91,6 +91,22 @@ namespace {
         return Resources::DecodeStringId(c ? c->name_id : 1);
     }
 
+    const char* GetProfessionName(const GW::Constants::Profession prof) {
+        switch (prof) {
+            case GW::Constants::Profession::Warrior:      return "Warrior";
+            case GW::Constants::Profession::Ranger:       return "Ranger";
+            case GW::Constants::Profession::Monk:         return "Monk";
+            case GW::Constants::Profession::Necromancer:  return "Necromancer";
+            case GW::Constants::Profession::Mesmer:       return "Mesmer";
+            case GW::Constants::Profession::Elementalist: return "Elementalist";
+            case GW::Constants::Profession::Assassin:     return "Assassin";
+            case GW::Constants::Profession::Ritualist:    return "Ritualist";
+            case GW::Constants::Profession::Paragon:      return "Paragon";
+            case GW::Constants::Profession::Dervish:      return "Dervish";
+            default:                                      return "Unknown";
+        }
+    }
+
     const size_t GetPlayerHeroCount()
     {
         size_t ret = 0;
@@ -186,9 +202,25 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
         ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
         ImGui::SetNextWindowSize(ImVec2(300, 250), ImGuiCond_FirstUseEver);
         if (ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
+            const auto* me = GW::Agents::GetControlledCharacter();
+            const auto player_profession = me ? static_cast<GW::Constants::Profession>(me->primary) : GW::Constants::Profession::None;
+            if (player_profession != GW::Constants::Profession::None) {
+                char filter_label[64];
+                snprintf(filter_label, sizeof(filter_label), "Filter by %s", GetProfessionName(player_profession));
+                ImGui::Checkbox(filter_label, &filter_by_profession);
+            }
             const float btn_width = 60.0f * ImGui::FontScale();
             const float& item_spacing = ImGui::GetStyle().ItemInnerSpacing.x;
             for (TeamHeroBuild& tbuild : teambuilds) {
+                if (filter_by_profession && player_profession != GW::Constants::Profession::None) {
+                    const char* player_code = tbuild.builds[0].code;
+                    if (player_code && player_code[0] != '\0') {
+                        GW::SkillbarMgr::SkillTemplate t{};
+                        if (GW::SkillbarMgr::DecodeSkillTemplate(t, player_code) && t.primary != player_profession) {
+                            continue;
+                        }
+                    }
+                }
                 ImGui::PushID(static_cast<int>(tbuild.ui_id));
                 ImGui::GetStyle().ButtonTextAlign = ImVec2(0.0f, 0.5f);
                 if (ImGui::Button(tbuild.name, ImVec2(ImGui::GetContentRegionAvail().x - item_spacing - btn_width, 0))) {
@@ -776,6 +808,7 @@ void HeroBuildsWindow::LoadSettings(ToolboxIni* ini)
     ToolboxWindow::LoadSettings(ini);
     LOAD_BOOL(hide_when_entering_explorable);
     LOAD_BOOL(one_teambuild_at_a_time);
+    LOAD_BOOL(filter_by_profession);
     LoadFromFile();
 }
 
@@ -791,6 +824,7 @@ void HeroBuildsWindow::SaveSettings(ToolboxIni* ini)
     ToolboxWindow::SaveSettings(ini);
     SAVE_BOOL(hide_when_entering_explorable);
     SAVE_BOOL(one_teambuild_at_a_time);
+    SAVE_BOOL(filter_by_profession);
     SaveToFile();
 }
 

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -190,7 +190,7 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
             const auto player_profession = me ? static_cast<GW::Constants::Profession>(me->primary) : GW::Constants::Profession::None;
             if (player_profession != GW::Constants::Profession::None) {
                 char filter_label[64];
-                snprintf(filter_label, sizeof(filter_label), "Filter by %s", ToolboxUtils::GetProfessionName(player_profession).c_str());
+                snprintf(filter_label, sizeof(filter_label), "Filter by %s", ToolboxUtils::GetProfessionName(player_profession)->string().c_str());
                 ImGui::Checkbox(filter_label, &filter_by_profession);
             }
             const float btn_width = 60.0f * ImGui::FontScale();

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -24,6 +24,7 @@
 #include <Modules/GwDatTextureModule.h>
 #include <Modules/Resources.h>
 #include <Windows/HeroBuildsWindow.h>
+#include <Windows/Hotkeys.h>
 
 #include <GWToolbox.h>
 #include <Utils/TextUtils.h>
@@ -89,22 +90,6 @@ namespace {
     GuiUtils::EncString* GetHeroEncName(GW::Constants::HeroID hero_id) {
         const auto c = GW::PartyMgr::GetHeroConstData(hero_id);
         return Resources::DecodeStringId(c ? c->name_id : 1);
-    }
-
-    const char* GetProfessionName(const GW::Constants::Profession prof) {
-        switch (prof) {
-            case GW::Constants::Profession::Warrior:      return "Warrior";
-            case GW::Constants::Profession::Ranger:       return "Ranger";
-            case GW::Constants::Profession::Monk:         return "Monk";
-            case GW::Constants::Profession::Necromancer:  return "Necromancer";
-            case GW::Constants::Profession::Mesmer:       return "Mesmer";
-            case GW::Constants::Profession::Elementalist: return "Elementalist";
-            case GW::Constants::Profession::Assassin:     return "Assassin";
-            case GW::Constants::Profession::Ritualist:    return "Ritualist";
-            case GW::Constants::Profession::Paragon:      return "Paragon";
-            case GW::Constants::Profession::Dervish:      return "Dervish";
-            default:                                      return "Unknown";
-        }
     }
 
     const size_t GetPlayerHeroCount()
@@ -206,7 +191,7 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
             const auto player_profession = me ? static_cast<GW::Constants::Profession>(me->primary) : GW::Constants::Profession::None;
             if (player_profession != GW::Constants::Profession::None) {
                 char filter_label[64];
-                snprintf(filter_label, sizeof(filter_label), "Filter by %s", GetProfessionName(player_profession));
+                snprintf(filter_label, sizeof(filter_label), "Filter by %s", TBHotkey::professions[static_cast<size_t>(player_profession)]);
                 ImGui::Checkbox(filter_label, &filter_by_profession);
             }
             const float btn_width = 60.0f * ImGui::FontScale();

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -24,7 +24,6 @@
 #include <Modules/GwDatTextureModule.h>
 #include <Modules/Resources.h>
 #include <Windows/HeroBuildsWindow.h>
-#include <Windows/Hotkeys.h>
 
 #include <GWToolbox.h>
 #include <Utils/TextUtils.h>
@@ -191,7 +190,7 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
             const auto player_profession = me ? static_cast<GW::Constants::Profession>(me->primary) : GW::Constants::Profession::None;
             if (player_profession != GW::Constants::Profession::None) {
                 char filter_label[64];
-                snprintf(filter_label, sizeof(filter_label), "Filter by %s", TBHotkey::professions[static_cast<size_t>(player_profession)]);
+                snprintf(filter_label, sizeof(filter_label), "Filter by %s", ToolboxUtils::GetProfessionName(player_profession).c_str());
                 ImGui::Checkbox(filter_label, &filter_by_profession);
             }
             const float btn_width = 60.0f * ImGui::FontScale();

--- a/GWToolboxdll/Windows/HeroBuildsWindow.h
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.h
@@ -102,6 +102,7 @@ public:
 private:
     bool hide_when_entering_explorable = false;
     bool one_teambuild_at_a_time = false;
+    bool filter_by_profession = false;
 
     // Load a teambuild
     void Load(const TeamHeroBuild& tbuild);

--- a/GWToolboxdll/Windows/Hotkeys.cpp
+++ b/GWToolboxdll/Windows/Hotkeys.cpp
@@ -26,6 +26,7 @@
 #include <Logger.h>
 
 #include <Modules/Resources.h>
+#include <Utils/ToolboxUtils.h>
 #include <Windows/BuildsWindow.h>
 #include <Windows/HeroBuildsWindow.h>
 #include <Windows/Hotkeys.h>
@@ -415,7 +416,7 @@ bool TBHotkey::Draw(Op* op, bool first, bool last)
                 if (!prof_ids_written) {
                     format = "%s";
                 }
-                prof_ids_written += snprintf(&prof_ids_buf[prof_ids_written], _countof(prof_ids_buf) - prof_ids_written, format, GetProfessionAcronym(static_cast<GW::Constants::Profession>(i)));
+                prof_ids_written += snprintf(&prof_ids_buf[prof_ids_written], _countof(prof_ids_buf) - prof_ids_written, format, ToolboxUtils::GetProfessionAcronym(static_cast<GW::Constants::Profession>(i))->string().c_str());
             }
             written += snprintf(&header[written], _countof(header) - written, " [%s]", prof_ids_buf);
         }

--- a/GWToolboxdll/Windows/PartySearchWindow.cpp
+++ b/GWToolboxdll/Windows/PartySearchWindow.cpp
@@ -30,6 +30,7 @@
 
 #include <GWToolbox.h>
 #include <Utils/TextUtils.h>
+#include <Utils/ToolboxUtils.h>
 
 // Every connection cost 30 seconds.
 // You have 2 tries.
@@ -696,13 +697,13 @@ void PartySearchWindow::Draw(IDirect3DDevice9*)
             char label[64];
             if (party->secondary) {
                 snprintf(label, 64, "%s/%s %s",
-                         GetProfessionAcronym(static_cast<GW::Constants::Profession>(party->primary)),
-                         GetProfessionAcronym(static_cast<GW::Constants::Profession>(party->secondary)),
+                         ToolboxUtils::GetProfessionAcronym(static_cast<GW::Constants::Profession>(party->primary))->string().c_str(),
+                         ToolboxUtils::GetProfessionAcronym(static_cast<GW::Constants::Profession>(party->secondary))->string().c_str(),
                          party->player_name.c_str());
             }
             else {
                 snprintf(label, 64, "%s %s",
-                         GetProfessionAcronym(static_cast<GW::Constants::Profession>(party->primary)),
+                         ToolboxUtils::GetProfessionAcronym(static_cast<GW::Constants::Profession>(party->primary))->string().c_str(),
                          party->player_name.c_str());
             }
 

--- a/GWToolboxdll/Windows/SkillListingWindow.cpp
+++ b/GWToolboxdll/Windows/SkillListingWindow.cpp
@@ -12,6 +12,7 @@
 #include <Modules/Resources.h>
 #include <Windows/SkillListingWindow.h>
 #include <Utils/TextUtils.h>
+#include <Utils/ToolboxUtils.h>
 #include <Modules/GwDatTextureModule.h>
 
 static uintptr_t skill_array_addr;
@@ -227,7 +228,7 @@ void SkillListingWindow::Draw(IDirect3DDevice9*)
         ImGui::SameLine(offset += long_text_width);
         ImGui::Text("%d", skills[i]->skill->attribute);
         ImGui::SameLine(offset += tiny_text_width);
-        ImGui::Text("%s", GetProfessionAcronym(static_cast<GW::Constants::Profession>(skills[i]->skill->profession)));
+        ImGui::Text("%s", ToolboxUtils::GetProfessionAcronym(static_cast<GW::Constants::Profession>(skills[i]->skill->profession))->string().c_str());
         ImGui::SameLine(offset += tiny_text_width);
         ImGui::Text("%d", skills[i]->skill->type);
         ImGui::SameLine();


### PR DESCRIPTION
Adds a "Filter by <Profession>" checkbox at the top of the Hero Builds window. When checked, only teambuilds whose player slot has a build code matching the current player's primary profession are shown.

Closes #629

Generated with [Claude Code](https://claude.ai/code)