### PR TITLE
Separate InventoryManager::Item into InventoryItem.h/cpp

### DIFF
--- a/GWToolboxdll/Modules/InventoryItem.cpp
+++ b/GWToolboxdll/Modules/InventoryItem.cpp
@@ -1,0 +1,157 @@
+#include "stdafx.h"
+
+#include <GWCA/Constants/Constants.h>
+#include <GWCA/Managers/TradeMgr.h>
+
+#include <Utils/ToolboxUtils.h>
+
+#include "Modules/InventoryItem.h"
+
+GW::ItemModifier* InventoryItem::GetModifier(const uint32_t identifier) const
+{
+    for (size_t i = 0; i < mod_struct_size; i++) {
+        GW::ItemModifier* mod = &mod_struct[i];
+        if (mod->identifier() == identifier) {
+            return mod;
+        }
+    }
+    return nullptr;
+}
+
+uint32_t InventoryItem::GetUses() const
+{
+    const GW::ItemModifier* mod = GetModifier(0x2458);
+    return (mod ? mod->arg2() : 1) * quantity;
+}
+
+bool InventoryItem::IsSalvageKit() const
+{
+    return IsLesserKit() || IsExpertSalvageKit();
+}
+
+bool InventoryItem::IsTome() const
+{
+    const GW::ItemModifier* mod = GetModifier(0x2788);
+    const uint32_t use_id = mod ? mod->arg() : 0;
+    return use_id > 15 && use_id < 36;
+}
+
+bool InventoryItem::IsIdentificationKit() const
+{
+    const GW::ItemModifier* mod = GetModifier(0x25E8);
+    return mod && mod->arg1() == 1;
+}
+
+bool InventoryItem::IsLesserKit() const
+{
+    const GW::ItemModifier* mod = GetModifier(0x25E8);
+    return mod && mod->arg1() == 3;
+}
+
+bool InventoryItem::IsExpertSalvageKit() const
+{
+    const GW::ItemModifier* mod = GetModifier(0x25E8);
+    return mod && mod->arg1() == 2;
+}
+
+bool InventoryItem::IsPerfectSalvageKit() const
+{
+    const GW::ItemModifier* mod = GetModifier(0x25E8);
+    return mod && mod->arg1() == 6;
+}
+
+bool InventoryItem::IsRareMaterial() const
+{
+    const GW::ItemModifier* mod = GetModifier(0x2508);
+    return mod && mod->arg1() > 11;
+}
+
+bool InventoryItem::IsInventoryItem() const
+{
+    return bag && (bag->IsInventoryBag() || bag->bag_type == GW::Constants::BagType::Equipped);
+}
+
+bool InventoryItem::IsStorageItem() const
+{
+    return bag && (bag->IsStorageBag() || bag->IsMaterialStorage());
+}
+
+GW::Constants::Rarity InventoryItem::GetRarity() const
+{
+    return GW::Items::GetRarity(this);
+}
+
+bool InventoryItem::IsWeapon() const
+{
+    switch (static_cast<GW::Constants::ItemType>(type)) {
+        case GW::Constants::ItemType::Axe:
+        case GW::Constants::ItemType::Sword:
+        case GW::Constants::ItemType::Shield:
+        case GW::Constants::ItemType::Scythe:
+        case GW::Constants::ItemType::Bow:
+        case GW::Constants::ItemType::Wand:
+        case GW::Constants::ItemType::Staff:
+        case GW::Constants::ItemType::Offhand:
+        case GW::Constants::ItemType::Daggers:
+        case GW::Constants::ItemType::Hammer:
+        case GW::Constants::ItemType::Spear:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool InventoryItem::IsArmor() const
+{
+    switch (static_cast<GW::Constants::ItemType>(type)) {
+        case GW::Constants::ItemType::Headpiece:
+        case GW::Constants::ItemType::Chestpiece:
+        case GW::Constants::ItemType::Leggings:
+        case GW::Constants::ItemType::Boots:
+        case GW::Constants::ItemType::Gloves:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool InventoryItem::IsOfferedInTrade() const
+{
+    return GW::Trade::IsItemOffered(item_id) != nullptr;
+}
+
+bool InventoryItem::CanBeIdentified() const
+{
+    if (GetIsIdentified()) return false;
+    if (IsSalvagable(false)) return true;
+    switch (type) {
+        case GW::Constants::ItemType::Bundle:
+        case GW::Constants::ItemType::Usable:
+        case GW::Constants::ItemType::Quest_Item:
+        case GW::Constants::ItemType::Storybook:
+            return false;
+    }
+    if (IsWeapon() || IsArmor()) return true;
+    if (IsGreen()) return false;
+    switch (model_file_id) {
+        case 0x44CAC:
+            return false;
+    }
+    return true;
+}
+
+bool InventoryItem::IsOldSchool() const
+{
+    // Not OS if inscribable (Nightfall/EotN) or not salvagable
+    if (GetIsInscribable() || !IsSalvagable(false)) return false;
+
+    // OS off-hands (wand/focus/shield) have 2 inherent mods, no upgrade slots
+    switch (type) {
+        case GW::Constants::ItemType::Wand:
+        case GW::Constants::ItemType::Offhand:
+            return !IsUpgradable();
+    }
+
+    // Other OS weapons have 1 inherent + 1 suffix slot (so they ARE upgradable)
+    return IsWeapon() && !IsPrefixUpgradable();
+}

--- a/GWToolboxdll/Modules/InventoryItem.h
+++ b/GWToolboxdll/Modules/InventoryItem.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <GWCA/GameEntities/Item.h>
+
+namespace GW {
+    namespace Constants {
+        enum class Rarity : uint8_t;
+    }
+}
+
+struct InventoryItem : GW::Item {
+    GW::ItemModifier* GetModifier(uint32_t identifier) const;
+    GW::Constants::Rarity GetRarity() const;
+    uint32_t GetUses() const;
+    bool IsIdentificationKit() const;
+    bool IsSalvageKit() const;
+    bool IsTome() const;
+    bool IsLesserKit() const;
+    bool IsExpertSalvageKit() const;
+    bool IsPerfectSalvageKit() const;
+    bool IsWeapon() const;
+    bool IsArmor() const;
+    bool IsSalvagable(bool check_bag = true, bool check_blocked_from_being_salvaged = true) const;
+    bool IsHiddenFromMerchants() const;
+
+    bool IsInventoryItem() const;
+    bool IsStorageItem() const;
+
+    bool IsRareMaterial() const;
+    bool IsOfferedInTrade() const;
+    bool CanOfferToTrade() const;
+
+    [[nodiscard]] bool IsSparkly() const
+    {
+        return (interaction & 0x2000) == 0;
+    }
+
+    [[nodiscard]] bool GetIsIdentified() const
+    {
+        return (interaction & 1) != 0;
+    }
+    [[nodiscard]] bool CanBeIdentified() const;
+    [[nodiscard]] bool IsPrefixUpgradable() const
+    {
+        return ((interaction >> 14) & 1) == 0;
+    }
+
+    [[nodiscard]] bool IsSuffixUpgradable() const
+    {
+        return ((interaction >> 15) & 1) == 0;
+    }
+
+    [[nodiscard]] bool IsUsable() const
+    {
+        return (interaction & 0x1000000) != 0;
+    }
+
+    [[nodiscard]] bool IsTradable() const
+    {
+        return (interaction & 0x100) == 0;
+    }
+
+    [[nodiscard]] bool IsInscription() const
+    {
+        return (interaction & 0x25000000) == 0x25000000;
+    }
+
+    [[nodiscard]] bool IsOldSchool() const;
+
+    [[nodiscard]] bool IsUpgradable() const
+    {
+        return GetIsInscribable() || IsPrefixUpgradable() || IsSuffixUpgradable();
+    }
+
+    [[nodiscard]] bool IsBlue() const
+    {
+        return single_item_name && single_item_name[0] == 0xA3F;
+    }
+
+    [[nodiscard]] bool IsPurple() const
+    {
+        return (interaction & 0x400000) != 0;
+    }
+
+    [[nodiscard]] bool IsGreen() const
+    {
+        return (interaction & 0x10) != 0;
+    }
+
+    [[nodiscard]] bool IsGold() const
+    {
+        return (interaction & 0x20000) != 0;
+    }
+};

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -179,10 +179,6 @@ namespace {
     PendingItem pending_salvage_kit;
     PendingTransaction pending_transaction;
 
-    bool wcseq(const wchar_t* a, const wchar_t* b) {
-        return a && b && wcscmp(a, b) == 0;
-    }
-
     bool GetIsProfessionUnlocked(GW::Constants::ProfessionByte prof)
     {
         const auto world = GW::GetWorldContext();
@@ -2681,12 +2677,7 @@ void InventoryManager::ItemClickCallback(GW::HookStatus* status, GW::UI::UIPacke
 #pragma warning(pop)
 }
 
-bool InventoryManager::Item::IsOfferedInTrade() const
-{
-    return GW::Trade::IsItemOffered(item_id) != nullptr;
-}
-
-bool InventoryManager::Item::CanOfferToTrade() const
+bool InventoryItem::CanOfferToTrade() const
 {
     auto* player_items = GetPlayerTradeItems();
     if (!player_items) {
@@ -2695,43 +2686,7 @@ bool InventoryManager::Item::CanOfferToTrade() const
     return IsTradable() && IsTradeWindowOpen() && !IsOfferedInTrade() && player_items->size() < 7;
 }
 
-bool InventoryManager::Item::CanBeIdentified() const
-{
-    if (GetIsIdentified()) return false;
-    if (IsSalvagable(false)) return true;
-    switch (type) {
-        case GW::Constants::ItemType::Bundle:
-        case GW::Constants::ItemType::Usable:
-        case GW::Constants::ItemType::Quest_Item:
-        case GW::Constants::ItemType::Storybook:
-            return false;
-    }
-    if (IsWeapon() || IsArmor()) return true;
-    if (IsGreen()) return false;
-    switch (model_file_id) {
-        case 0x44CAC:
-            return false;
-    }
-    return true;
-}
-
-bool InventoryManager::Item::IsOldSchool() const
-{
-    // Not OS if inscribable (Nightfall/EotN) or not salvagable
-    if (GetIsInscribable() || !IsSalvagable(false)) return false;
-
-    // OS off-hands (wand/focus/shield) have 2 inherent mods, no upgrade slots
-    switch (type) {
-        case GW::Constants::ItemType::Wand:
-        case GW::Constants::ItemType::Offhand:
-            return !IsUpgradable();
-    }
-
-    // Other OS weapons have 1 inherent + 1 suffix slot (so they ARE upgradable)
-    return IsWeapon() && !IsPrefixUpgradable();
-}
-
-bool InventoryManager::Item::IsSalvagable(bool check_bag, bool check_blocked_from_being_salvaged) const
+bool InventoryItem::IsSalvagable(bool check_bag, bool check_blocked_from_being_salvaged) const
 {
     if (item_formula == 0x5da) {
         return false;
@@ -2768,41 +2723,7 @@ bool InventoryManager::Item::IsSalvagable(bool check_bag, bool check_blocked_fro
     return false;
 }
 
-bool InventoryManager::Item::IsWeapon() const
-{
-    switch (static_cast<GW::Constants::ItemType>(type)) {
-        case GW::Constants::ItemType::Axe:
-        case GW::Constants::ItemType::Sword:
-        case GW::Constants::ItemType::Shield:
-        case GW::Constants::ItemType::Scythe:
-        case GW::Constants::ItemType::Bow:
-        case GW::Constants::ItemType::Wand:
-        case GW::Constants::ItemType::Staff:
-        case GW::Constants::ItemType::Offhand:
-        case GW::Constants::ItemType::Daggers:
-        case GW::Constants::ItemType::Hammer:
-        case GW::Constants::ItemType::Spear:
-            return true;
-        default:
-            return false;
-    }
-}
-
-bool InventoryManager::Item::IsArmor() const
-{
-    switch (static_cast<GW::Constants::ItemType>(type)) {
-        case GW::Constants::ItemType::Headpiece:
-        case GW::Constants::ItemType::Chestpiece:
-        case GW::Constants::ItemType::Leggings:
-        case GW::Constants::ItemType::Boots:
-        case GW::Constants::ItemType::Gloves:
-            return true;
-        default:
-            return false;
-    }
-}
-
-bool InventoryManager::Item::IsHiddenFromMerchants() const
+bool InventoryItem::IsHiddenFromMerchants() const
 {
     if (hide_unsellable_items && !value) {
         return true;
@@ -2817,80 +2738,6 @@ bool InventoryManager::Item::IsHiddenFromMerchants() const
         return true;
     }
     return false;
-}
-
-GW::ItemModifier* InventoryManager::Item::GetModifier(const uint32_t identifier) const
-{
-    for (size_t i = 0; i < mod_struct_size; i++) {
-        GW::ItemModifier* mod = &mod_struct[i];
-        if (mod->identifier() == identifier) {
-            return mod;
-        }
-    }
-    return nullptr;
-}
-
-// InventoryManager::Item definitions
-
-uint32_t InventoryManager::Item::GetUses() const
-{
-    const GW::ItemModifier* mod = GetModifier(0x2458);
-    return (mod ? mod->arg2() : 1) * quantity;
-}
-
-bool InventoryManager::Item::IsSalvageKit() const
-{
-    return IsLesserKit() || IsExpertSalvageKit(); // || IsPerfectSalvageKit();
-}
-
-bool InventoryManager::Item::IsTome() const
-{
-    const GW::ItemModifier* mod = GetModifier(0x2788);
-    const uint32_t use_id = mod ? mod->arg() : 0;
-    return use_id > 15 && use_id < 36;
-}
-
-bool InventoryManager::Item::IsIdentificationKit() const
-{
-    const GW::ItemModifier* mod = GetModifier(0x25E8);
-    return mod && mod->arg1() == 1;
-}
-
-bool InventoryManager::Item::IsLesserKit() const
-{
-    const GW::ItemModifier* mod = GetModifier(0x25E8);
-    return mod && mod->arg1() == 3;
-}
-
-bool InventoryManager::Item::IsExpertSalvageKit() const
-{
-    const GW::ItemModifier* mod = GetModifier(0x25E8);
-    return mod && mod->arg1() == 2;
-}
-
-bool InventoryManager::Item::IsPerfectSalvageKit() const
-{
-    const GW::ItemModifier* mod = GetModifier(0x25E8);
-    return mod && mod->arg1() == 6;
-}
-
-bool InventoryManager::Item::IsRareMaterial() const
-{
-    const GW::ItemModifier* mod = GetModifier(0x2508);
-    return mod && mod->arg1() > 11;
-}
-bool InventoryManager::Item::IsInventoryItem() const
-{
-    return bag && (bag->IsInventoryBag() || bag->bag_type == GW::Constants::BagType::Equipped);
-}
-bool InventoryManager::Item::IsStorageItem() const
-{
-    return bag && (bag->IsStorageBag() || bag->IsMaterialStorage());
-}
-
-GW::Constants::Rarity InventoryManager::Item::GetRarity() const
-{
-    return GW::Items::GetRarity(this);
 }
 
 bool PendingItem::set(const InventoryManager::Item* item)

--- a/GWToolboxdll/Modules/InventoryManager.h
+++ b/GWToolboxdll/Modules/InventoryManager.h
@@ -2,11 +2,11 @@
 
 #include <GWCA/Utilities/Hook.h>
 
-#include <GWCA/GameEntities/Item.h>
-
 #include <Utils/GuiUtils.h>
 
 #include <ToolboxWidget.h>
+
+#include <Modules/InventoryItem.h>
 
 namespace GW {
     namespace Constants {
@@ -91,89 +91,7 @@ protected:
     void ShowVisibleRadio() override { }
 
 public:
-    struct Item : GW::Item {
-        GW::ItemModifier* GetModifier(uint32_t identifier) const;
-        GW::Constants::Rarity GetRarity() const;
-        uint32_t GetUses() const;
-        bool IsIdentificationKit() const;
-        bool IsSalvageKit() const;
-        bool IsTome() const;
-        bool IsLesserKit() const;
-        bool IsExpertSalvageKit() const;
-        bool IsPerfectSalvageKit() const;
-        bool IsWeapon() const;
-        bool IsArmor() const;
-        bool IsSalvagable(bool check_bag = true, bool check_blocked_from_being_salvaged = true) const;
-        bool IsHiddenFromMerchants() const;
-
-        bool IsInventoryItem() const;
-        bool IsStorageItem() const;
-
-        bool IsRareMaterial() const;
-        bool IsOfferedInTrade() const;
-        bool CanOfferToTrade() const;
-
-        [[nodiscard]] bool IsSparkly() const
-        {
-            return (interaction & 0x2000) == 0;
-        }
-
-        [[nodiscard]] bool GetIsIdentified() const
-        {
-            return (interaction & 1) != 0;
-        }
-        [[nodiscard]] bool CanBeIdentified() const;
-        [[nodiscard]] bool IsPrefixUpgradable() const
-        {
-            return ((interaction >> 14) & 1) == 0;
-        }
-
-        [[nodiscard]] bool IsSuffixUpgradable() const
-        {
-            return ((interaction >> 15) & 1) == 0;
-        }
-
-        [[nodiscard]] bool IsUsable() const
-        {
-            return (interaction & 0x1000000) != 0;
-        }
-
-        [[nodiscard]] bool IsTradable() const
-        {
-            return (interaction & 0x100) == 0;
-        }
-
-        [[nodiscard]] bool IsInscription() const
-        {
-            return (interaction & 0x25000000) == 0x25000000;
-        }
-
-        [[nodiscard]] bool IsOldSchool() const;
-
-        [[nodiscard]] bool IsUpgradable() const { 
-            return GetIsInscribable() || IsPrefixUpgradable() || IsSuffixUpgradable();
-        }
-
-        [[nodiscard]] bool IsBlue() const
-        {
-            return single_item_name && single_item_name[0] == 0xA3F;
-        }
-
-        [[nodiscard]] bool IsPurple() const
-        {
-            return (interaction & 0x400000) != 0;
-        }
-
-        [[nodiscard]] bool IsGreen() const
-        {
-            return (interaction & 0x10) != 0;
-        }
-
-        [[nodiscard]] bool IsGold() const
-        {
-            return (interaction & 0x20000) != 0;
-        }
-    };
+    using Item = InventoryItem;
 
     static uint16_t MoveItem(const Item* item, const uint16_t quantity = 1000u);
     static Item* GetNextUnsalvagedItem(const Item* salvage_kit = nullptr, const Item* start_after_item = nullptr);


### PR DESCRIPTION
Closes #1958

Separates the `InventoryManager::Item` class into its own `InventoryItem.h` and `InventoryItem.cpp` files. `InventoryManager` now exposes `using Item = InventoryItem`, so all existing callers are unchanged.

Methods that depend on InventoryManager module-local state (`IsSalvagable`, `IsHiddenFromMerchants`, `CanOfferToTrade`) remain implemented in InventoryManager.cpp.

Also removes an unused anonymous-namespace `wcseq` duplicate in InventoryManager.cpp — the only call site was already using `::wcseq` which resolves to the global definition in TextUtils.h.

Generated with [Claude Code](https://claude.ai/code)