### PR TITLE
Don't open right-click context menu when there's nothing to show

### DIFF
--- a/GWToolboxdll/Windows/FriendListWindow.cpp
+++ b/GWToolboxdll/Windows/FriendListWindow.cpp
@@ -1130,7 +1130,7 @@ void FriendListWindow::Draw(IDirect3DDevice9*)
         ImGui::Button("", ImVec2(ImGui::GetContentRegionAvail().x, height));
         const bool left_clicked = ImGui::IsItemClicked(0);
         const bool right_clicked = ImGui::IsItemClicked(1);
-        if (right_clicked) {
+        if (right_clicked && lfp->current_map_id != 0) {
             ImGui::OpenPopup("##friend_ctx");
         }
 


### PR DESCRIPTION
Only trigger the friend list context menu popup when the friend has a current_map_id, since that's the only item (Travel to X) the menu contains.

Related to #2004

Generated with [Claude Code](https://claude.ai/code)