### PR TITLE
feat: add withdraw Nick items context menu to Daily Quests window

### DIFF
--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -1947,6 +1947,61 @@ uint16_t InventoryManager::StoreItems(uint16_t quantity, const std::vector<unsig
     return moved;
 }
 
+uint16_t InventoryManager::WithdrawItemsByModelID(const uint32_t model_id, const uint32_t amount, const bool check_already_withdrawn)
+{
+    const auto is_same_item = [model_id](const Item* cmp) {
+        return cmp && cmp->model_id == model_id;
+    };
+    uint32_t to_move = amount;
+    if (check_already_withdrawn) {
+        const auto in_inventory = count_items(GW::Constants::Bag::Backpack, GW::Constants::Bag::Equipment_Pack, is_same_item);
+        if (in_inventory >= to_move) {
+            return 0;
+        }
+        to_move -= in_inventory;
+    }
+    uint16_t moved = 0;
+    const auto storage_items = filter_items(GW::Constants::Bag::Material_Storage, GW::Constants::Bag::Storage_14, is_same_item);
+    for (const auto item : storage_items) {
+        const auto this_move = move_item_to_inventory(item, static_cast<uint16_t>(to_move));
+        moved += this_move;
+        to_move -= this_move;
+        if (to_move < 1) {
+            break;
+        }
+    }
+    return moved;
+}
+
+uint16_t InventoryManager::WithdrawItemsByName(const wchar_t* name_enc, const uint32_t amount, const bool check_already_withdrawn)
+{
+    if (!name_enc) {
+        return 0;
+    }
+    const auto is_same_item = [name_enc](const Item* cmp) {
+        return cmp && cmp->name_enc && wcscmp(cmp->name_enc, name_enc) == 0;
+    };
+    uint32_t to_move = amount;
+    if (check_already_withdrawn) {
+        const auto in_inventory = count_items(GW::Constants::Bag::Backpack, GW::Constants::Bag::Equipment_Pack, is_same_item);
+        if (in_inventory >= to_move) {
+            return 0;
+        }
+        to_move -= in_inventory;
+    }
+    uint16_t moved = 0;
+    const auto storage_items = filter_items(GW::Constants::Bag::Material_Storage, GW::Constants::Bag::Storage_14, is_same_item);
+    for (const auto item : storage_items) {
+        const auto this_move = move_item_to_inventory(item, static_cast<uint16_t>(to_move));
+        moved += this_move;
+        to_move -= this_move;
+        if (to_move < 1) {
+            break;
+        }
+    }
+    return moved;
+}
+
 GW::Item* InventoryManager::GetAvailableInventoryStack(GW::Item* like_item, const bool entire_stack)
 {
     if (!like_item || like_item->GetIsStackable()) {

--- a/GWToolboxdll/Modules/InventoryManager.h
+++ b/GWToolboxdll/Modules/InventoryManager.h
@@ -78,6 +78,12 @@ public:
     static std::pair<GW::Bag*, uint32_t> GetAvailableInventorySlot(GW::Item* like_item = nullptr);
     static uint16_t RefillUpToQuantity(uint16_t quantity, const std::vector<uint32_t>& model_ids);
     static uint16_t StoreItems(uint16_t quantity, const std::vector<uint32_t>& model_ids);
+    // Withdraw `amount` items matching the encoded name from storage to inventory.
+    // If check_already_withdrawn is true, items already in inventory count toward the amount.
+    static uint16_t WithdrawItemsByName(const wchar_t* name_enc, uint32_t amount, bool check_already_withdrawn = true);
+    // Withdraw `amount` items matching the model id from storage to inventory.
+    // If check_already_withdrawn is true, items already in inventory count toward the amount.
+    static uint16_t WithdrawItemsByModelID(uint32_t model_id, uint32_t amount, bool check_already_withdrawn = true);
     // Find an empty (or partially empty) inventory slot that this item can go into. !entire_stack = Returns slots that are the same item, but won't hold all of them.
     static GW::Item* GetAvailableInventoryStack(GW::Item* like_item, bool entire_stack = false);
     // Checks model info and struct info to make sure item is the same.

--- a/GWToolboxdll/Windows/DailyQuestsWindow.cpp
+++ b/GWToolboxdll/Windows/DailyQuestsWindow.cpp
@@ -692,6 +692,8 @@ namespace {
     bool show_weekly_bonus_pvp_in_window = true;
     bool show_other_searing_dailies = false;
 
+    int nicholas_withdraw_gott_count = 5;
+
     uint32_t subscriptions_lookahead_days = 7;
 
     float text_width = 200.0f;
@@ -873,6 +875,10 @@ namespace {
         ImGui::Separator();
         bool travel = ImGui::Button("Travel to nearest outpost", size);
         bool wiki = ImGui::Button("Guild Wars Wiki", size);
+        const auto withdraw_amount = static_cast<uint32_t>(info->quantity * nicholas_withdraw_gott_count);
+        char withdraw_label[64];
+        snprintf(withdraw_label, sizeof(withdraw_label), "Withdraw for %d GOTTs (%d items)", nicholas_withdraw_gott_count, withdraw_amount);
+        bool withdraw = ImGui::Button(withdraw_label, size);
 
         ImGui::PopStyleColor();
         ImGui::PopStyleVar();
@@ -881,6 +887,10 @@ namespace {
         }
         if (wiki) {
             GuiUtils::SearchWiki(info->GetWikiName());
+            return false;
+        }
+        if (withdraw) {
+            InventoryManager::WithdrawItemsByName(info->enc_name.c_str(), withdraw_amount);
             return false;
         }
         return true;
@@ -1470,6 +1480,7 @@ void DailyQuests::DrawSettingsInternal()
     ToolboxWindow::DrawSettingsInternal();
     ImGui::PushItemWidth(200.f * ImGui::FontScale());
     ImGui::InputInt("Show daily quests for the next N days", &daily_quest_window_count);
+    ImGui::InputInt("Number of GOTTs to withdraw items for (Nicholas)", &nicholas_withdraw_gott_count);
     ImGui::PopItemWidth();
     ImGui::Text("Quests to show in Daily Quests window:");
     ImGui::Indent();
@@ -1499,6 +1510,7 @@ void DailyQuests::LoadSettings(ToolboxIni* ini)
 {
     ToolboxWindow::LoadSettings(ini);
 
+    nicholas_withdraw_gott_count = static_cast<int>(ini->GetLongValue(Name(), "nicholas_withdraw_gott_count", nicholas_withdraw_gott_count));
     LOAD_BOOL(show_zaishen_bounty_in_window);
     LOAD_BOOL(show_zaishen_combat_in_window);
     LOAD_BOOL(show_zaishen_missions_in_window);
@@ -1568,6 +1580,7 @@ void DailyQuests::SaveSettings(ToolboxIni* ini)
 {
     ToolboxWindow::SaveSettings(ini);
 
+    ini->SetLongValue(Name(), "nicholas_withdraw_gott_count", static_cast<long>(nicholas_withdraw_gott_count));
     SAVE_BOOL(show_zaishen_bounty_in_window);
     SAVE_BOOL(show_zaishen_combat_in_window);
     SAVE_BOOL(show_zaishen_missions_in_window);


### PR DESCRIPTION
Adds right-click "Withdraw for N GOTTs" context menu on Nicholas items in the Daily Quests window, plus centralised WithdrawItemsByName/WithdrawItemsByModelID helpers in InventoryManager.

Closes #1503

Generated with [Claude Code](https://claude.ai/code)