### PR TITLE
feat: Add multi-tab support to Notepad widget

### DIFF
--- a/GWToolboxdll/Windows/NotePadWindow.cpp
+++ b/GWToolboxdll/Windows/NotePadWindow.cpp
@@ -7,25 +7,119 @@
 #include <ImGuiAddons.h>
 
 namespace {
-    constexpr auto text_buffer_length = 2024 * 16;
-    char* text_buffer = nullptr;
+    constexpr size_t text_buffer_length = 2024 * 16;
+    constexpr size_t tab_name_length = 64;
 
     constexpr float text_size_min = static_cast<float>(FontLoader::FontSize::text);
     float font_size = static_cast<float>(FontLoader::FontSize::text);
 
-    bool filedirty = false;
+    struct NotepadTab {
+        char name[tab_name_length]{};
+        char* text = nullptr;
+        bool dirty = false;
+        int id = 0;
+
+        NotepadTab(int tab_id, const char* tab_name)
+            : id(tab_id)
+        {
+            text = new char[text_buffer_length]{};
+            if (tab_name && *tab_name) {
+                strncpy_s(name, tab_name, tab_name_length - 1);
+            }
+        }
+
+        ~NotepadTab() { delete[] text; }
+
+        NotepadTab(const NotepadTab&) = delete;
+        NotepadTab& operator=(const NotepadTab&) = delete;
+    };
+
+    std::vector<std::unique_ptr<NotepadTab>> tabs;
+    int next_tab_id = 0;
+    int renaming_tab = -1;
+    bool rename_needs_focus = false;
+    char rename_buf[tab_name_length]{};
+
+    std::wstring GetTabFilename(int id)
+    {
+        return L"Notepad_" + std::to_wstring(id) + L".txt";
+    }
+
+    NotepadTab* AddTab(const char* name = nullptr, int id = -1)
+    {
+        if (id < 0) {
+            id = next_tab_id++;
+        }
+        else {
+            next_tab_id = std::max(next_tab_id, id + 1);
+        }
+        std::string default_name;
+        if (!name || !*name) {
+            default_name = "Note " + std::to_string(tabs.size() + 1);
+            name = default_name.c_str();
+        }
+        auto tab = std::make_unique<NotepadTab>(id, name);
+        NotepadTab* ptr = tab.get();
+        tabs.push_back(std::move(tab));
+        return ptr;
+    }
+
+    void SaveTabContent(size_t idx)
+    {
+        if (idx >= tabs.size() || !tabs[idx]->dirty) {
+            return;
+        }
+        auto& tab = *tabs[idx];
+        const auto path = Resources::GetPath(GetTabFilename(tab.id));
+        std::ofstream file(path);
+        if (file) {
+            file.write(tab.text, strlen(tab.text));
+            tab.dirty = false;
+        }
+    }
+
+    void LoadTabContent(size_t idx)
+    {
+        if (idx >= tabs.size()) {
+            return;
+        }
+        auto& tab = *tabs[idx];
+        const auto path = Resources::GetPath(GetTabFilename(tab.id));
+        std::ifstream file(path);
+        if (file) {
+            file.get(tab.text, text_buffer_length, '\0');
+        }
+    }
+
+    void DeleteTab(int idx)
+    {
+        if (idx < 0 || idx >= static_cast<int>(tabs.size()) || tabs.size() <= 1) {
+            return;
+        }
+        const auto path = Resources::GetPath(GetTabFilename(tabs[idx]->id));
+        std::filesystem::remove(path);
+        tabs.erase(tabs.begin() + idx);
+
+        if (renaming_tab == idx) {
+            renaming_tab = -1;
+        }
+        else if (renaming_tab > idx) {
+            renaming_tab--;
+        }
+    }
 }
 
 void NotePadWindow::Initialize()
 {
     ToolboxWindow::Initialize();
-    text_buffer = new char[text_buffer_length];
-    memset(text_buffer, 0, text_buffer_length);
 }
+
 void NotePadWindow::Terminate()
 {
     ToolboxWindow::Terminate();
-    delete[] text_buffer;
+    tabs.clear();
+    next_tab_id = 0;
+    renaming_tab = -1;
 }
 
 void NotePadWindow::Draw(IDirect3DDevice9*)
@@ -37,14 +131,71 @@ void NotePadWindow::Draw(IDirect3DDevice9*)
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
     ImGui::SetNextWindowSize(ImVec2(300.0f, 200.0f), ImGuiCond_FirstUseEver);
     if (ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
-        const ImVec2 avail = ImGui::GetContentRegionAvail();
-        const auto font = FontLoader::GetFont();
-        ImGui::PushFont(font, font_size);
-        if (ImGui::InputTextMultiline("##source", text_buffer, text_buffer_length,
-                                      avail, ImGuiInputTextFlags_AllowTabInput)) {
-            filedirty = true;
+        if (ImGui::BeginTabBar("##notepad_tabs", ImGuiTabBarFlags_Reorderable | ImGuiTabBarFlags_AutoSelectNewTabs)) {
+            if (ImGui::TabItemButton("+", ImGuiTabItemFlags_Trailing | ImGuiTabItemFlags_NoTooltip)) {
+                AddTab();
+            }
+
+            int delete_tab = -1;
+            for (int i = 0; i < static_cast<int>(tabs.size()); i++) {
+                auto& tab = *tabs[i];
+                const ImGuiTabItemFlags flags = tab.dirty ? ImGuiTabItemFlags_UnsavedDocument : ImGuiTabItemFlags_None;
+                bool tab_open = true;
+                const bool tab_visible = ImGui::BeginTabItem(tab.name, tabs.size() > 1 ? &tab_open : nullptr, flags);
+
+                if (ImGui::BeginPopupContextItem()) {
+                    if (ImGui::MenuItem("Rename")) {
+                        renaming_tab = i;
+                        strncpy_s(rename_buf, tab.name, tab_name_length - 1);
+                        rename_needs_focus = true;
+                    }
+                    if (tabs.size() > 1 && ImGui::MenuItem("Close")) {
+                        delete_tab = i;
+                    }
+                    ImGui::EndPopup();
+                }
+
+                if (!tab_open) {
+                    delete_tab = i;
+                }
+
+                if (tab_visible) {
+                    if (renaming_tab == i) {
+                        ImGui::SetNextItemWidth(-1.0f);
+                        if (rename_needs_focus) {
+                            ImGui::SetKeyboardFocusHere(0);
+                            rename_needs_focus = false;
+                        }
+                        const bool confirmed = ImGui::InputText("##rename", rename_buf, tab_name_length,
+                            ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll);
+                        if (confirmed) {
+                            if (rename_buf[0]) {
+                                strncpy_s(tab.name, rename_buf, tab_name_length - 1);
+                            }
+                            renaming_tab = -1;
+                        }
+                        else if (ImGui::IsItemDeactivated()) {
+                            renaming_tab = -1;
+                        }
+                    }
+
+                    const ImVec2 avail = ImGui::GetContentRegionAvail();
+                    const auto font = FontLoader::GetFont();
+                    ImGui::PushFont(font, font_size);
+                    if (ImGui::InputTextMultiline("##text", tab.text, text_buffer_length, avail, ImGuiInputTextFlags_AllowTabInput)) {
+                        tab.dirty = true;
+                    }
+                    ImGui::PopFont();
+                    ImGui::EndTabItem();
+                }
+            }
+
+            if (delete_tab >= 0) {
+                DeleteTab(delete_tab);
+            }
+
+            ImGui::EndTabBar();
         }
-        ImGui::PopFont();
     }
     ImGui::End();
     ImGui::PopStyleVar();
@@ -53,25 +204,49 @@ void NotePadWindow::Draw(IDirect3DDevice9*)
 void NotePadWindow::LoadSettings(ToolboxIni* ini)
 {
     ToolboxWindow::LoadSettings(ini);
+    LOAD_FLOAT(font_size);
 
-    std::ifstream file(Resources::GetPath(L"Notepad.txt"));
-    if (file) {
-        file.get(text_buffer, text_buffer_length, '\0');
-        file.close();
+    const long tab_count = ini->GetLongValue(Name(), "tab_count", -1);
+    if (tab_count < 0) {
+        // Old single-tab config: try to load legacy Notepad.txt
+        auto* tab = AddTab("Note 1");
+        std::ifstream file(Resources::GetPath(L"Notepad.txt"));
+        if (file) {
+            file.get(tab->text, text_buffer_length, '\0');
+        }
+    }
+    else {
+        next_tab_id = static_cast<int>(ini->GetLongValue(Name(), "next_tab_id", tab_count));
+        for (long i = 0; i < tab_count; i++) {
+            char id_key[32], name_key[32];
+            snprintf(id_key, sizeof(id_key), "tab_%ld_id", i);
+            snprintf(name_key, sizeof(name_key), "tab_%ld_name", i);
+            const int id = static_cast<int>(ini->GetLongValue(Name(), id_key, i));
+            const char* name = ini->GetValue(Name(), name_key, "Note");
+            AddTab(name, id);
+            LoadTabContent(tabs.size() - 1);
+        }
+        if (tabs.empty()) {
+            AddTab("Note 1");
+        }
     }
 }
 
 void NotePadWindow::SaveSettings(ToolboxIni* ini)
 {
     ToolboxWindow::SaveSettings(ini);
+    SAVE_FLOAT(font_size);
 
-    if (filedirty) {
-        std::ofstream file(Resources::GetPath(L"Notepad.txt"));
-        if (file) {
-            file.write(text_buffer, strlen(text_buffer));
-            file.close();
-            filedirty = false;
-        }
+    ini->SetLongValue(Name(), "tab_count", static_cast<long>(tabs.size()));
+    ini->SetLongValue(Name(), "next_tab_id", static_cast<long>(next_tab_id));
+
+    for (size_t i = 0; i < tabs.size(); i++) {
+        char id_key[32], name_key[32];
+        snprintf(id_key, sizeof(id_key), "tab_%zu_id", i);
+        snprintf(name_key, sizeof(name_key), "tab_%zu_name", i);
+        ini->SetLongValue(Name(), id_key, static_cast<long>(tabs[i]->id));
+        ini->SetValue(Name(), name_key, tabs[i]->name);
+        SaveTabContent(i);
     }
 }
 


### PR DESCRIPTION
Adds tabbed interface to the Notepad window, similar to Notepad++ / Visual Studio.

**Features:**
- Add tabs via `+` button
- Close tabs via `×` button (disabled when only 1 tab remains)
- Rename tabs via right-click context menu
- Reorderable tabs within a session
- Unsaved-content indicator on tab headers

**Persistence:**
- Tab names/count saved in GWToolbox.ini
- Each tab's content saved to `Notepad_<id>.txt` (stable IDs, no renaming on delete)
- Backward compatible: existing `Notepad.txt` loaded as first tab

Closes #1361

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/gwdevhub/GWToolboxpp/actions/runs/25700192818