### PR TITLE
Show bounty kill counter when count is 0

### DIFF
--- a/GWToolboxdll/Widgets/BountyKillTrackerWidget.cpp
+++ b/GWToolboxdll/Widgets/BountyKillTrackerWidget.cpp
@@ -239,7 +239,6 @@ void BountyKillTrackerWidget::Draw(IDirect3DDevice9*)
     ImGui::PushFont(FontLoader::GetFont(), draw_list, font_size);
 
     for (const auto& [skill_id, state] : active_bounties) {
-        if (state.kill_count == 0) continue;
         const auto* skill_frame = GW::UI::GetChildFrame(effects_frame, static_cast<uint32_t>(skill_id) + 0x4);
         if (!skill_frame) continue;
         std::array<char, 16> count_str{};


### PR DESCRIPTION
Show the kill counter overlay even when the count is 0, so it appears immediately when a bounty is picked up.

References #1970

Generated with [Claude Code](https://claude.ai/code)