### PR TITLE
Fix window title cog and pcons icons z-order and collapsed state

### DIFF
--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -1106,6 +1106,7 @@ void GWToolbox::Draw(IDirect3DDevice9* device)
         //ImGui::ShowDemoWindow();
         //ImGui::ShowStyleEditor(); // Warning, this WILL change your theme. Back up theme.ini first!
 #endif
+        ToolboxSettings::DrawSettingsCogButtons();
         ImGui::DrawContextMenu();
         ImGui::DrawConfirmDialog();
         if ((ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable) == 0)

--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -364,7 +364,6 @@ void ToolboxSettings::SaveSettings(ToolboxIni* ini)
 void ToolboxSettings::Draw(IDirect3DDevice9*)
 {
     ImGui::GetStyle().WindowBorderSize = move_all ? 1.0f : 0.0f;
-    DrawSettingsCogButtons();
 }
 
 void ToolboxSettings::DrawSettingsCogButtons()
@@ -394,7 +393,8 @@ void ToolboxSettings::DrawSettingsCogButtons()
         const bool hovered = mouse_pos.x >= btn_min.x && mouse_pos.x < btn_max.x
                           && mouse_pos.y >= btn_min.y && mouse_pos.y < btn_max.y;
 
-        ImDrawList* dl = ImGui::GetForegroundDrawList(window->Viewport);
+        ImDrawList* dl = window->DrawList;
+        dl->PushClipRect(tb.Min, tb.Max, false);
 
         if (hovered) {
             hovered_elem = const_cast<ToolboxUIElement*>(elem);
@@ -414,6 +414,7 @@ void ToolboxSettings::DrawSettingsCogButtons()
         ImVec4 col = ImGui::GetStyle().Colors[ImGuiCol_Text];
         if (!hovered) col.w *= 0.5f;
         dl->AddText(icon_pos, ImGui::ColorConvertFloat4ToU32(col), ICON_FA_COG);
+        dl->PopClipRect();
     }
 
     if (hovered_elem) {

--- a/GWToolboxdll/Windows/PconsWindow.cpp
+++ b/GWToolboxdll/Windows/PconsWindow.cpp
@@ -604,8 +604,10 @@ void PconsWindow::Draw(IDirect3DDevice9* device)
                     tb.Max.x - (close_offset * 2) - bar_h * 0.5f - text_size.x * 0.5f,
                     tb.GetCenter().y - text_size.y * 0.5f
                 };
-                auto* dl = ImGui::GetForegroundDrawList(win->Viewport);
+                auto* dl = ImGui::GetWindowDrawList();
+                dl->PushClipRect(tb.Min, tb.Max, false);
                 dl->AddText(icon_pos, enabled ? IM_COL32(0, 200, 0, 230) : IM_COL32(200, 0, 0, 230), icon);
+                dl->PopClipRect();
             }
         }
         return ImGui::End();


### PR DESCRIPTION
Fixes #1994

Use `window->DrawList` with `PushClipRect(title_bar, intersect=false)` instead of `GetForegroundDrawList`, so icons render at each window's z-level and remain visible when collapsed. `intersect=false` overrides the zero-height clip rect that ImGui pushes for collapsed windows.

Also moves `DrawSettingsCogButtons()` to run after all UI elements have drawn, so window draw lists are fully initialized before we append to them.

Generated with [Claude Code](https://claude.ai/code)