### PR TITLE
Add character inventory sorting (backpack, bags, belt pouch)

### DIFF
--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -544,7 +544,7 @@ namespace GW {
                 case ItemType::Chestpiece:
                     return "Chestpiece";
                 case ItemType::Rune_Mod:
-                    return "Rune";
+                    return "Rune/Upgrade";
                 case ItemType::Usable:
                     return "Usable Item";
                 case ItemType::Dye:

--- a/GWToolboxdll/Windows/InventorySorting.cpp
+++ b/GWToolboxdll/Windows/InventorySorting.cpp
@@ -63,6 +63,7 @@ namespace {
 
     // Sort order configuration
     std::vector<GW::Constants::ItemType> sort_order;
+    bool sort_equipment_pack = false;
 
     // Primary key: item type (from sort_order). Secondary key: for Nicholas collectibles,
     // weeks until Nick requests them (0 = this week); for all other items, model_file_id.
@@ -280,6 +281,7 @@ void InventorySorting::LoadSettings(ToolboxIni* ini)
         ResetSortOrder();
     }
 
+    LOAD_BOOL(sort_equipment_pack);
 }
 
 void InventorySorting::SaveSettings(ToolboxIni* ini)
@@ -294,6 +296,8 @@ void InventorySorting::SaveSettings(ToolboxIni* ini)
         snprintf(key, sizeof(key), "sort_order_%zu", i);
         ini->SetLongValue(Name(), key, static_cast<long>(std::to_underlying(sort_order[i])));
     }
+
+    SAVE_BOOL(sort_equipment_pack);
 }
 
 void InventorySorting::Draw(IDirect3DDevice9*)
@@ -304,6 +308,26 @@ void InventorySorting::Draw(IDirect3DDevice9*)
 void InventorySorting::DrawSettingsInternal()
 {
     ImGui::PushID("inventory_sorting_settings");
+
+    // Character inventory sorting
+    {
+        bool sort_char_inv = false;
+        if (ImGui::ConfirmButton("Sort Character Inventory!", &sort_char_inv)) {
+            const auto end_bag = sort_equipment_pack
+                ? GW::Constants::Bag::Equipment_Pack
+                : GW::Constants::Bag::Bag_2;
+            Resources::EnqueueWorkerTask([end_bag]() {
+                SortInventory(GW::Constants::Bag::Backpack, end_bag);
+            });
+        }
+        ImGui::SameLine();
+        ImGui::Checkbox("Include Equipment Pack", &sort_equipment_pack);
+    }
+
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
     bool open = ImGui::CollapsingHeader("Change Storage Inventory Sorting Order", ImGuiTreeNodeFlags_SpanLabelWidth);
     ImGui::SameLine(0.f, 20.f);
     bool sort_inv = false;

--- a/GWToolboxdll/Windows/InventorySorting.cpp
+++ b/GWToolboxdll/Windows/InventorySorting.cpp
@@ -7,6 +7,7 @@
 
 #include <GWCA/Constants/Constants.h>
 
+#include <GWCA/Managers/ChatMgr.h>
 #include <GWCA/Managers/GameThreadMgr.h>
 #include <GWCA/Managers/ItemMgr.h>
 #include <GWCA/Managers/MapMgr.h>
@@ -61,6 +62,14 @@ namespace {
     bool pending_cancel = false;
     size_t items_sorted_count = 0;
 
+    // Chat command hook entries
+    GW::HookEntry sort_inventory_cmd_entry;
+    GW::HookEntry sort_storage_cmd_entry;
+
+    // Flags set by chat commands to trigger confirm dialogs on the next Draw
+    bool pending_sortinventory_confirm = false;
+    bool pending_sortstorage_confirm = false;
+
     // Sort order configuration
     std::vector<GW::Constants::ItemType> sort_order;
     bool sort_equipment_pack = false;
@@ -106,6 +115,16 @@ namespace {
         const uint32_t priority_b = GetItemSortPriority(item_b);
 
         return priority_a < priority_b;
+    }
+
+    void CHAT_CMD_FUNC(CmdSortInventory)
+    {
+        pending_sortinventory_confirm = true;
+    }
+
+    void CHAT_CMD_FUNC(CmdSortStorage)
+    {
+        pending_sortstorage_confirm = true;
     }
 
     /**
@@ -252,8 +271,17 @@ void InventorySorting::Initialize()
 {
     ToolboxUIElement::Initialize();
 
-    // Initialize default sort order
     ResetSortOrder();
+
+    GW::Chat::CreateCommand(&sort_inventory_cmd_entry, L"sortinventory", CmdSortInventory);
+    GW::Chat::CreateCommand(&sort_storage_cmd_entry, L"sortstorage", CmdSortStorage);
+}
+
+void InventorySorting::Terminate()
+{
+    ToolboxUIElement::Terminate();
+    GW::Chat::DeleteCommand(&sort_inventory_cmd_entry);
+    GW::Chat::DeleteCommand(&sort_storage_cmd_entry);
 }
 
 void InventorySorting::LoadSettings(ToolboxIni* ini)
@@ -303,6 +331,45 @@ void InventorySorting::SaveSettings(ToolboxIni* ini)
 void InventorySorting::Draw(IDirect3DDevice9*)
 {
     DrawSortInventoryPopup();
+
+    if (pending_sortinventory_confirm) {
+        pending_sortinventory_confirm = false;
+        ImGui::OpenPopup("##sortinventory_confirm");
+    }
+    if (ImGui::BeginPopupModal("##sortinventory_confirm", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::TextUnformatted("Are you sure you want to sort character inventory?");
+        if (ImGui::Button("OK", ImVec2(120, 0)) || ImGui::IsKeyReleased(ImGuiKey_Enter)) {
+            const auto end_bag = sort_equipment_pack ? GW::Constants::Bag::Equipment_Pack : GW::Constants::Bag::Bag_2;
+            Resources::EnqueueWorkerTask([end_bag]() {
+                SortInventory(GW::Constants::Bag::Backpack, end_bag);
+            });
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", ImVec2(120, 0))) {
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
+    }
+
+    if (pending_sortstorage_confirm) {
+        pending_sortstorage_confirm = false;
+        ImGui::OpenPopup("##sortstorage_confirm");
+    }
+    if (ImGui::BeginPopupModal("##sortstorage_confirm", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::TextUnformatted("Are you sure you want to sort storage inventory?");
+        if (ImGui::Button("OK", ImVec2(120, 0)) || ImGui::IsKeyReleased(ImGuiKey_Enter)) {
+            Resources::EnqueueWorkerTask([]() {
+                SortInventory(GW::Constants::Bag::Storage_1, GW::Constants::Bag::Storage_14);
+            });
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", ImVec2(120, 0))) {
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
+    }
 }
 
 void InventorySorting::DrawSettingsInternal()

--- a/GWToolboxdll/Windows/InventorySorting.h
+++ b/GWToolboxdll/Windows/InventorySorting.h
@@ -26,6 +26,7 @@ public:
     [[nodiscard]] const char* Icon() const override { return ICON_FA_SORT; }
 
     void Initialize() override;
+    void Terminate() override;
     void Draw(IDirect3DDevice9* device) override;
     void LoadSettings(ToolboxIni* ini) override;
     void SaveSettings(ToolboxIni* ini) override;


### PR DESCRIPTION
Adds a "Sort Character Inventory" button to the Inventory Sorting settings, covering backpack, belt pouch, bag 1 and bag 2. An "Include Equipment Pack" checkbox is available but off by default to avoid reordering armor sets. Also renames the "Rune" sort category to "Rune/Upgrade" to better reflect that it covers weapon mods and insignia.

Closes #1669

Generated with [Claude Code](https://claude.ai/code)