### PR TITLE
Fix window title cog: uncollapse settings, collapse others, hide in explorable

### DIFF
--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -323,8 +323,11 @@ void ToolboxSettings::DrawFreezeSetting()
     ImGui::Checkbox("Clamp growing windows to screen bounds", &clamp_windows_to_screen);
     ImGui::NextSpacedElement();
     ImGui::Checkbox("Hide toolbox on loading screens", &hide_on_loading_screen);
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Hide close button in explorable areas", &hide_close_in_explorable);
+    ImGui::Text("Show close button in:");
+    ImGui::Indent();
+    ImGui::Checkbox("Outpost##close", &show_close_in_outpost);
+    ImGui::Checkbox("Explorable##close", &show_close_in_explorable);
+    ImGui::Unindent();
     ImGui::Text("Show cog in:");
     ImGui::ShowHelp("Show a " ICON_FA_COG " button in the title bar of each window.\nClick it to quickly open that window's settings.");
     ImGui::Indent();
@@ -344,7 +347,13 @@ void ToolboxSettings::LoadSettings(ToolboxIni* ini)
     LOAD_BOOL(send_anonymous_gameplay_info);
     LOAD_BOOL(show_cog_in_outpost);
     LOAD_BOOL(show_cog_in_explorable);
-    LOAD_BOOL(hide_close_in_explorable);
+    // Migrate from old hide_close_in_explorable: if it was true, default both show vars to false
+    if (ini->GetBoolValue(Name(), "hide_close_in_explorable", false)) {
+        show_close_in_outpost = false;
+        show_close_in_explorable = false;
+    }
+    LOAD_BOOL(show_close_in_outpost);
+    LOAD_BOOL(show_close_in_explorable);
 
     for (auto& m : optional_modules) {
         m.enabled = ini->GetBoolValue(modules_ini_section, m.name, m.enabled);
@@ -363,7 +372,8 @@ void ToolboxSettings::SaveSettings(ToolboxIni* ini)
     SAVE_BOOL(send_anonymous_gameplay_info);
     SAVE_BOOL(show_cog_in_outpost);
     SAVE_BOOL(show_cog_in_explorable);
-    SAVE_BOOL(hide_close_in_explorable);
+    SAVE_BOOL(show_close_in_outpost);
+    SAVE_BOOL(show_close_in_explorable);
 
     for (const auto& m : optional_modules) {
         ini->SetBoolValue(modules_ini_section, m.name, m.enabled);

--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -326,6 +326,10 @@ void ToolboxSettings::DrawFreezeSetting()
     ImGui::NextSpacedElement();
     ImGui::Checkbox("Show settings button in window title bars", &show_settings_cog);
     ImGui::ShowHelp("Show a " ICON_FA_COG " button in the title bar of each window.\nClick it to quickly open that window's settings.");
+    ImGui::NextSpacedElement();
+    ImGui::Checkbox("Hide cog icon in explorable areas", &hide_cog_in_explorable);
+    ImGui::NextSpacedElement();
+    ImGui::Checkbox("Hide close button in explorable areas", &hide_close_in_explorable);
 }
 
 void ToolboxSettings::LoadSettings(ToolboxIni* ini)
@@ -338,6 +342,8 @@ void ToolboxSettings::LoadSettings(ToolboxIni* ini)
     LOAD_BOOL(hide_on_loading_screen);
     LOAD_BOOL(send_anonymous_gameplay_info);
     LOAD_BOOL(show_settings_cog);
+    LOAD_BOOL(hide_cog_in_explorable);
+    LOAD_BOOL(hide_close_in_explorable);
 
     for (auto& m : optional_modules) {
         m.enabled = ini->GetBoolValue(modules_ini_section, m.name, m.enabled);
@@ -355,6 +361,8 @@ void ToolboxSettings::SaveSettings(ToolboxIni* ini)
     SAVE_BOOL(hide_on_loading_screen);
     SAVE_BOOL(send_anonymous_gameplay_info);
     SAVE_BOOL(show_settings_cog);
+    SAVE_BOOL(hide_cog_in_explorable);
+    SAVE_BOOL(hide_close_in_explorable);
 
     for (const auto& m : optional_modules) {
         ini->SetBoolValue(modules_ini_section, m.name, m.enabled);
@@ -364,11 +372,13 @@ void ToolboxSettings::SaveSettings(ToolboxIni* ini)
 void ToolboxSettings::Draw(IDirect3DDevice9*)
 {
     ImGui::GetStyle().WindowBorderSize = move_all ? 1.0f : 0.0f;
+    is_in_explorable = GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable;
 }
 
 void ToolboxSettings::DrawSettingsCogButtons()
 {
     if (!show_settings_cog) return;
+    if (hide_cog_in_explorable && is_in_explorable) return;
 
     const ImVec2 mouse_pos = ImGui::GetIO().MousePos;
     ToolboxUIElement* hovered_elem = nullptr;

--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -324,12 +324,13 @@ void ToolboxSettings::DrawFreezeSetting()
     ImGui::NextSpacedElement();
     ImGui::Checkbox("Hide toolbox on loading screens", &hide_on_loading_screen);
     ImGui::NextSpacedElement();
-    ImGui::Checkbox("Show settings button in window title bars", &show_settings_cog);
-    ImGui::ShowHelp("Show a " ICON_FA_COG " button in the title bar of each window.\nClick it to quickly open that window's settings.");
-    ImGui::NextSpacedElement();
-    ImGui::Checkbox("Hide cog icon in explorable areas", &hide_cog_in_explorable);
-    ImGui::NextSpacedElement();
     ImGui::Checkbox("Hide close button in explorable areas", &hide_close_in_explorable);
+    ImGui::Text("Show cog in:");
+    ImGui::ShowHelp("Show a " ICON_FA_COG " button in the title bar of each window.\nClick it to quickly open that window's settings.");
+    ImGui::Indent();
+    ImGui::Checkbox("Outpost", &show_cog_in_outpost);
+    ImGui::Checkbox("Explorable", &show_cog_in_explorable);
+    ImGui::Unindent();
 }
 
 void ToolboxSettings::LoadSettings(ToolboxIni* ini)
@@ -341,8 +342,8 @@ void ToolboxSettings::LoadSettings(ToolboxIni* ini)
     LOAD_BOOL(clamp_windows_to_screen);
     LOAD_BOOL(hide_on_loading_screen);
     LOAD_BOOL(send_anonymous_gameplay_info);
-    LOAD_BOOL(show_settings_cog);
-    LOAD_BOOL(hide_cog_in_explorable);
+    LOAD_BOOL(show_cog_in_outpost);
+    LOAD_BOOL(show_cog_in_explorable);
     LOAD_BOOL(hide_close_in_explorable);
 
     for (auto& m : optional_modules) {
@@ -360,8 +361,8 @@ void ToolboxSettings::SaveSettings(ToolboxIni* ini)
     SAVE_BOOL(clamp_windows_to_screen);
     SAVE_BOOL(hide_on_loading_screen);
     SAVE_BOOL(send_anonymous_gameplay_info);
-    SAVE_BOOL(show_settings_cog);
-    SAVE_BOOL(hide_cog_in_explorable);
+    SAVE_BOOL(show_cog_in_outpost);
+    SAVE_BOOL(show_cog_in_explorable);
     SAVE_BOOL(hide_close_in_explorable);
 
     for (const auto& m : optional_modules) {
@@ -377,8 +378,7 @@ void ToolboxSettings::Draw(IDirect3DDevice9*)
 
 void ToolboxSettings::DrawSettingsCogButtons()
 {
-    if (!show_settings_cog) return;
-    if (hide_cog_in_explorable && is_in_explorable) return;
+    if (is_in_explorable ? !show_cog_in_explorable : !show_cog_in_outpost) return;
 
     const ImVec2 mouse_pos = ImGui::GetIO().MousePos;
     ToolboxUIElement* hovered_elem = nullptr;

--- a/GWToolboxdll/Modules/ToolboxSettings.h
+++ b/GWToolboxdll/Modules/ToolboxSettings.h
@@ -42,6 +42,9 @@ public:
     static inline bool hide_on_loading_screen = false;
     static inline bool send_anonymous_gameplay_info = true;
     static inline bool show_settings_cog = false;
+    static inline bool hide_cog_in_explorable = false;
+    static inline bool hide_close_in_explorable = false;
+    static inline bool is_in_explorable = false;
 private:
     // === location stuff ===
     clock_t location_timer = 0;

--- a/GWToolboxdll/Modules/ToolboxSettings.h
+++ b/GWToolboxdll/Modules/ToolboxSettings.h
@@ -41,8 +41,8 @@ public:
     static inline bool clamp_windows_to_screen = false;
     static inline bool hide_on_loading_screen = false;
     static inline bool send_anonymous_gameplay_info = true;
-    static inline bool show_settings_cog = false;
-    static inline bool hide_cog_in_explorable = false;
+    static inline bool show_cog_in_outpost = false;
+    static inline bool show_cog_in_explorable = false;
     static inline bool hide_close_in_explorable = false;
     static inline bool is_in_explorable = false;
 private:

--- a/GWToolboxdll/Modules/ToolboxSettings.h
+++ b/GWToolboxdll/Modules/ToolboxSettings.h
@@ -43,7 +43,8 @@ public:
     static inline bool send_anonymous_gameplay_info = true;
     static inline bool show_cog_in_outpost = false;
     static inline bool show_cog_in_explorable = false;
-    static inline bool hide_close_in_explorable = false;
+    static inline bool show_close_in_outpost = true;
+    static inline bool show_close_in_explorable = true;
     static inline bool is_in_explorable = false;
 private:
     // === location stuff ===

--- a/GWToolboxdll/ToolboxUIElement.cpp
+++ b/GWToolboxdll/ToolboxUIElement.cpp
@@ -86,7 +86,7 @@ bool* ToolboxUIElement::GetVisiblePtr()
 {
     if (!has_closebutton) return &visible;
     if (!show_closebutton) return nullptr;
-    if (ToolboxSettings::hide_close_in_explorable && ToolboxSettings::is_in_explorable) return nullptr;
+    if (ToolboxSettings::is_in_explorable ? !ToolboxSettings::show_close_in_explorable : !ToolboxSettings::show_close_in_outpost) return nullptr;
     return &visible;
 }
 

--- a/GWToolboxdll/ToolboxUIElement.cpp
+++ b/GWToolboxdll/ToolboxUIElement.cpp
@@ -82,6 +82,14 @@ void ToolboxUIElement::UpdateLocationAgainstSnappedFrame()
     last_frame_pos = frame_pos;
 }
 
+bool* ToolboxUIElement::GetVisiblePtr()
+{
+    if (!has_closebutton) return &visible;
+    if (!show_closebutton) return nullptr;
+    if (ToolboxSettings::hide_close_in_explorable && ToolboxSettings::is_in_explorable) return nullptr;
+    return &visible;
+}
+
 const char* ToolboxUIElement::UIName() const
 {
     if (Icon()) {

--- a/GWToolboxdll/ToolboxUIElement.h
+++ b/GWToolboxdll/ToolboxUIElement.h
@@ -50,10 +50,7 @@ public:
     bool show_breakout_button = false;
     bool lock_breakout_button = false;
 
-    bool* GetVisiblePtr()
-    {
-        return has_closebutton && !show_closebutton ? nullptr : &visible;
-    }
+    bool* GetVisiblePtr();
 
     bool has_titlebar = false;
     bool show_titlebar = true;

--- a/GWToolboxdll/Windows/SettingsWindow.cpp
+++ b/GWToolboxdll/Windows/SettingsWindow.cpp
@@ -17,6 +17,7 @@
 void SettingsWindow::NavigateToSection(const char* section)
 {
     visible = true;
+    pending_uncollapse = true;
     pending_navigate_to = section;
 }
 
@@ -46,6 +47,10 @@ void SettingsWindow::Draw(IDirect3DDevice9*)
 
     if (!visible) {
         return;
+    }
+    if (pending_uncollapse) {
+        ImGui::SetNextWindowCollapsed(false, ImGuiCond_Always);
+        pending_uncollapse = false;
     }
     ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowSize(ImVec2(768, 768), ImGuiCond_FirstUseEver);
@@ -270,6 +275,8 @@ bool SettingsWindow::DrawSettingsSection(const char* section)
     const bool should_navigate = !pending_navigate_to.empty() && pending_navigate_to == section;
     if (should_navigate) {
         ImGui::SetNextItemOpen(true, ImGuiCond_Always);
+    } else if (!pending_navigate_to.empty()) {
+        ImGui::SetNextItemOpen(false, ImGuiCond_Always);
     }
     const bool is_showing = ImGui::CollapsingHeader(std::format("##{}",section).c_str(), ImGuiTreeNodeFlags_AllowOverlap);
     ImGui::SameLine(header_text_offset_x);
@@ -280,7 +287,6 @@ bool SettingsWindow::DrawSettingsSection(const char* section)
     ImGui::TextUnformatted(section);
     if (should_navigate) {
         ImGui::SetScrollHereY(0.0f);
-        pending_navigate_to.clear();
     }
 
     ImGui::PushID(section);

--- a/GWToolboxdll/Windows/SettingsWindow.h
+++ b/GWToolboxdll/Windows/SettingsWindow.h
@@ -38,5 +38,6 @@ public:
 private:
     std::map<std::string, bool> drawn_settings{};
     bool hide_when_entering_explorable = false;
+    bool pending_uncollapse = false;
     std::string pending_navigate_to;
 };


### PR DESCRIPTION
Fixes #1994

Three amendments to the window title cog/pcons icon fixes:

1. Clicking the cog now uncollapses the settings window if it was collapsed (double-click collapsed)
2. When navigating to a specific settings section via the cog, all other sections are collapsed so only the relevant one is open
3. Added "Hide cog icon in explorable areas" and "Hide close button in explorable areas" options to Toolbox Settings (saved/loaded to ini)

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/gwdevhub/GWToolboxpp/actions/runs/25786596670) | [`claude/issue-1994-20260513-0806`](https://github.com/gwdevhub/GWToolboxpp/tree/claude/issue-1994-20260513-0806