### PR TITLE
Use portal account UUID to link completion characters by account

### DIFF
--- a/GWToolboxdll/Modules/GuildWarsSettingsModule.cpp
+++ b/GWToolboxdll/Modules/GuildWarsSettingsModule.cpp
@@ -379,20 +379,7 @@ namespace {
     std::filesystem::path GetDefaultFilename()
     {
         const auto uuid = GW::AccountMgr::GetAccountUuid();
-        const GUID empty{};
-        if (memcmp(&uuid, &empty, sizeof(uuid)) == 0) {
-            return L"GuildWarsSettings.ini";
-        }
-        const auto uuid_filename = std::filesystem::path(TextUtils::StringToWString(TextUtils::GuidToString(&uuid)) + L"_GuildWarsSettings.ini");
-        // Migration: prefer old email-based file if UUID file doesn't exist yet
-        const auto c = GW::GetCharContext();
-        if (c && c->player_email && *c->player_email) {
-            const auto email_filename = std::filesystem::path(std::wstring(c->player_email) + L"_GuildWarsSettings.ini");
-            if (std::filesystem::exists(Resources::GetPath(email_filename)) && !std::filesystem::exists(Resources::GetPath(uuid_filename))) {
-                return email_filename;
-            }
-        }
-        return uuid_filename;
+        return std::filesystem::path(TextUtils::StringToWString(TextUtils::GuidToString(&uuid)) + L"_GuildWarsSettings.ini");
     }
 
     void OnPreferencesSaveFileChosen(const char* result)

--- a/GWToolboxdll/Modules/GuildWarsSettingsModule.cpp
+++ b/GWToolboxdll/Modules/GuildWarsSettingsModule.cpp
@@ -23,6 +23,7 @@
 #include "GuildWarsSettingsModule.h"
 
 #include <Utils/TextUtils.h>
+#include <Utils/ToolboxUtils.h>
 
 namespace {
     uint32_t* key_mappings_array = nullptr;
@@ -377,7 +378,21 @@ namespace {
 
     std::filesystem::path GetDefaultFilename()
     {
-        return std::format(L"{}_GuildWarsSettings.ini", GW::GetCharContext()->player_email);
+        const auto uuid = GW::AccountMgr::GetAccountUuid();
+        const GUID empty{};
+        if (memcmp(&uuid, &empty, sizeof(uuid)) == 0) {
+            return L"GuildWarsSettings.ini";
+        }
+        const auto uuid_filename = std::filesystem::path(TextUtils::StringToWString(TextUtils::GuidToString(&uuid)) + L"_GuildWarsSettings.ini");
+        // Migration: prefer old email-based file if UUID file doesn't exist yet
+        const auto c = GW::GetCharContext();
+        if (c && c->player_email && *c->player_email) {
+            const auto email_filename = std::filesystem::path(std::wstring(c->player_email) + L"_GuildWarsSettings.ini");
+            if (std::filesystem::exists(Resources::GetPath(email_filename)) && !std::filesystem::exists(Resources::GetPath(uuid_filename))) {
+                return email_filename;
+            }
+        }
+        return uuid_filename;
     }
 
     void OnPreferencesSaveFileChosen(const char* result)

--- a/GWToolboxdll/Modules/Obfuscator.cpp
+++ b/GWToolboxdll/Modules/Obfuscator.cpp
@@ -22,6 +22,7 @@
 #include <Modules/ChatSettings.h>
 #include <Modules/Obfuscator.h>
 #include <Utils/GuiUtils.h>
+#include <Utils/ToolboxUtils.h>
 #include <Windows/FriendListWindow.h>
 
 #include <Defines.h>
@@ -251,7 +252,7 @@ namespace {
     std::wstring character_summary_obfuscated_name(20, 0);
     // Ease of access to avoid having to call ObfuscateName() every time.
     std::wstring player_guild_invited_name;
-    std::wstring player_email;
+    GUID current_account_uuid{};
     // Static variable; GW will use a pointer to this object for UI messages
     std::wstring ui_message_temp_message;
     std::wstring speech_message_temp_message;
@@ -535,11 +536,10 @@ namespace {
     {
         ObfuscateGuildRoster(pending_state == ObfuscatorState::Enabled);
         const auto c = GW::GetCharContext();
-        if (!c || c->player_email != player_email) {
+        const GUID uuid = c ? GW::AccountMgr::GetAccountUuid() : GUID{};
+        if (!c || memcmp(&uuid, &current_account_uuid, sizeof(uuid)) != 0) {
             player_guild_invited_name.clear();
-            if (c && c->player_email) {
-                player_email = c->player_email;
-            }
+            if (c) current_account_uuid = uuid;
         }
         std::ranges::shuffle(obfuscated_name_pool, dre);
         pool_index = 0;

--- a/GWToolboxdll/Modules/Obfuscator.cpp
+++ b/GWToolboxdll/Modules/Obfuscator.cpp
@@ -535,11 +535,10 @@ namespace {
     void Reset()
     {
         ObfuscateGuildRoster(pending_state == ObfuscatorState::Enabled);
-        const auto c = GW::GetCharContext();
-        const GUID uuid = c ? GW::AccountMgr::GetAccountUuid() : GUID{};
-        if (!c || memcmp(&uuid, &current_account_uuid, sizeof(uuid)) != 0) {
+        const GUID uuid = GW::AccountMgr::GetAccountUuid();
+        if (memcmp(&uuid, &current_account_uuid, sizeof(uuid)) != 0) {
             player_guild_invited_name.clear();
-            if (c) current_account_uuid = uuid;
+            current_account_uuid = uuid;
         }
         std::ranges::shuffle(obfuscated_name_pool, dre);
         pool_index = 0;

--- a/GWToolboxdll/Modules/PartyBroadcastModule.cpp
+++ b/GWToolboxdll/Modules/PartyBroadcastModule.cpp
@@ -101,14 +101,6 @@ namespace {
         return true;
     }
 
-    bool get_uuid(std::string& out)
-    {
-        const auto account_uuid = GW::AccountMgr::GetPortalAccountUuid();
-        if (!account_uuid) return false;
-        out = TextUtils::GuidToString(account_uuid);
-        return true;
-    }
-
     void on_websocket_closed()
     {
         // NOTE: called on the worker thread by ThreadedWebSocket.
@@ -127,9 +119,10 @@ namespace {
         party_ws.SetReconnectCost(30'000, 60'000);
 
         party_ws.SetHeadersFactory([] {
-            std::string api_key, uuid;
+            std::string api_key;
             get_api_key(api_key);
-            get_uuid(uuid);
+            const auto acct_uuid = GW::AccountMgr::GetAccountUuid();
+            const auto uuid = TextUtils::GuidToString(&acct_uuid);
             easywsclient::HeaderKeyValuePair headers = {{"User-Agent", "GWToolboxpp"}, {"X-Api-Key", api_key}, {"X-Account-Uuid", uuid}, {"X-Bot-Version", "101"}};
             Log::Log("Connecting to wss://party.gwtoolbox.com (X-Api-Key: %s, X-Account-Uuid: %s)", api_key.c_str(), uuid.c_str());
             return headers;

--- a/GWToolboxdll/Unused/ChatLog.cpp
+++ b/GWToolboxdll/Unused/ChatLog.cpp
@@ -15,6 +15,7 @@
 #include <Defines.h>
 #include <GWCA/Managers/GameThreadMgr.h>
 #include <Utils/TextUtils.h>
+#include <Utils/ToolboxUtils.h>
 
 namespace GW::Chat {
     constexpr size_t SENT_LOG_LENGTH = 0x32;
@@ -405,13 +406,25 @@ namespace {
         }
     }
 
-    // Load chat log from file via account email address
+    // Load chat log from file via account UUID string
     void Load(const std::wstring& _account)
     {
         Reset();
 
         // Recv log FIFO
         account = _account;
+        // Migration: if UUID-based log doesn't exist, rename old email-based logs
+        const auto c = GW::GetCharContext();
+        if (c && c->player_email && *c->player_email && !std::filesystem::exists(LogPath(L"recv"))) {
+            const std::wstring email_str = c->player_email;
+            Resources::EnsureFolderExists(Resources::GetPath(L"chat logs"));
+            for (const auto* prefix : {L"recv", L"sent"}) {
+                const auto old_path = Resources::GetPath(L"chat logs", (std::wstring(prefix) + L"_" + email_str + L".ini").c_str());
+                if (std::filesystem::exists(old_path)) {
+                    std::filesystem::rename(old_path, LogPath(prefix));
+                }
+            }
+        }
         ToolboxIni inifile;
         auto res = inifile.LoadIfExists(LogPath(L"recv"));
         for (size_t i = 0; i < 10 && res != SI_OK; i++) {
@@ -536,7 +549,8 @@ namespace {
         if (!c) {
             return false;
         }
-        const std::wstring this_account = c->player_email;
+        const auto uuid = GW::AccountMgr::GetAccountUuid();
+        const auto this_account = TextUtils::StringToWString(TextUtils::GuidToString(&uuid));
         if (this_account == account) {
             return false;
         }

--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -385,6 +385,14 @@ namespace GW {
             return account_uuid;
         }
 
+        GUID GetAccountUuid()
+        {
+            const auto uuid = GetPortalAccountUuid();
+            if (uuid) return *uuid;
+            const auto email = GetAccountEmail();
+            return email && *email ? TextUtils::ConvertWStringToGuid(email) : GUID{};
+        }
+
         AvailableCharacterInfo* GetAvailableCharacter(const wchar_t* name)
         {
             const auto characters = name ? GetAvailableChars() : nullptr;

--- a/GWToolboxdll/Utils/ToolboxUtils.h
+++ b/GWToolboxdll/Utils/ToolboxUtils.h
@@ -163,6 +163,7 @@ namespace GW {
         // Try not to be a dick with this info
         const wchar_t* GetAccountEmail();
         const UUID* GetPortalAccountUuid();
+        GUID GetAccountUuid();
 
         AvailableCharacterInfo* GetAvailableCharacter(const wchar_t* name);
     }

--- a/GWToolboxdll/Windows/AccountInventoryWindow.cpp
+++ b/GWToolboxdll/Windows/AccountInventoryWindow.cpp
@@ -123,11 +123,6 @@ const char* HERO_NAME[] = {
         return player_name ? TextUtils::WStringToString(player_name) : "";
     }
 
-    UUID GetAccountGuid() {
-        const auto account_uuid = GW::AccountMgr::GetPortalAccountUuid();
-        return account_uuid ? *account_uuid : TextUtils::ConvertWStringToGuid(GW::AccountMgr::GetAccountEmail());
-    }
-
     bool IsChestBag(GW::Constants::Bag bag_id)
     {
         if (GW::Constants::Bag::Material_Storage == bag_id) return true;
@@ -1175,7 +1170,7 @@ void AccountInventoryWindow::Initialize()
 {
     ToolboxWindow::Initialize();
 
-    current_account = GetAccountGuid();
+    current_account = GW::AccountMgr::GetAccountUuid();
     current_character = GetCurrentPlayerNameS();
 
     const GW::UI::UIMessage ui_messages[] = {
@@ -1490,7 +1485,7 @@ void AccountInventoryWindow::Update(float)
 
 void AccountInventoryWindow::PreMapLoad()
 {
-    current_account = GetAccountGuid();
+    current_account = GW::AccountMgr::GetAccountUuid();
     current_character = GetCurrentPlayerNameS();
     inventory_lookup.clear(); // discard now outdated id caches
     while (!hero_bag_generation_order.empty()) hero_bag_generation_order.pop();
@@ -1525,7 +1520,7 @@ void AccountInventoryWindow::PostMapLoad()
     bool character_changed = false;
     map_loaded_delayed_trigger = true;
     map_loaded_delayed_timer = TIMER_INIT();
-    current_account = GetAccountGuid();
+    current_account = GW::AccountMgr::GetAccountUuid();
     current_character = GetCurrentPlayerNameS();
     GW::Inventory* gw_inventory = GW::Items::GetInventory();
     if (last_character != current_character) {
@@ -2077,7 +2072,7 @@ void AccountInventoryWindow::DrawSettingsInternal()
 void AccountInventoryWindow::LoadSettings(ToolboxIni* ini)
 {
     ToolboxWindow::LoadSettings(ini);
-    current_account = GetAccountGuid();
+    current_account = GW::AccountMgr::GetAccountUuid();
     current_character = GetCurrentPlayerNameS();
 
     LOAD_BOOL(detailed_view);

--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -2863,7 +2863,19 @@ void CompletionWindow::LoadSettings(ToolboxIni* ini)
 
         const auto c = GetCharacterCompletion(name_ws.data(), true);
         c->profession = static_cast<Profession>(completion_ini.GetLongValue(ini_section, "profession", 0));
-        c->account = TextUtils::StringToWString(completion_ini.GetValue(ini_section, "account", ""));
+        // Migrate old email-format account IDs to UUID strings
+        {
+            const auto account_raw = TextUtils::StringToWString(completion_ini.GetValue(ini_section, "account", ""));
+            if (!account_raw.empty()) {
+                GUID guid;
+                if (TextUtils::StringToGuid(TextUtils::WStringToString(account_raw), &guid)) {
+                    c->account = account_raw;
+                } else {
+                    guid = TextUtils::ConvertWStringToGuid(account_raw);
+                    c->account = TextUtils::StringToWString(TextUtils::GuidToString(&guid));
+                }
+            }
+        }
         c->is_pvp = completion_ini.GetBoolValue(ini_section, "is_pvp", false);
         c->is_pre_searing = completion_ini.GetBoolValue(ini_section, "is_pre_searing", false);
 

--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -79,27 +79,12 @@ namespace {
         }
     }
 
-    const wchar_t* GetAccountEmail()
-    {
-        const auto c = GW::GetCharContext();
-        return c && *c->player_email ? c->player_email : nullptr;
-    }
-
-    // Returns the portal account UUID as a hex string, falling back to email if UUID is unavailable.
-    // UUID is preferred since it remains stable across email changes.
     std::wstring GetCurrentAccountId()
     {
-        if (const auto uuid = GW::AccountMgr::GetPortalAccountUuid()) {
-            wchar_t buf[33];
-            const auto d = uuid->Data4;
-            swprintf(buf, _countof(buf), L"%08X%04X%04X%02X%02X%02X%02X%02X%02X%02X%02X",
-                static_cast<uint32_t>(uuid->Data1), static_cast<uint32_t>(uuid->Data2),
-                static_cast<uint32_t>(uuid->Data3),
-                d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
-            return buf;
-        }
-        const auto email = GetAccountEmail();
-        return email ? email : L"";
+        const auto uuid = GW::AccountMgr::GetAccountUuid();
+        const GUID empty{};
+        if (memcmp(&uuid, &empty, sizeof(uuid)) == 0) return {};
+        return TextUtils::StringToWString(TextUtils::GuidToString(&uuid));
     }
 
     const wchar_t* GetPlayerName()

--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -85,6 +85,23 @@ namespace {
         return c && *c->player_email ? c->player_email : nullptr;
     }
 
+    // Returns the portal account UUID as a hex string, falling back to email if UUID is unavailable.
+    // UUID is preferred since it remains stable across email changes.
+    std::wstring GetCurrentAccountId()
+    {
+        if (const auto uuid = GW::AccountMgr::GetPortalAccountUuid()) {
+            wchar_t buf[33];
+            const auto d = uuid->Data4;
+            swprintf(buf, _countof(buf), L"%08X%04X%04X%02X%02X%02X%02X%02X%02X%02X%02X",
+                static_cast<uint32_t>(uuid->Data1), static_cast<uint32_t>(uuid->Data2),
+                static_cast<uint32_t>(uuid->Data3),
+                d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
+            return buf;
+        }
+        const auto email = GetAccountEmail();
+        return email ? email : L"";
+    }
+
     const wchar_t* GetPlayerName()
     {
         const auto c = GW::GetCharContext();
@@ -577,11 +594,11 @@ namespace {
         pending_refresh_account_characters = true;
     }
 
-    // Check login screen; assign missing characters to email account
+    // Check login screen; assign missing characters to account guid
     bool UpdateRefreshAccountCharacters()
     {
-        const auto email = GetAccountEmail();
-        if (!email) return false;
+        const auto account_id = GetCurrentAccountId();
+        if (account_id.empty()) return false;
         const auto loading = std::ranges::find_if(character_completion, [](const std::pair<std::wstring, CharacterCompletion*>& t) {
             return t.second->hom_achievements.isLoading();
         });
@@ -591,7 +608,7 @@ namespace {
         if (chars && chars->size()) {
             for (const auto& character : *chars) {
                 const auto cc = CompletionWindow::GetCharacterCompletion(character.player_name, true);
-                cc->account = email;
+                cc->account = account_id;
                 cc->profession = static_cast<Profession>(character.primary());
                 cc->is_pvp = character.is_pvp();
                 cc->is_pre_searing = GW::Map::IsPreSearing(character.map_id());
@@ -599,7 +616,7 @@ namespace {
             // Remove any account chars that no longer exist
             auto it = character_completion.begin();
             while (it != character_completion.end()) {
-                if (it->second->account == email) {
+                if (it->second->account == account_id) {
                     const auto exists = std::ranges::find_if(*chars, [char_name = it->first](const GW::AvailableCharacterInfo& character) {
                         return character.player_name == char_name;
                     });
@@ -616,7 +633,7 @@ namespace {
         if (const auto pn = GetPlayerName()) {
             const auto cc = CompletionWindow::GetCharacterCompletion(pn);
             if (cc) {
-                cc->account = email;
+                cc->account = account_id;
                 cc->is_pre_searing = GW::Map::IsPreSearing();
             }
         }
@@ -2172,7 +2189,7 @@ void CompletionWindow::Draw(IDirect3DDevice9* device)
     ImGui::PushItemWidth(200.f * gscale);
     if (ImGui::BeginCombo("##completion_character_select", chosen_player_name_s.c_str())) // The second parameter is the label previewed before opening the combo.
     {
-        const auto email = GetAccountEmail();
+        const auto account_id = GetCurrentAccountId();
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, {2.f, 8.f});
         bool is_selected = false;
         for (auto& it : character_completion) {
@@ -2181,7 +2198,7 @@ void CompletionWindow::Draw(IDirect3DDevice9* device)
                 is_selected = true;
                 sel = &it.first;
             }
-            if (!is_selected && only_show_account_chars && it.second->account != email) {
+            if (!is_selected && only_show_account_chars && !account_id.empty() && it.second->account != account_id) {
                 continue; // Different account
             }
             if (it.second->is_pvp || it.second->is_pre_searing)
@@ -3078,11 +3095,11 @@ std::vector<CharacterCompletion*> CompletionWindow::GetCharactersWithoutAreaComp
     if (map_id == MapID::None)
         return out;
     const auto info = GW::Map::GetMapInfo(map_id);
-    const auto email = GW::AccountMgr::GetAccountEmail();
+    const auto account_id = GetCurrentAccountId();
     for (auto& it : character_completion) {
         if (it.second->is_pvp || it.second->is_pre_searing)
             continue;
-        if (only_show_account_chars && it.second->account != email)
+        if (only_show_account_chars && !account_id.empty() && it.second->account != account_id)
             continue;
         if (!::IsAreaComplete(it.first.c_str(), map_id, check, info))
             out.push_back(it.second);
@@ -3096,11 +3113,11 @@ std::vector<CharacterCompletion*> CompletionWindow::GetCharactersWithoutAreaComp
 std::vector<CharacterCompletion*> CompletionWindow::GetCharactersWithoutAreaUnlocked(MapID map_id)
 {
     std::vector<CharacterCompletion*> out;
-    const auto email = GW::AccountMgr::GetAccountEmail();
+    const auto account_id = GetCurrentAccountId();
     for (auto& it : character_completion) {
         if (it.second->is_pvp || it.second->is_pre_searing)
             continue;
-        if (only_show_account_chars && it.second->account != email)
+        if (only_show_account_chars && !account_id.empty() && it.second->account != account_id)
             continue;
         if (!IsAreaUnlocked(it.first.c_str(), map_id))
             out.push_back(it.second);
@@ -3114,11 +3131,11 @@ std::vector<CharacterCompletion*> CompletionWindow::GetCharactersWithoutAreaUnlo
 std::vector<CharacterCompletion*> CompletionWindow::GetCharactersWithoutSkillUnlocked(SkillID skill_id)
 {
     std::vector<CharacterCompletion*> out;
-    const auto email = GW::AccountMgr::GetAccountEmail();
+    const auto account_id = GetCurrentAccountId();
     for (auto& it : character_completion) {
         if (it.second->is_pvp || it.second->is_pre_searing)
             continue;
-        if (only_show_account_chars && it.second->account != email)
+        if (only_show_account_chars && !account_id.empty() && it.second->account != account_id)
             continue;
         if (!IsSkillUnlocked(it.first.c_str(), skill_id))
             out.push_back(it.second);

--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -2863,19 +2863,7 @@ void CompletionWindow::LoadSettings(ToolboxIni* ini)
 
         const auto c = GetCharacterCompletion(name_ws.data(), true);
         c->profession = static_cast<Profession>(completion_ini.GetLongValue(ini_section, "profession", 0));
-        // Migrate old email-format account IDs to UUID strings
-        {
-            const auto account_raw = TextUtils::StringToWString(completion_ini.GetValue(ini_section, "account", ""));
-            if (!account_raw.empty()) {
-                GUID guid;
-                if (TextUtils::StringToGuid(TextUtils::WStringToString(account_raw), &guid)) {
-                    c->account = account_raw;
-                } else {
-                    guid = TextUtils::ConvertWStringToGuid(account_raw);
-                    c->account = TextUtils::StringToWString(TextUtils::GuidToString(&guid));
-                }
-            }
-        }
+        c->account = TextUtils::StringToWString(completion_ini.GetValue(ini_section, "account", ""));
         c->is_pvp = completion_ini.GetBoolValue(ini_section, "is_pvp", false);
         c->is_pre_searing = completion_ini.GetBoolValue(ini_section, "is_pre_searing", false);
 


### PR DESCRIPTION
Use the portal account UUID (`GW::AccountMgr::GetPortalAccountUuid()`) instead of email to group characters by account in CompletionWindow. UUID is more stable than email since it doesn't change if the user changes their account email.

Closes #864

Generated with [Claude Code](https://claude.ai/code)