### PR TITLE
Add optional settings cog to window title bars

### DIFF
--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -78,6 +78,7 @@
 #include <Windows/GWMarketWindow.h>
 #include <Windows/InventorySorting.h>
 #include <Windows/PerformanceWindow.h>
+#include <Windows/SettingsWindow.h>
 
 #include <Widgets/TimerWidget.h>
 #include <Widgets/HealthWidget.h>
@@ -320,6 +321,9 @@ void ToolboxSettings::DrawFreezeSetting()
     ImGui::Checkbox("Clamp growing windows to screen bounds", &clamp_windows_to_screen);
     ImGui::NextSpacedElement();
     ImGui::Checkbox("Hide toolbox on loading screens", &hide_on_loading_screen);
+    ImGui::NextSpacedElement();
+    ImGui::Checkbox("Show settings button in window title bars", &show_settings_cog);
+    ImGui::ShowHelp("Show a " ICON_FA_COG " button in the title bar of each window.\nClick it to quickly open that window's settings.");
 }
 
 void ToolboxSettings::LoadSettings(ToolboxIni* ini)
@@ -331,6 +335,7 @@ void ToolboxSettings::LoadSettings(ToolboxIni* ini)
     LOAD_BOOL(clamp_windows_to_screen);
     LOAD_BOOL(hide_on_loading_screen);
     LOAD_BOOL(send_anonymous_gameplay_info);
+    LOAD_BOOL(show_settings_cog);
 
     for (auto& m : optional_modules) {
         m.enabled = ini->GetBoolValue(modules_ini_section, m.name, m.enabled);
@@ -347,6 +352,7 @@ void ToolboxSettings::SaveSettings(ToolboxIni* ini)
     SAVE_BOOL(clamp_windows_to_screen);
     SAVE_BOOL(hide_on_loading_screen);
     SAVE_BOOL(send_anonymous_gameplay_info);
+    SAVE_BOOL(show_settings_cog);
 
     for (const auto& m : optional_modules) {
         ini->SetBoolValue(modules_ini_section, m.name, m.enabled);
@@ -356,6 +362,61 @@ void ToolboxSettings::SaveSettings(ToolboxIni* ini)
 void ToolboxSettings::Draw(IDirect3DDevice9*)
 {
     ImGui::GetStyle().WindowBorderSize = move_all ? 1.0f : 0.0f;
+    DrawSettingsCogButtons();
+}
+
+void ToolboxSettings::DrawSettingsCogButtons()
+{
+    if (!show_settings_cog) return;
+
+    const ImVec2 mouse_pos = ImGui::GetIO().MousePos;
+    ToolboxUIElement* hovered_elem = nullptr;
+
+    for (const auto* elem : GWToolbox::GetUIElements()) {
+        if (!elem->visible || !elem->show_titlebar) continue;
+
+        const ImGuiWindow* window = ImGui::FindWindowByName(elem->Name());
+        if (!window || (window->Flags & ImGuiWindowFlags_NoTitleBar)) continue;
+        if (!window->Viewport) continue;
+
+        const ImRect tb = window->TitleBarRect();
+        const float btn_h = tb.GetHeight();
+
+        // Leave room for the ImGui close button if one is shown
+        const bool close_btn_shown = elem->IsWindow() && elem->GetVisiblePtr() != nullptr;
+        const float close_offset = close_btn_shown ? btn_h : 0.f;
+
+        const ImVec2 btn_min = {tb.Max.x - close_offset - btn_h, tb.Min.y};
+        const ImVec2 btn_max = {btn_min.x + btn_h, tb.Max.y};
+
+        const bool hovered = mouse_pos.x >= btn_min.x && mouse_pos.x < btn_max.x
+                          && mouse_pos.y >= btn_min.y && mouse_pos.y < btn_max.y;
+
+        ImDrawList* dl = ImGui::GetForegroundDrawList(window->Viewport);
+
+        if (hovered) {
+            hovered_elem = const_cast<ToolboxUIElement*>(elem);
+            dl->AddRectFilled(btn_min, btn_max, IM_COL32(255, 255, 255, 30));
+
+            const ImVec2 drag = ImGui::GetMouseDragDelta(ImGuiMouseButton_Left);
+            if (ImGui::IsMouseReleased(ImGuiMouseButton_Left) && drag.x == 0.f && drag.y == 0.f) {
+                SettingsWindow::Instance().NavigateToSection(elem->SettingsName());
+            }
+        }
+
+        const ImVec2 text_size = ImGui::CalcTextSize(ICON_FA_COG);
+        const ImVec2 icon_pos = {
+            btn_min.x + (btn_h - text_size.x) * 0.5f,
+            tb.Min.y  + (btn_h - text_size.y) * 0.5f
+        };
+        ImVec4 col = ImGui::GetStyle().Colors[ImGuiCol_Text];
+        if (!hovered) col.w *= 0.5f;
+        dl->AddText(icon_pos, ImGui::ColorConvertFloat4ToU32(col), ICON_FA_COG);
+    }
+
+    if (hovered_elem) {
+        ImGui::SetTooltip("Open %s settings", hovered_elem->SettingsName());
+    }
 }
 
 void ToolboxSettings::Update(float)

--- a/GWToolboxdll/Modules/ToolboxSettings.h
+++ b/GWToolboxdll/Modules/ToolboxSettings.h
@@ -35,10 +35,13 @@ public:
 
     void DrawSizeAndPositionSettings() override { }
 
+    static void DrawSettingsCogButtons();
+
     static inline bool move_all = false;
     static inline bool clamp_windows_to_screen = false;
     static inline bool hide_on_loading_screen = false;
     static inline bool send_anonymous_gameplay_info = true;
+    static inline bool show_settings_cog = false;
 private:
     // === location stuff ===
     clock_t location_timer = 0;

--- a/GWToolboxdll/Windows/SettingsWindow.cpp
+++ b/GWToolboxdll/Windows/SettingsWindow.cpp
@@ -14,6 +14,12 @@
 
 #include <ToolboxWidget.h>
 
+void SettingsWindow::NavigateToSection(const char* section)
+{
+    visible = true;
+    pending_navigate_to = section;
+}
+
 void SettingsWindow::LoadSettings(ToolboxIni* ini)
 {
     ToolboxWindow::LoadSettings(ini);
@@ -233,6 +239,7 @@ void SettingsWindow::Draw(IDirect3DDevice9*)
         ImGui::PopTextWrapPos();
     }
     ImGui::End();
+    pending_navigate_to.clear(); // consumed inside DrawSettingsSection, or cleared if section wasn't found
 }
 
 bool SettingsWindow::DrawSettingsSection(const char* section)
@@ -260,6 +267,10 @@ bool SettingsWindow::DrawSettingsSection(const char* section)
     const auto pos = ImGui::GetCursorScreenPos();
     const auto padding = ImGui::GetStyle().FramePadding;
     float header_text_offset_x = text_height + padding.x * 3;
+    const bool should_navigate = !pending_navigate_to.empty() && pending_navigate_to == section;
+    if (should_navigate) {
+        ImGui::SetNextItemOpen(true, ImGuiCond_Always);
+    }
     const bool is_showing = ImGui::CollapsingHeader(std::format("##{}",section).c_str(), ImGuiTreeNodeFlags_AllowOverlap);
     ImGui::SameLine(header_text_offset_x);
     if (icon) {
@@ -267,6 +278,10 @@ bool SettingsWindow::DrawSettingsSection(const char* section)
         ImGui::SameLine(header_text_offset_x += text_height + padding.x);
     }
     ImGui::TextUnformatted(section);
+    if (should_navigate) {
+        ImGui::SetScrollHereY(0.0f);
+        pending_navigate_to.clear();
+    }
 
     ImGui::PushID(section);
     size_t i = 0;

--- a/GWToolboxdll/Windows/SettingsWindow.h
+++ b/GWToolboxdll/Windows/SettingsWindow.h
@@ -28,6 +28,9 @@ public:
 
     bool DrawSettingsSection(const char* section);
 
+    // Open this window and scroll/expand the given settings section
+    void NavigateToSection(const char* section);
+
     size_t sep_modules = 0;
     size_t sep_windows = 0;
     size_t sep_widgets = 0;
@@ -35,4 +38,5 @@ public:
 private:
     std::map<std::string, bool> drawn_settings{};
     bool hide_when_entering_explorable = false;
+    std::string pending_navigate_to;
 };


### PR DESCRIPTION
Adds a global toggle (default: off) that overlays a ⚙ icon in the title bar of every visible Toolbox window. Clicking it opens the Settings window and scrolls directly to that window's settings section.

Resolves #1384

Generated with [Claude Code](https://claude.ai/code)