### PR TITLE
fix: increase timeout for Kokoro TTS to fix multi-sentence audio generation

### DIFF
--- a/GWToolboxdll/Modules/TextToSpeechModule.cpp
+++ b/GWToolboxdll/Modules/TextToSpeechModule.cpp
@@ -1022,7 +1022,7 @@ Gender GetGenderByFileId(const uint32_t file_id)
         return total_size;
     }
 
-    std::string PostJson(RestClient& client, const std::string& url, const nlohmann::json& request_body, const std::string& service_name = "API")
+    std::string PostJson(RestClient& client, const std::string& url, const nlohmann::json& request_body, const std::string& service_name = "API", int timeout_sec = 2)
     {
         client.SetUrl(url.c_str());
         client.SetHeader("Content-Type", "application/json");
@@ -1030,7 +1030,7 @@ Gender GetGenderByFileId(const uint32_t file_id)
         client.SetFollowLocation(true);
         client.SetVerifyHost(false);
         client.SetVerifyPeer(false);
-        client.SetTimeoutSec(2);
+        client.SetTimeoutSec(timeout_sec);
         client.Execute();
         if (!client.IsSuccessful()) {
             VoiceLog("%s returned error code: %ld", service_name.c_str(), client.GetStatusCode());
@@ -1164,7 +1164,8 @@ Gender GetGenderByFileId(const uint32_t file_id)
         request_body["lang_code"] = lang_code;
 
         RestClient client;
-        const auto audio_data = PostJson(client, base_url + "/v1/audio/speech", request_body, api_config->name);
+        // Kokoro streams audio as it generates; long texts can take 60+ seconds on CPU hardware
+        const auto audio_data = PostJson(client, base_url + "/v1/audio/speech", request_body, api_config->name, 120);
         if (!audio_data.empty()) VoiceLog("Kokoro voice generation successful, received %zu bytes", audio_data.size());
         return audio_data;
     }


### PR DESCRIPTION
Kokoro-FastAPI streams audio responses: it sends HTTP 200 OK headers immediately but only delivers the body after fully generating audio. For long texts on CPU-only hardware this can take 60+ seconds. The shared PostJson() helper was hard-coding a 2-second timeout, so the connection timed out while waiting for the streamed body.

Add an optional timeout_sec parameter to PostJson (default 2, preserving all other providers) and pass 120 for Kokoro so CPU-based servers have enough time to generate full dialogue.

Fixes #1756

Generated with [Claude Code](https://claude.ai/code)