### PR TITLE
Add offline status reminder when creating a party search

### DIFF
--- a/GWToolboxdll/Modules/PartyWindowModule.cpp
+++ b/GWToolboxdll/Modules/PartyWindowModule.cpp
@@ -20,6 +20,10 @@
 #include <GWCA/Managers/GameThreadMgr.h>
 #include <GWCA/Managers/UIMgr.h>
 #include <GWCA/Managers/SkillbarMgr.h>
+#include <GWCA/Managers/FriendListMgr.h>
+#include <GWCA/Managers/PlayerMgr.h>
+
+#include <GWCA/GameEntities/Friendslist.h>
 
 #include <ImGuiAddons.h>
 #include <Logger.h>
@@ -110,6 +114,9 @@ namespace {
     std::map<GW::Constants::MapID, std::wstring> map_names_by_id;
 
     bool is_explorable = false;
+
+    clock_t offline_party_search_reminder_last_sent = 0;
+    bool check_party_search_offline_reminder = false;
 
     bool IsPvE()
     {
@@ -517,6 +524,14 @@ namespace {
     {
         if (status->blocked) return;
         switch (message_id) {
+            case GW::UI::UIMessage::kPartySearchCreated:
+            case GW::UI::UIMessage::kPartySearchUpdated: {
+                const auto* party_search = static_cast<GW::PartySearch*>(wparam);
+                if (!party_search) break;
+                const wchar_t* my_name = GW::PlayerMgr::GetPlayerName();
+                if (!my_name || wcscmp(my_name, party_search->party_leader) != 0) break;
+                check_party_search_offline_reminder = true;
+            } break;
             case GW::UI::UIMessage::kSetAgentProfession: {
                 const auto agent_id = *(uint32_t*)wparam;
                 if (GW::PartyMgr::IsAgentInParty(agent_id)) RefreshPartySortHandler();
@@ -825,6 +840,13 @@ namespace {
 
 void PartyWindowModule::Update(float delta) {
     ToolboxModule::Update(delta);
+    if (check_party_search_offline_reminder) {
+        check_party_search_offline_reminder = false;
+        if (TIMER_DIFF(offline_party_search_reminder_last_sent) > 10000 && GW::FriendListMgr::GetMyStatus() == GW::FriendStatus::Offline) {
+            offline_party_search_reminder_last_sent = TIMER_INIT();
+            Log::Flash("You're currently offline, and won't receive party search responses.\nType '/online' in chat to set your status to Online.");
+        }
+    }
     while (!summons_pending.empty()) {
         const SummonPending summon = summons_pending.front();
 
@@ -958,10 +980,12 @@ void PartyWindowModule::Initialize()
     );
 
     const GW::UI::UIMessage ui_messages[] = {
-        GW::UI::UIMessage::kSetAgentProfession, 
-        GW::UI::UIMessage::kPartyRemovePlayer, 
+        GW::UI::UIMessage::kSetAgentProfession,
+        GW::UI::UIMessage::kPartyRemovePlayer,
         GW::UI::UIMessage::kPartyAddPlayer,
-        GW::UI::UIMessage::kMapLoaded
+        GW::UI::UIMessage::kMapLoaded,
+        GW::UI::UIMessage::kPartySearchCreated,
+        GW::UI::UIMessage::kPartySearchUpdated
     };
     for (auto ui_message : ui_messages) {
         GW::UI::RegisterUIMessageCallback(&OnPostUIMessage_HookEntry, ui_message, OnPostUIMessage, 0x8000);


### PR DESCRIPTION
Fixes #1165

When a player creates or updates a party search (e.g. trade advert) while their friend list status is Offline, flash a reminder that they won't receive party search responses and prompt them to go online.

Hooks into `kPartySearchCreated` and `kPartySearchUpdated` UI messages in `PartyWindowModule`, filtering to only the local player's own searches via party leader name comparison.

Generated with [Claude Code](https://claude.ai/code)