### PR TITLE
Fix GetNearestOutpost returning wrong outpost when given an outpost

### DIFF
--- a/GWToolboxdll/Windows/TravelWindow.cpp
+++ b/GWToolboxdll/Windows/TravelWindow.cpp
@@ -894,6 +894,10 @@ GW::Constants::MapID TravelWindow::GetNearestOutpostToPlayer()
 
 GW::Constants::MapID TravelWindow::GetNearestOutpost(const GW::Constants::MapID map_to)
 {
+    // If map_to is itself a valid unlocked outpost, just return it directly.
+    if (IsValidOutpost(map_to) && GW::Map::GetIsMapUnlocked(map_to))
+        return map_to;
+
     // BFS over the map adjacency graph to find the nearest unlocked outpost.
     // When multiple outposts are found at the same BFS depth, use Euclidean
     // distance on the world map as a tiebreaker.


### PR DESCRIPTION
GetNearestOutpost skipped the starting node, so passing an outpost MapID (e.g. from the Completion Window) returned the nearest *other* outpost via BFS instead of the outpost itself.