### PR TITLE
Add Resources::GetHeroName and refactor hardcoded hero name arrays

### DIFF
--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -7,11 +7,13 @@
 #include <GWCA/GameEntities/Map.h>
 #include <GWCA/GameEntities/Item.h>
 #include <GWCA/GameEntities/Skill.h>
+#include <GWCA/GameEntities/Hero.h>
 
 #include <GWCA/Managers/SkillbarMgr.h>
 #include <GWCA/Managers/MapMgr.h>
 #include <GWCA/Managers/UIMgr.h>
 #include <GWCA/Managers/ItemMgr.h>
+#include <GWCA/Managers/PartyMgr.h>
 
 #include <EmbeddedResource.h>
 #include <GWToolbox.h>
@@ -132,6 +134,7 @@ namespace {
     std::unordered_map<GW::Constants::MapID, GuiUtils::EncString*> map_names;
     std::unordered_map<GW::Constants::SkillID, GuiUtils::EncString*> skill_names;
     std::unordered_map<GW::Constants::MapID, GuiUtils::EncString*> region_names;
+    std::unordered_map<GW::Constants::HeroID, GuiUtils::EncString*> hero_names;
     std::unordered_map<GW::Constants::Language, std::unordered_map<uint32_t, std::unique_ptr<GuiUtils::EncString>>> encoded_string_ids;
     std::filesystem::path current_settings_folder;
     constexpr size_t MAX_WORKERS = 20;
@@ -1176,6 +1179,17 @@ IDirect3DTexture9** Resources::GetSkillImageFromGWW(GW::Constants::SkillID skill
 GuiUtils::EncString* Resources::GetSkillName(const GW::Constants::SkillID skill_id)
 {
     return DecodeStringId(GW::SkillbarMgr::GetSkillConstantData(skill_id)->name);
+}
+
+GuiUtils::EncString* Resources::GetHeroName(const GW::Constants::HeroID hero_id)
+{
+    const auto found = hero_names.find(hero_id);
+    if (found != hero_names.end()) {
+        return found->second;
+    }
+    const auto hero_data = GW::PartyMgr::GetHeroConstData(hero_id);
+    hero_names[hero_id] = DecodeStringId(hero_data ? hero_data->name_id : 0x3);
+    return hero_names[hero_id];
 }
 
 GuiUtils::EncString* Resources::GetMapName(const GW::Constants::MapID map_id)

--- a/GWToolboxdll/Modules/Resources.h
+++ b/GWToolboxdll/Modules/Resources.h
@@ -13,6 +13,7 @@ namespace GW {
         enum class MapID : uint32_t;
         enum class SkillID : uint32_t;
         enum class Language;
+        enum HeroID : uint32_t;
     }
 }
 
@@ -116,6 +117,9 @@ public:
 
     // Guaranteed to return a pointer, but may not yet be decoded.
     static GuiUtils::EncString* GetMapName(GW::Constants::MapID map_id);
+
+    // Guaranteed to return a pointer, but may not yet be decoded.
+    static GuiUtils::EncString* GetHeroName(GW::Constants::HeroID hero_id);
 
     static const wchar_t* GetRegionName(GW::Constants::MapID map_id);
     // Guaranteed to return a pointer, but may not yet be decoded.

--- a/GWToolboxdll/Windows/AccountInventoryWindow.cpp
+++ b/GWToolboxdll/Windows/AccountInventoryWindow.cpp
@@ -47,51 +47,7 @@ namespace {
     constexpr clock_t MAP_LOADED_DELAYED_TIMEOUT = 400;
     constexpr clock_t SAVE_DIRTY_INVENTORIES_TIMEOUT = 1000;
 
-const char* HERO_NAME[] = {
-        "(Player)",
-        "Norgu",
-        "Goren",
-        "Tahlkora",
-        "Master Of Whispers",
-        "Acolyte Jin",
-        "Koss",
-        "Dunkoro",
-        "Acolyte Sousuke",
-        "Melonni",
-        "Zhed Shadowhoof",
-        "General Morgahn",
-        "Margrid The Sly",
-        "Zenmai",
-        "Olias",
-        "Razah",
-        "MOX",
-        "Keiran Thackeray",
-        "Jora",
-        "Pyre Fierceshot",
-        "Anton",
-        "Livia",
-        "Hayda",
-        "Kahmu",
-        "Gwen",
-        "Xandra",
-        "Vekk",
-        "Ogden",
-        "Mercenary Hero 1",
-        "Mercenary Hero 2",
-        "Mercenary Hero 3",
-        "Mercenary Hero 4",
-        "Mercenary Hero 5",
-        "Mercenary Hero 6",
-        "Mercenary Hero 7",
-        "Mercenary Hero 8",
-        "Miku",
-        "Zei Ri",
-        "Devona",
-        "Ghost of Althea"
-    };
-
-
-  const char* BAG_NAME[] = {"",          "Backpack",  "Belt Pouch", "Bag 1",     "Bag 2",     "Equipment Pack", "Material Storage", "Unclaimed Items", "Storage 1",  "Storage 2",  "Storage 3",     "Storage 4",
+    const char* BAG_NAME[] = {"",          "Backpack",  "Belt Pouch", "Bag 1",     "Bag 2",     "Equipment Pack", "Material Storage", "Unclaimed Items", "Storage 1",  "Storage 2",  "Storage 3",     "Storage 4",
                           "Storage 5", "Storage 6", "Storage 7",  "Storage 8", "Storage 9", "Storage 10",     "Storage 11",       "Storage 12",      "Storage 13", "Storage 14", "Equipped Items"};
     uint32_t GetMaxBagCapacity(GW::Constants::Bag bag_id)
     {
@@ -862,7 +818,7 @@ struct MergeStack;
                 item.model_file_id = i->model_file_id;
                 item.interaction = i->interaction;
                 i->texture = Resources::GetItemImage(&item);
-                i->location = HERO_NAME[i->hero_id];
+                i->location = i->hero_id == GW::Constants::HeroID::NoHero ? "(Player)" : Resources::GetHeroName(i->hero_id)->string();
                 if (IsChestBag(i->bag_id)) {
                     i->location = BAG_NAME[(int)(i->bag_id)];
                 }
@@ -1074,7 +1030,7 @@ struct MergeStack;
         i->equipped = item->equipped;
         i->item_id = item->item_id;
         i->texture = Resources::GetItemImage(item);
-        i->location = HERO_NAME[i->hero_id];
+        i->location = i->hero_id == GW::Constants::HeroID::NoHero ? "(Player)" : Resources::GetHeroName(i->hero_id)->string();
         if (IsChestBag(i->bag_id)) {
             i->location = BAG_NAME[(int)(i->bag_id)];
         }

--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -1060,7 +1060,7 @@ void HeroUnlock::CheckProgress(const std::wstring& player_name)
 
 const char* HeroUnlock::Name()
 {
-    return hero_names[std::to_underlying(skill_id)];
+    return Resources::GetHeroName(static_cast<GW::Constants::HeroID>(std::to_underlying(skill_id)))->string().c_str();
 }
 
 size_t HeroUnlock::GetLoadedIcons(IDirect3DTexture9* icons_out[4])

--- a/GWToolboxdll/Windows/CompletionWindow_Constants.h
+++ b/GWToolboxdll/Windows/CompletionWindow_Constants.h
@@ -7,31 +7,6 @@ namespace CompletionWindow_Constants {
     constexpr std::array campaign_names = {"Core", "Prophecies", "Factions", "Nightfall", "Eye Of The North", "Dungeons"};
 
     const char* CampaignName(const Campaign camp) { return campaign_names[std::to_underlying(camp)]; }
-    constexpr std::array hero_names = {"", "Norgu", "Goren", "Tahlkora", "Master of Whispers", "Acolyte Jin", "Koss", "Dunkoro", "Acolyte Sousuke", "Melonni", "Zhed Shadowhoof", "General Morgahn", "Margrid the Sly", "Zenmai", "Olias", "Razah", "M.O.X.",
-        "Keiran Thackeray",
-        "Jora",
-        "Pyre Fierceshot",
-        "Anton",
-        "Livia",
-        "Hayda",
-        "Kahmu",
-        "Gwen",
-        "Xandra",
-        "Vekk",
-        "Ogden Stonehealer",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "Miku",
-        "Zei Ri",
-        "Devona",
-        "Ghost of Althea"
-    };
 
 
     // GW loads these icons as an array of file hashes once, and then keeps it in memory - I can't find where these are in RDATA reliably, so have to define them here :(

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -86,11 +86,6 @@ namespace {
         HeroID::GhostOfAlthea
     };
 
-    GuiUtils::EncString* GetHeroEncName(GW::Constants::HeroID hero_id) {
-        const auto c = GW::PartyMgr::GetHeroConstData(hero_id);
-        return Resources::DecodeStringId(c ? c->name_id : 1);
-    }
-
     // Returns hero IDs sorted by name; re-sorts each frame until all names are decoded.
     const std::vector<HeroID>& SortedHeroIDs() {
         static std::vector<HeroID> sorted;
@@ -102,13 +97,13 @@ namespace {
             }
             bool all_decoded = true;
             for (const auto id : sorted) {
-                if (GetHeroEncName(id)->string().empty()) {
+                if (Resources::GetHeroName(id)->string().empty()) {
                     all_decoded = false;
                     break;
                 }
             }
             std::ranges::sort(sorted, [](const HeroID a, const HeroID b) {
-                return _stricmp(GetHeroEncName(a)->string().c_str(), GetHeroEncName(b)->string().c_str()) < 0;
+                return _stricmp(Resources::GetHeroName(a)->string().c_str(), Resources::GetHeroName(b)->string().c_str()) < 0;
             });
             is_sorted = all_decoded;
         }
@@ -375,7 +370,7 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                             [](void*, const int idx, const char** out_text) -> bool {
                                 const auto& heroes = SortedHeroIDs();
                                 if (idx < 0 || idx >= static_cast<int>(heroes.size())) return false;
-                                *out_text = GetHeroEncName(heroes[idx])->string().c_str();
+                                *out_text = Resources::GetHeroName(heroes[idx])->string().c_str();
                                 return true;
                             },
                             nullptr, static_cast<int>(sorted_heroes.size()))) {
@@ -663,7 +658,7 @@ void HeroBuildsWindow::HeroBuildName(const TeamHeroBuild& tbuild, const size_t i
     if (name.empty() && code.empty() && id == HeroID::NoHero) {
         return; // nothing to do here
     }
-    const char* c = GetHeroEncName(id)->string().c_str();
+    const char* c = Resources::GetHeroName(id)->string().c_str();
 
     if (name.empty()) {
         if (idx > 0) {


### PR DESCRIPTION
Adds `Resources::GetHeroName(GW::Constants::HeroID)` returning `GuiUtils::EncString*` using `GW::PartyMgr::GetHeroConstData` to resolve names from in-game data.

Removes three hardcoded hero name arrays:
- `HERO_NAME[]` in AccountInventoryWindow.cpp
- `hero_names[]` in CompletionWindow_Constants.h
- Local `GetHeroEncName()` in HeroBuildsWindow.cpp

Refactors all callers to use `Resources::GetHeroName` instead.

Closes #1961

Generated with [Claude Code](https://claude.ai/code)