### PR TITLE
Fix /tp preferring explorable zones over outposts with same name

### DIFF
--- a/GWToolboxdll/Windows/TravelWindow.cpp
+++ b/GWToolboxdll/Windows/TravelWindow.cpp
@@ -602,8 +602,16 @@ namespace {
                 return false;
             // Now that this one has decoded, check that there's nothing yet in the searchable areas that have the same name, e.g. festival outposts
             if (searchable_area_indeces_by_name.contains(it->Name())) {
-                vec.erase(vec.begin() + i);
-                delete it;
+                auto* existing = searchable_area_indeces_by_name[it->Name()];
+                // Prefer outposts over non-outposts (e.g. The Eternal Grove outpost vs explorable)
+                if (IsValidOutpost(it->map_id) && !IsValidOutpost(existing->map_id)) {
+                    auto existing_pos = std::ranges::find(vec, existing);
+                    vec.erase(existing_pos);
+                    delete existing;
+                } else {
+                    vec.erase(vec.begin() + i);
+                    delete it;
+                }
                 return CheckSearchableAreasDecoded(vec);
             }
             searchable_area_indeces_by_name[it->Name()] = it;


### PR DESCRIPTION
When deduplicating searchable areas with identical names (e.g. The Eternal Grove exists as both an explorable zone and a mission outpost), keep the outpost instead of whichever has the lower map ID. Previously the explorable zone won, causing /tp to resolve it via nearest-outpost adjacency to the wrong destination (Vasburg Armory).