### PR TITLE
Add /custommarker chat command for world map markers

### DIFF
--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -350,6 +350,9 @@ namespace {
                                 "Use the skill number instead of [slot] (e.g. '/useskill 5').\n"
                                 "Use '/useskill [stop|off|slot|0]' to stop the skill.";
 
+    constexpr auto custommarker_syntax = "'/custommarker <x> <y>' to place a custom marker at world map coordinates (x, y).\n"
+                                         "'/custommarker clear' to remove the custom marker.";
+
     void CHAT_CMD_FUNC(CmdChatTab)
     {
         if (argc < 2) {
@@ -1409,6 +1412,8 @@ const GW::AgentTargetFlags AnyLivingNpc = GW::TargetFilter::AnyLiving & ~GW::Age
                     "\t'toggle' alternate between given value and configuration on disk.\n"
                     "\t'load' reset key to its disk configuration.");
         ImGui::Bullet();
+        ImGui::Text(custommarker_syntax);
+        ImGui::Bullet();
         ImGui::Text("'/damage' or '/dmg' to print party damage to chat.\n"
             "'/damage me' sends your own damage only.\n"
             "'/damage <number>' sends the damage of a party member (e.g. '/damage 3').\n"
@@ -1868,6 +1873,19 @@ void CHAT_CMD_FUNC(ChatCommands::CmdPingQuest)
     Instance().quest_ping.Init();
 }
 
+void CHAT_CMD_FUNC(ChatCommands::CmdCustomMarker)
+{
+    if (argc == 2 && wcscmp(argv[1], L"clear") == 0) {
+        QuestModule::ClearCustomQuestMarker();
+        return;
+    }
+    float x, y;
+    if (argc < 3 || !TextUtils::ParseFloat(argv[1], &x) || !TextUtils::ParseFloat(argv[2], &y)) {
+        return Log::Error(custommarker_syntax);
+    }
+    QuestModule::SetCustomQuestMarker({x, y});
+}
+
 void ChatCommands::Initialize()
 {
     ToolboxModule::Initialize();
@@ -1950,6 +1968,7 @@ void ChatCommands::Initialize()
         {L"addhenchman", CmdAddHenchman},
         {L"addhero", CmdAddHero},
         {L"leave", CmdLeave},
+        {L"custommarker", CmdCustomMarker},
     };
 
 

--- a/GWToolboxdll/Modules/ChatCommands.h
+++ b/GWToolboxdll/Modules/ChatCommands.h
@@ -54,6 +54,7 @@ public:
     void Update(float delta) override;
 
     static void CHAT_CMD_FUNC(CmdReapplyTitle);
+    static void CHAT_CMD_FUNC(CmdCustomMarker);
 
     // Add a /setting <setting_name> [1|0|toggle] command to easily change a static setting in memory. NB: static_setting_ptr MUST be a pointer to a STATIC location in memory!
     static void RegisterSettingChatCommand(const wchar_t* setting_name, const bool* static_setting_ptr, const wchar_t* description = nullptr);


### PR DESCRIPTION
Adds `/custommarker <x> <y>` to place a custom quest marker at the given world map coordinates, and `/custommarker clear` to remove it.

Closes #1955

Generated with [Claude Code](https://claude.ai/code)