### PR TITLE
feat: make minimap range circles user-configurable

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/RangeRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/RangeRenderer.cpp
@@ -265,7 +265,7 @@ void RangeRenderer::Initialize(IDirect3DDevice9* device)
         for (auto i = 0; i <= static_cast<int>(circle_triangles); i += 2) {
             const auto angle = i / static_cast<float>(circle_triangles) * DirectX::XM_2PI;
             vertices.push_back({radius * cos(angle), radius * sin(angle), 0.f, color});
-            vertices.push_back({(radius - diff) * cos(angle), (radius - diff) * sin(angle), 0.f, color});
+            vertices.push_back({(radius + diff) * cos(angle), (radius + diff) * sin(angle), 0.f, color});
         }
     };
 


### PR DESCRIPTION
Replaces the fixed player-centred range circles with a user-configurable list. Each circle has a label, radius (gwinches), origin (Player/Target), line thickness (px, zoom-compensated, extending outward from radius), colour, and visible toggle. Special-case circles (HoS, chain aggro, res aggro, shadowstep) remain unchanged.

Closes #1498

Generated with [Claude Code](https://claude.ai/code)