### PR TITLE
feat: make minimap range circles user-configurable

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/RangeRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/RangeRenderer.cpp
@@ -16,45 +16,94 @@
 
 #include <ImGuiAddons.h>
 
-void RangeRenderer::LoadSettings(const ToolboxIni* ini, const char* section)
-{
-    LoadDefaults();
-    color_range_hos = Colors::Load(ini, section, "color_range_hos", color_range_hos);
-    color_range_aggro = Colors::Load(ini, section, "color_range_aggro", color_range_aggro);
-    color_range_cast = Colors::Load(ini, section, "color_range_cast", color_range_cast);
-    color_range_spirit = Colors::Load(ini, section, "color_range_spirit", color_range_spirit);
-    color_range_spirit_extended = Colors::Load(ini, section, "color_range_spirit_extended", color_range_spirit_extended);
-    color_range_compass = Colors::Load(ini, section, "color_range_compass", color_range_compass);
-    color_range_chain_aggro = Colors::Load(ini, section, "color_range_chain_aggro", color_range_chain_aggro);
-    color_range_res_aggro = Colors::Load(ini, section, "color_range_res_aggro", color_range_res_aggro);
-    color_range_shadowstep_aggro = Colors::Load(ini, section, "color_range_shadowstep_aggro", color_range_shadowstep_aggro);
-    line_thickness = static_cast<float>(ini->GetDoubleValue(section, "range_line_thickness", line_thickness));
-    Invalidate();
+namespace {
+    constexpr float BTN_WIDTH = 20.0f;
 }
 
 void RangeRenderer::LoadDefaults()
 {
+    circles_ = {
+        {"Compass",         GW::Constants::Range::Compass,        1.f, 0xFF666611, true,  false},
+        {"Spirit Extended", GW::Constants::Range::SpiritExtended, 1.f, 0xFF337733, true,  false},
+        {"Spirit",          GW::Constants::Range::Spirit,         1.f, 0xFF337733, true,  false},
+        {"Cast",            GW::Constants::Range::Spellcast,      1.f, 0xFF117777, true,  false},
+        {"Aggro",           GW::Constants::Range::Earshot,        1.f, 0xFF994444, true,  false},
+    };
     color_range_hos = 0xFF881188;
-    color_range_aggro = 0xFF994444;
-    color_range_cast = 0xFF117777;
-    color_range_spirit = color_range_spirit_extended = 0xFF337733;
-    color_range_compass = 0xFF666611;
     color_range_chain_aggro = 0x00994444;
     color_range_res_aggro = 0x64D6D6D6;
     color_range_shadowstep_aggro = Colors::ARGB(200, 128, 0, 128);
-    line_thickness = 1.f;
+    Invalidate();
+}
+
+void RangeRenderer::LoadSettings(const ToolboxIni* ini, const char* section)
+{
+    LoadDefaults();
+
+    const bool has_new_format = ini->GetValue(section, "range_circle_count", nullptr) != nullptr;
+    if (has_new_format) {
+        const auto count = ini->GetLongValue(section, "range_circle_count", 0);
+        circles_.clear();
+        for (long i = 0; i < count; i++) {
+            char key[64];
+            RangeCircle c;
+            snprintf(key, sizeof(key), "range_circle_%ld_label", i);
+            snprintf(c.label, sizeof(c.label), "%s", ini->GetValue(section, key, ""));
+            snprintf(key, sizeof(key), "range_circle_%ld_radius", i);
+            c.radius = static_cast<float>(ini->GetDoubleValue(section, key, c.radius));
+            snprintf(key, sizeof(key), "range_circle_%ld_thickness", i);
+            c.line_thickness = static_cast<float>(ini->GetDoubleValue(section, key, c.line_thickness));
+            snprintf(key, sizeof(key), "range_circle_%ld_color", i);
+            c.color = Colors::Load(ini, section, key, c.color);
+            snprintf(key, sizeof(key), "range_circle_%ld_visible", i);
+            c.visible = ini->GetBoolValue(section, key, c.visible);
+            snprintf(key, sizeof(key), "range_circle_%ld_on_target", i);
+            c.on_target = ini->GetBoolValue(section, key, c.on_target);
+            circles_.push_back(c);
+        }
+    }
+    else {
+        // Migrate colors from the old per-name format
+        if (circles_.size() >= 5) {
+            circles_[0].color = Colors::Load(ini, section, "color_range_compass", circles_[0].color);
+            circles_[1].color = Colors::Load(ini, section, "color_range_spirit_extended", circles_[1].color);
+            circles_[2].color = Colors::Load(ini, section, "color_range_spirit", circles_[2].color);
+            circles_[3].color = Colors::Load(ini, section, "color_range_cast", circles_[3].color);
+            circles_[4].color = Colors::Load(ini, section, "color_range_aggro", circles_[4].color);
+            const auto old_thickness = static_cast<float>(ini->GetDoubleValue(section, "range_line_thickness", 1.0));
+            for (auto& c : circles_) {
+                c.line_thickness = old_thickness;
+            }
+        }
+    }
+
+    color_range_hos = Colors::Load(ini, section, "color_range_hos", color_range_hos);
+    color_range_chain_aggro = Colors::Load(ini, section, "color_range_chain_aggro", color_range_chain_aggro);
+    color_range_res_aggro = Colors::Load(ini, section, "color_range_res_aggro", color_range_res_aggro);
+    color_range_shadowstep_aggro = Colors::Load(ini, section, "color_range_shadowstep_aggro", color_range_shadowstep_aggro);
     Invalidate();
 }
 
 void RangeRenderer::SaveSettings(ToolboxIni* ini, const char* section) const
 {
+    ini->SetLongValue(section, "range_circle_count", static_cast<long>(circles_.size()));
+    for (size_t i = 0; i < circles_.size(); i++) {
+        char key[64];
+        const auto& c = circles_[i];
+        snprintf(key, sizeof(key), "range_circle_%zu_label", i);
+        ini->SetValue(section, key, c.label);
+        snprintf(key, sizeof(key), "range_circle_%zu_radius", i);
+        ini->SetDoubleValue(section, key, c.radius);
+        snprintf(key, sizeof(key), "range_circle_%zu_thickness", i);
+        ini->SetDoubleValue(section, key, c.line_thickness);
+        snprintf(key, sizeof(key), "range_circle_%zu_color", i);
+        Colors::Save(ini, section, key, c.color);
+        snprintf(key, sizeof(key), "range_circle_%zu_visible", i);
+        ini->SetBoolValue(section, key, c.visible);
+        snprintf(key, sizeof(key), "range_circle_%zu_on_target", i);
+        ini->SetBoolValue(section, key, c.on_target);
+    }
     Colors::Save(ini, section, "color_range_hos", color_range_hos);
-    Colors::Save(ini, section, "color_range_aggro", color_range_aggro);
-    Colors::Save(ini, section, "color_range_cast", color_range_cast);
-    Colors::Save(ini, section, "color_range_spirit", color_range_spirit);
-    Colors::Save(ini, section, "color_range_spirit_extended", color_range_spirit_extended);
-    Colors::Save(ini, section, "color_range_compass", color_range_compass);
-    ini->SetDoubleValue(section, "range_line_thickness", line_thickness);
     Colors::Save(ini, section, "color_range_chain_aggro", color_range_chain_aggro);
     Colors::Save(ini, section, "color_range_res_aggro", color_range_res_aggro);
     Colors::Save(ini, section, "color_range_shadowstep_aggro", color_range_shadowstep_aggro);
@@ -63,22 +112,138 @@ void RangeRenderer::SaveSettings(ToolboxIni* ini, const char* section) const
 void RangeRenderer::DrawSettings()
 {
     bool changed = false;
-    ImGui::SmallConfirmButton("Restore Defaults", "Are you sure?", [&](bool result, void*) {
+
+    ImGui::SmallConfirmButton("Restore Defaults##ranges", "Are you sure?", [&](const bool result, void*) {
         if (result) {
             LoadDefaults();
-            Invalidate();
         }
     });
-    changed |= Colors::DrawSettingHueWheel("HoS range", &color_range_hos);
-    changed |= Colors::DrawSettingHueWheel("Aggro range", &color_range_aggro);
-    changed |= Colors::DrawSettingHueWheel("Cast range", &color_range_cast);
-    changed |= Colors::DrawSettingHueWheel("Spirit range", &color_range_spirit);
-    changed |= Colors::DrawSettingHueWheel("Extended Spirit range", &color_range_spirit_extended);
-    changed |= Colors::DrawSettingHueWheel("Compass range", &color_range_compass);
-    changed |= Colors::DrawSettingHueWheel("Chain Aggro range", &color_range_chain_aggro);
-    changed |= Colors::DrawSettingHueWheel("Res Aggro range", &color_range_res_aggro);
-    changed |= Colors::DrawSettingHueWheel("Shadow Step range", &color_range_shadowstep_aggro);
-    changed |= ImGui::DragFloat("Line thickness", &line_thickness, 0.1f, 1.f, 10.f, "%.1f");
+
+    ImGui::TextDisabled("Radius in gwinches: Aggro=1012, Cast=1248, Spirit=2512, Extended=3500, Compass=5000");
+    ImGui::Separator();
+
+    const float spacing = ImGui::GetStyle().ItemInnerSpacing.x;
+
+    ImGui::PushID("range_circles");
+    for (size_t i = 0; i < circles_.size(); i++) {
+        auto& c = circles_[i];
+        bool row_changed = false;
+        ImGui::PushID(static_cast<int>(i));
+
+        row_changed |= ImGui::Checkbox("##visible", &c.visible);
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Visible");
+        }
+        ImGui::SameLine(0.f, spacing);
+
+        ImGui::PushItemWidth(120.f);
+        row_changed |= ImGui::InputText("##label", c.label, sizeof(c.label));
+        ImGui::PopItemWidth();
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Label");
+        }
+        ImGui::SameLine(0.f, spacing);
+
+        ImGui::PushItemWidth(70.f);
+        row_changed |= ImGui::DragFloat("##radius", &c.radius, 10.f, 1.f, 10000.f, "%.0f");
+        ImGui::PopItemWidth();
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Radius (gwinches)");
+        }
+        ImGui::SameLine(0.f, spacing);
+
+        ImGui::PushItemWidth(60.f);
+        constexpr const char* origins[] = {"Player", "Target"};
+        int origin_idx = c.on_target ? 1 : 0;
+        if (ImGui::Combo("##origin", &origin_idx, origins, 2)) {
+            c.on_target = origin_idx == 1;
+            row_changed = true;
+        }
+        ImGui::PopItemWidth();
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Circle origin: centered on Player or current Target");
+        }
+        ImGui::SameLine(0.f, spacing);
+
+        ImGui::PushItemWidth(50.f);
+        row_changed |= ImGui::DragFloat("##thick", &c.line_thickness, 0.1f, 0.1f, 20.f, "%.1fpx");
+        ImGui::PopItemWidth();
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Line thickness (pixels)");
+        }
+        ImGui::SameLine(0.f, spacing);
+
+        row_changed |= ImGui::ColorButtonPicker("##color", &c.color);
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Circle color");
+        }
+        ImGui::SameLine(0.f, spacing);
+
+        if (i > 0) {
+            const bool move_up = ImGui::Button(ICON_FA_ARROW_UP, ImVec2(BTN_WIDTH, 0));
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Move up");
+            }
+            if (move_up) {
+                std::swap(circles_[i], circles_[i - 1]);
+                row_changed = true;
+            }
+            ImGui::SameLine(0.f, spacing);
+        }
+        else {
+            ImGui::SameLine(0.f, BTN_WIDTH + spacing * 2);
+        }
+
+        if (i < circles_.size() - 1) {
+            const bool move_down = ImGui::Button(ICON_FA_ARROW_DOWN, ImVec2(BTN_WIDTH, 0));
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Move down");
+            }
+            if (move_down) {
+                std::swap(circles_[i], circles_[i + 1]);
+                row_changed = true;
+            }
+            ImGui::SameLine(0.f, spacing);
+        }
+        else {
+            ImGui::SameLine(0.f, BTN_WIDTH + spacing * 2);
+        }
+
+        const bool remove = ImGui::Button("x##del", ImVec2(BTN_WIDTH, 0));
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Delete");
+        }
+
+        ImGui::PopID();
+        if (row_changed) {
+            changed = true;
+        }
+        if (remove) {
+            circles_.erase(circles_.begin() + static_cast<ptrdiff_t>(i));
+            changed = true;
+            break;
+        }
+    }
+    ImGui::PopID();
+
+    if (ImGui::Button("Add Circle")) {
+        RangeCircle c;
+        snprintf(c.label, sizeof(c.label), "Custom %zu", circles_.size() + 1);
+        c.radius = GW::Constants::Range::Earshot;
+        circles_.push_back(c);
+        changed = true;
+    }
+
+    ImGui::Separator();
+    if (ImGui::TreeNodeEx("Special Range Circles", ImGuiTreeNodeFlags_FramePadding | ImGuiTreeNodeFlags_SpanAvailWidth)) {
+        ImGui::TextDisabled("These circles have special conditional rendering and are not user-configurable.");
+        changed |= Colors::DrawSettingHueWheel("HoS range", &color_range_hos);
+        changed |= Colors::DrawSettingHueWheel("Chain Aggro range (enemy target)", &color_range_chain_aggro);
+        changed |= Colors::DrawSettingHueWheel("Res Aggro range (dead ally target)", &color_range_res_aggro);
+        changed |= Colors::DrawSettingHueWheel("Shadow Step range", &color_range_shadowstep_aggro);
+        ImGui::TreePop();
+    }
+
     if (changed) {
         Invalidate();
     }
@@ -91,30 +256,30 @@ void RangeRenderer::Initialize(IDirect3DDevice9* device)
     havehos_ = false;
 
     clear();
-    vertices.reserve(circle_points * num_circles + 6);
+    // configurable circles + 4 special circles (HoS, chain aggro, res aggro, shadowstep)
+    vertices.reserve(circle_points * (circles_.size() + 4) + 6);
 
-    auto CreateCircle =
-        [&](const float radius, const DWORD color) {
-            const auto xdiff = static_cast<float>(line_thickness) / gwinches_per_pixel;
-            const auto ydiff = static_cast<float>(line_thickness) / gwinches_per_pixel;
-            for (auto i = 0; i <= circle_triangles; i += 2) {
-                const auto angle = i / static_cast<float>(circle_triangles) * DirectX::XM_2PI;
-                vertices.push_back({radius * cos(angle), radius * sin(angle), 0.f, color});
-                vertices.push_back({(radius - xdiff) * cos(angle), (radius - ydiff) * sin(angle), 0.f, color});
-            }
-        };
+    // xdiff/ydiff convert px thickness → game units using current zoom
+    auto CreateCircle = [&](const float radius, const DWORD color, const float thickness_px) {
+        const float diff = thickness_px / gwinches_per_pixel;
+        for (auto i = 0; i <= static_cast<int>(circle_triangles); i += 2) {
+            const auto angle = i / static_cast<float>(circle_triangles) * DirectX::XM_2PI;
+            vertices.push_back({radius * cos(angle), radius * sin(angle), 0.f, color});
+            vertices.push_back({(radius - diff) * cos(angle), (radius - diff) * sin(angle), 0.f, color});
+        }
+    };
 
-    CreateCircle(GW::Constants::Range::Compass, color_range_compass);
-    CreateCircle(GW::Constants::Range::Spirit, color_range_spirit);
-    CreateCircle(GW::Constants::Range::SpiritExtended, color_range_spirit_extended);
-    CreateCircle(GW::Constants::Range::Spellcast, color_range_cast);
-    CreateCircle(GW::Constants::Range::Earshot, color_range_aggro);
-    CreateCircle(360.f, color_range_hos);
-    CreateCircle(700.f, color_range_chain_aggro);
-    CreateCircle(GW::Constants::Range::Earshot, color_range_res_aggro);
-    CreateCircle(GW::Constants::Range::Earshot, color_range_shadowstep_aggro);
+    for (const auto& c : circles_) {
+        CreateCircle(c.radius, c.color, c.line_thickness);
+    }
 
-    // HoS line
+    // Special circles (conditionally rendered)
+    CreateCircle(360.f, color_range_hos, 1.f);                                  // HoS
+    CreateCircle(700.f, color_range_chain_aggro, 1.f);                          // Chain aggro
+    CreateCircle(GW::Constants::Range::Earshot, color_range_res_aggro, 1.f);    // Res aggro
+    CreateCircle(GW::Constants::Range::Earshot, color_range_shadowstep_aggro, 1.f); // Shadowstep
+
+    // HoS line (2 vertices) + draw_center cross (4 vertices)
     vertices.push_back({260.f, 0.f, 0.f, color_range_hos});
     vertices.push_back({460.f, 0.f, 0.f, color_range_hos});
     vertices.push_back({-150.f, 0.f, 0.f, color_range_hos});
@@ -173,35 +338,48 @@ void RangeRenderer::Render(IDirect3DDevice9* device, float _gwinches_per_pixel)
         device->SetTransform(D3DTS_WORLD, &oldworld);
         offset += circle_points;
     };
-
-    size_t offset = 0;
-
-    DrawCircle(offset); // Compass
-    DrawCircle(offset); // Spirit
-    DrawCircle(offset); // Spirit Extended
-    DrawCircle(offset); // Cast
-    DrawCircle(offset); // Aggro
-
-    // HoS range
-    if (havehos_) device->DrawPrimitive(type, offset, circle_triangles);
-    offset += circle_points;
+    const auto SkipCircle = [&](size_t& offset) {
+        offset += circle_points;
+    };
 
     const GW::AgentLiving* target = GW::Agents::GetTargetAsAgentLiving();
 
-    // Chain aggro (on target)
+    size_t offset = 0;
+
+    // User-configurable circles
+    for (const auto& c : circles_) {
+        if (!c.visible || (c.color & IM_COL32_A_MASK) == 0) {
+            SkipCircle(offset);
+        }
+        else if (c.on_target && target) {
+            DrawCircleAt(offset, target->x, target->y);
+        }
+        else if (!c.on_target) {
+            DrawCircle(offset);
+        }
+        else {
+            SkipCircle(offset);
+        }
+    }
+
+    // HoS circle (only when player has HoS/Viper's)
+    if (havehos_) DrawCircle(offset);
+    else SkipCircle(offset);
+
+    // Chain aggro — on enemy target
     if ((color_range_chain_aggro & IM_COL32_A_MASK) && target && target->allegiance == GW::Constants::Allegiance::Enemy) {
         DrawCircleAt(offset, target->x, target->y);
     }
     else {
-        offset += circle_points;
+        SkipCircle(offset);
     }
 
-    // Res aggro (on dead ally)
+    // Res aggro — on dead ally in explorable
     if ((color_range_res_aggro & IM_COL32_A_MASK) && target && GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable && target->allegiance == GW::Constants::Allegiance::Ally_NonAttackable && target->GetIsDead()) {
         DrawCircleAt(offset, target->x, target->y);
     }
     else {
-        offset += circle_points;
+        SkipCircle(offset);
     }
 
     // Shadowstep aggro
@@ -210,7 +388,7 @@ void RangeRenderer::Render(IDirect3DDevice9* device, float _gwinches_per_pixel)
         DrawCircleAt(offset, shadowstep_location.x, shadowstep_location.y);
     }
     else {
-        offset += circle_points;
+        SkipCircle(offset);
     }
 
     // HoS line

--- a/GWToolboxdll/Widgets/Minimap/RangeRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/RangeRenderer.h
@@ -3,13 +3,23 @@
 #include <Color.h>
 #include <D3DContainers.h>
 
+#include <vector>
+
 class RangeRenderer : public D3DVertexBuffer {
-    static constexpr size_t num_circles = 9;
     static constexpr size_t circle_points = 192;
     static constexpr size_t circle_triangles = circle_points - 2;
 
 public:
-    void Render(IDirect3DDevice9* device) override { Render(device, gwinches_per_pixel); };
+    struct RangeCircle {
+        char label[128] = {};
+        float radius = 500.f;
+        float line_thickness = 1.f;
+        Color color = 0xFF888888;
+        bool visible = true;
+        bool on_target = false; // false = player origin, true = current target origin
+    };
+
+    void Render(IDirect3DDevice9* device) override { Render(device, gwinches_per_pixel); }
     void Render(IDirect3DDevice9* device, float _gwinches_per_pixel);
     void SetDrawCenter(const bool b) { draw_center_ = b; }
 
@@ -28,19 +38,15 @@ private:
 
     bool draw_center_ = false;
 
-    float line_thickness = 1.f;
-
     // This gets set at runtime when Render() is called
     float gwinches_per_pixel = 1.f;
 
+    // User-configurable range circles
+    std::vector<RangeCircle> circles_;
+
+    // Special-case circles with conditional rendering logic (not user-configurable)
+    Color color_range_hos = 0;
     Color color_range_chain_aggro = 0;
     Color color_range_res_aggro = 0;
-
-    Color color_range_hos = 0;
-    Color color_range_aggro = 0;
-    Color color_range_cast = 0;
-    Color color_range_spirit = 0;
-    Color color_range_spirit_extended = 0;
-    Color color_range_compass = 0;
     Color color_range_shadowstep_aggro = 0;
 };


### PR DESCRIPTION
Replaces the 5 fixed player-centred range circles with a user-configurable list. Each circle has a label, radius (gwinches), origin (Player/Target), line thickness (px, zoom-compensated), colour, and visible toggle. Special-case circles (HoS, chain aggro, res aggro, shadowstep) remain unchanged. Includes settings migration from the old per-name colour format.

Closes #1498

Generated with [Claude Code](https://claude.ai/code)