### PR TITLE
Add team chat toast/flash notifications

### DIFF
--- a/GWToolboxdll/Modules/ToastNotifications.cpp
+++ b/GWToolboxdll/Modules/ToastNotifications.cpp
@@ -8,6 +8,7 @@
 #include <GWCA/Packets/StoC.h>
 #include <GWCA/GameEntities/Agent.h>
 #include <GWCA/GameEntities/Party.h>
+#include <GWCA/GameEntities/Player.h>
 
 #include <GWCA/Managers/AgentMgr.h>
 #include <GWCA/Managers/ChatMgr.h>
@@ -120,6 +121,8 @@ namespace {
         }
         GuiUtils::FocusWindow();
     }
+
+    void SendEncodedToastMessage(const wchar_t* title, wchar_t* encoded_message);
 
     GW::HookEntry OnWhisper_Entry;
     GW::HookEntry OnTeamChat_Entry;

--- a/GWToolboxdll/Modules/ToastNotifications.cpp
+++ b/GWToolboxdll/Modules/ToastNotifications.cpp
@@ -37,6 +37,7 @@ namespace {
     bool show_notifications_on_whisper = true;
     bool show_notifications_on_guild_chat = false;
     bool show_notifications_on_ally_chat = false;
+    bool show_notifications_on_team_chat = false;
     bool show_notifications_on_last_to_ready = false;
     bool show_notifications_on_invite = false;
     bool show_notifications_on_everyone_ready = false;
@@ -45,6 +46,7 @@ namespace {
     bool flash_window_on_whisper = true;
     bool flash_window_on_guild_chat = false;
     bool flash_window_on_ally_chat = false;
+    bool flash_window_on_team_chat = false;
     bool flash_window_on_last_to_ready = false;
     bool flash_window_on_invite = false;
     bool flash_window_on_everyone_ready = false;
@@ -120,6 +122,7 @@ namespace {
     }
 
     GW::HookEntry OnWhisper_Entry;
+    GW::HookEntry OnTeamChat_Entry;
 
     void OnRecvWhisper(GW::HookStatus*, GW::UI::UIMessage, void* wparam, void*)
     {
@@ -131,6 +134,33 @@ namespace {
         if (flash_window_on_whisper) {
             FlashWindow();
         }
+    }
+
+    void OnTeamChatMessage(GW::HookStatus* status, GW::UI::UIMessage, void* wparam, void*)
+    {
+        if (status->blocked) {
+            return;
+        }
+        const auto packet = static_cast<GW::UI::UIPacket::kPlayerChatMessage*>(wparam);
+        if (packet->channel != GW::Chat::Channel::CHANNEL_GROUP) {
+            return;
+        }
+        if (packet->player_number == GW::PlayerMgr::GetPlayerNumber()) {
+            return; // Don't notify on own messages
+        }
+        if (flash_window_on_team_chat) {
+            FlashWindow();
+        }
+        if (!show_notifications_on_team_chat) {
+            return;
+        }
+        const auto sender = GW::PlayerMgr::GetPlayerByID(packet->player_number);
+        const wchar_t* sender_name = sender && sender->name ? sender->name : L"Unknown";
+        const size_t msg_len = wcslen(sender_name) + wcslen(packet->message) + 10;
+        const auto msg_with_sender = new wchar_t[msg_len];
+        swprintf(msg_with_sender, msg_len, L"\x108\x107%s: \x1\x2%s", sender_name, packet->message);
+        SendEncodedToastMessage(L"Team Chat", msg_with_sender);
+        delete[] msg_with_sender;
     }
 
     void TriggerToastCallback(const ToastNotifications::Toast* toast, const bool result)
@@ -423,6 +453,7 @@ void ToastNotifications::Initialize()
 
     is_platform_compatible = WinToastLib::WinToast::isCompatible();
     GW::UI::RegisterUIMessageCallback(&OnWhisper_Entry, GW::UI::UIMessage::kRecvWhisper, OnRecvWhisper);
+    GW::UI::RegisterUIMessageCallback(&OnTeamChat_Entry, GW::UI::UIMessage::kPlayerChatMessage, OnTeamChatMessage);
     for (auto& callback : stoc_callbacks) {
         GW::StoC::RegisterPacketCallback(&callback.hook_entry, callback.header, callback.cb, 0x8000);
     }
@@ -440,6 +471,7 @@ void ToastNotifications::Terminate()
         GW::StoC::RemoveCallback(callback.header, &callback.hook_entry);
     }
     GW::UI::RemoveUIMessageCallback(&OnWhisper_Entry);
+    GW::UI::RemoveUIMessageCallback(&OnTeamChat_Entry);
     for (const auto& toast : toasts | std::views::values) {
         TriggerToastCallback(toast, false);
         delete toast;
@@ -453,25 +485,23 @@ void ToastNotifications::DrawSettingsInternal()
     ImGui::TextDisabled("GWToolbox++ can send notifications and flash the taskbar on certain in-game triggers.");
 
     constexpr float checkbox_w = 150.f;
+    const auto NextCheckbox = [](const char* label, bool* v) {
+        ImGui::NextSpacedElement();
+        ImGui::Checkbox(label, v);
+    };
 
     ImGui::PushID("desktop_notifications");
     ImGui::Text("Send a desktop notification on:");
     ImGui::Indent();
     ImGui::StartSpacedElements(checkbox_w);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Whisper", &show_notifications_on_whisper);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Guild Chat", &show_notifications_on_guild_chat);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Alliance Chat", &show_notifications_on_ally_chat);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Party Invite", &show_notifications_on_invite);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Last to Tick", &show_notifications_on_last_to_ready);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Everyone Ticked", &show_notifications_on_everyone_ready);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Resurrection", &show_notifications_on_self_resurrected);
+    NextCheckbox("Whisper", &show_notifications_on_whisper);
+    NextCheckbox("Guild Chat", &show_notifications_on_guild_chat);
+    NextCheckbox("Alliance Chat", &show_notifications_on_ally_chat);
+    NextCheckbox("Team Chat", &show_notifications_on_team_chat);
+    NextCheckbox("Party Invite", &show_notifications_on_invite);
+    NextCheckbox("Last to Tick", &show_notifications_on_last_to_ready);
+    NextCheckbox("Everyone Ticked", &show_notifications_on_everyone_ready);
+    NextCheckbox("Resurrection", &show_notifications_on_self_resurrected);
     ImGui::Unindent();
     ImGui::PopID();
 
@@ -479,36 +509,25 @@ void ToastNotifications::DrawSettingsInternal()
     ImGui::Text("Flash taskbar on:");
     ImGui::Indent();
     ImGui::StartSpacedElements(checkbox_w);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Whisper", &flash_window_on_whisper);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Guild Chat", &flash_window_on_guild_chat);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Alliance Chat", &flash_window_on_ally_chat);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Party Invite", &flash_window_on_invite);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Last to Tick", &flash_window_on_last_to_ready);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Everyone Ticked", &flash_window_on_everyone_ready);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Resurrection", &flash_window_on_self_resurrected);
+    NextCheckbox("Whisper", &flash_window_on_whisper);
+    NextCheckbox("Guild Chat", &flash_window_on_guild_chat);
+    NextCheckbox("Alliance Chat", &flash_window_on_ally_chat);
+    NextCheckbox("Team Chat", &flash_window_on_team_chat);
+    NextCheckbox("Party Invite", &flash_window_on_invite);
+    NextCheckbox("Last to Tick", &flash_window_on_last_to_ready);
+    NextCheckbox("Everyone Ticked", &flash_window_on_everyone_ready);
+    NextCheckbox("Resurrection", &flash_window_on_self_resurrected);
     ImGui::Unindent();
     ImGui::PopID();
 
     ImGui::Text("Allow these notifications when Guild Wars is:");
     ImGui::Indent();
     ImGui::StartSpacedElements(checkbox_w);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Minimised", &show_notifications_when_minimised);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("In Background", &show_notifications_when_in_background);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("In Focus", &show_notifications_when_focussed);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("In Outpost", &show_notifications_when_in_outpost);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("In Explorable", &show_notifications_when_in_explorable);
+    NextCheckbox("Minimised", &show_notifications_when_minimised);
+    NextCheckbox("In Background", &show_notifications_when_in_background);
+    NextCheckbox("In Focus", &show_notifications_when_focussed);
+    NextCheckbox("In Outpost", &show_notifications_when_in_outpost);
+    NextCheckbox("In Explorable", &show_notifications_when_in_explorable);
     ImGui::Unindent();
 
     if (ImGui::Button("Show Test Notification")) {
@@ -529,6 +548,7 @@ void ToastNotifications::LoadSettings(ToolboxIni* ini)
     LOAD_BOOL(show_notifications_on_whisper);
     LOAD_BOOL(show_notifications_on_guild_chat);
     LOAD_BOOL(show_notifications_on_ally_chat);
+    LOAD_BOOL(show_notifications_on_team_chat);
     LOAD_BOOL(show_notifications_on_invite);
     LOAD_BOOL(show_notifications_on_last_to_ready);
     LOAD_BOOL(show_notifications_on_everyone_ready);
@@ -537,6 +557,7 @@ void ToastNotifications::LoadSettings(ToolboxIni* ini)
     LOAD_BOOL(flash_window_on_whisper);
     LOAD_BOOL(flash_window_on_guild_chat);
     LOAD_BOOL(flash_window_on_ally_chat);
+    LOAD_BOOL(flash_window_on_team_chat);
     LOAD_BOOL(flash_window_on_invite);
     LOAD_BOOL(flash_window_on_last_to_ready);
     LOAD_BOOL(flash_window_on_everyone_ready);
@@ -556,6 +577,7 @@ void ToastNotifications::SaveSettings(ToolboxIni* ini)
     SAVE_BOOL(show_notifications_on_whisper);
     SAVE_BOOL(show_notifications_on_guild_chat);
     SAVE_BOOL(show_notifications_on_ally_chat);
+    SAVE_BOOL(show_notifications_on_team_chat);
     SAVE_BOOL(show_notifications_on_invite);
     SAVE_BOOL(show_notifications_on_last_to_ready);
     SAVE_BOOL(show_notifications_on_everyone_ready);
@@ -564,6 +586,7 @@ void ToastNotifications::SaveSettings(ToolboxIni* ini)
     SAVE_BOOL(flash_window_on_whisper);
     SAVE_BOOL(flash_window_on_guild_chat);
     SAVE_BOOL(flash_window_on_ally_chat);
+    SAVE_BOOL(flash_window_on_team_chat);
     SAVE_BOOL(flash_window_on_invite);
     SAVE_BOOL(flash_window_on_last_to_ready);
     SAVE_BOOL(flash_window_on_everyone_ready);


### PR DESCRIPTION
Extends the toast notifications module to support team chat (CHANNEL_GROUP), alongside whisper, guild chat, and alliance chat.

**Changes:**
- Add `show_notifications_on_team_chat` and `flash_window_on_team_chat` settings
- Register `OnTeamChatMessage` handler via `kPlayerChatMessage` UIMessage, filtering for CHANNEL_GROUP and skipping own messages
- Sender name is prepended to the encoded message before `AsyncDecodeStr`
- Refactor `DrawSettingsInternal` with a `NextCheckbox` helper lambda (~19 lines saved)

Closes #1966

Generated with [Claude Code](https://claude.ai/code)