### PR TITLE
feat: add bag/slot mode to Use Item hotkey

### DIFF
--- a/GWToolboxdll/Windows/Hotkeys.cpp
+++ b/GWToolboxdll/Windows/Hotkeys.cpp
@@ -813,19 +813,31 @@ void HotkeySendChat::Execute()
 HotkeyUseItem::HotkeyUseItem(const ToolboxIni* ini, const char* section)
     : TBHotkey(ini, section)
 {
+    if (!ini) {
+        return;
+    }
     item_id = static_cast<size_t>(ini->GetLongValue(section, "ItemID", 0));
     strcpy_s(name, ini->GetValue(section, "ItemName", ""));
+    bag_idx = static_cast<size_t>(ini->GetLongValue(section, "Bag", bag_idx));
+    slot_idx = static_cast<size_t>(ini->GetLongValue(section, "Slot", slot_idx));
+    use_by = static_cast<UseBy>(ini->GetLongValue(section, "UseBy", use_by));
 }
 
 void HotkeyUseItem::Save(ToolboxIni* ini, const char* section) const
 {
     TBHotkey::Save(ini, section);
+    ini->SetLongValue(section, "UseBy", use_by);
     ini->SetLongValue(section, "ItemID", item_id);
     ini->SetValue(section, "ItemName", name);
+    ini->SetLongValue(section, "Bag", bag_idx);
+    ini->SetLongValue(section, "Slot", slot_idx);
 }
 
 int HotkeyUseItem::Description(char* buf, const size_t bufsz)
 {
+    if (use_by == SLOT) {
+        return snprintf(buf, bufsz, "Use item in bag %d slot %d", bag_idx, slot_idx);
+    }
     if (!name[0]) {
         return snprintf(buf, bufsz, "Use #%d", item_id);
     }
@@ -834,8 +846,23 @@ int HotkeyUseItem::Description(char* buf, const size_t bufsz)
 
 bool HotkeyUseItem::Draw()
 {
-    bool hotkey_changed = ImGui::InputInt("Item Model ID", (int*)&item_id);
-    hotkey_changed |= ImGui::InputText("Item Name", name, _countof(name));
+    bool hotkey_changed = false;
+    constexpr const char* bags[6] = {"None", "Backpack", "Belt Pouch", "Bag 1", "Bag 2", "Equipment Pack"};
+    ImGui::TextUnformatted("Use By: ");
+    ImGui::SameLine();
+    hotkey_changed |= ImGui::RadioButton("Item", (int*)&use_by, ITEM);
+    ImGui::ShowHelp("Find and use an item by its model ID, regardless of location in inventory.");
+    ImGui::SameLine();
+    hotkey_changed |= ImGui::RadioButton("Slot", (int*)&use_by, SLOT);
+    ImGui::ShowHelp("Use the item in a specific bag slot, regardless of what it is.\nUseful for quick equipment swapping or using consumables regardless of type.");
+    if (use_by == SLOT) {
+        hotkey_changed |= ImGui::Combo("Bag", (int*)&bag_idx, bags, _countof(bags));
+        hotkey_changed |= ImGui::InputInt("Slot (1-25)", (int*)&slot_idx);
+    }
+    else {
+        hotkey_changed |= ImGui::InputInt("Item Model ID", (int*)&item_id);
+        hotkey_changed |= ImGui::InputText("Item Name", name, _countof(name));
+    }
     hotkey_changed |= ImGui::Checkbox("Display error message on failure", &show_error_on_failure);
     return hotkey_changed;
 }
@@ -845,6 +872,30 @@ void HotkeyUseItem::Execute()
     if (!CanUse()) {
         return;
     }
+
+    if (use_by == SLOT) {
+        const auto bag_id = static_cast<GW::Constants::Bag>(bag_idx);
+        if (bag_id < GW::Constants::Bag::Backpack || bag_id > GW::Constants::Bag::Equipment_Pack || slot_idx < 1 || slot_idx > 25) {
+            show_error_on_failure && (Log::Error("Invalid bag slot %d/%d!", bag_id, slot_idx), true);
+            return;
+        }
+        const GW::Bag* bag = GW::Items::GetBag(bag_id);
+        if (!bag) {
+            show_error_on_failure && (Log::Error("Bag #%d not found!", bag_id), true);
+            return;
+        }
+        const GW::ItemArray& items = bag->items;
+        GW::Item* item = (items.valid() && slot_idx <= items.size()) ? items[slot_idx - 1] : nullptr;
+        if (!(item && item->bag == bag)) {
+            show_error_on_failure && (Log::Error("No item in bag %d slot %d!", bag_id, slot_idx), true);
+            return;
+        }
+        if (!GW::Items::UseItem(item) && show_error_on_failure) {
+            Log::Error("Failed to use item in bag %d slot %d!", bag_id, slot_idx);
+        }
+        return;
+    }
+
     if (item_id == 0) {
         return;
     }

--- a/GWToolboxdll/Windows/Hotkeys.h
+++ b/GWToolboxdll/Windows/Hotkeys.h
@@ -179,6 +179,14 @@ class HotkeyUseItem : public TBHotkey {
     UINT item_id = 0;
     char name[140]{};
 
+    UINT bag_idx = 0;
+    UINT slot_idx = 0;
+
+    enum UseBy : int {
+        ITEM,
+        SLOT
+    } use_by = ITEM;
+
 public:
     static const char* IniSection() { return "UseItem"; }
     [[nodiscard]] const char* Name() const override { return IniSection(); }
@@ -187,7 +195,7 @@ public:
 
     void Save(ToolboxIni* ini, const char* section) const override;
 
-    bool CanUse() override { return TBHotkey::CanUse() && item_id != 0; }
+    bool CanUse() override { return TBHotkey::CanUse() && (use_by == SLOT || item_id != 0); }
 
     bool Draw() override;
     int Description(char* buf, size_t bufsz) override;


### PR DESCRIPTION
## Summary
- Adds a `UseBy` radio toggle (Item / Slot) to the **Use Item** hotkey, mirroring the pattern already used by the **Equip Item** hotkey.
- In Slot mode the hotkey activates whatever item occupies the selected bag/slot — useful for quick equipment swapping or using consumables regardless of type (e.g. alcohol).
- Existing `UseItem` ini entries default to Item mode, preserving prior behavior.

## Test plan
- [ ] Create a new Use Item hotkey, leave default Item mode, set a model id, confirm it still uses the matching item.
- [ ] Switch the same hotkey to Slot mode, pick Backpack / slot 1 (or wherever an alcohol/consumable is), trigger and confirm the slot's item is used.
- [ ] Save and reload settings; confirm both modes round-trip correctly.
- [ ] Trigger the slot hotkey on an empty slot; confirm the "No item in bag X slot Y" error appears (or stays silent if the failure-error toggle is off).

Closes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)