### PR TITLE
Route ObserverExportWindow::ExportToGWRank through RestClient

### DIFF
--- a/GWToolboxdll/Windows/ObserverExportWindow.cpp
+++ b/GWToolboxdll/Windows/ObserverExportWindow.cpp
@@ -10,7 +10,7 @@
 #include <Windows/ObserverExportWindow.h>
 #include <Utils/TextUtils.h>
 
-#include <curl/curl.h>
+#include <RestClient.h>
 
 void ObserverExportWindow::Initialize()
 {
@@ -624,91 +624,49 @@ std::string ObserverExportWindow::PadLeft(std::string input, const uint8_t count
 void ObserverExportWindow::ExportToGWRank()
 {
     ObserverModule& observer_module = ObserverModule::Instance();
-    
-    // Check if match is finished
+
     if (!observer_module.match_finished) {
         GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GWCA1, L"<c=#FF0000>Match is not finished yet. Cannot export to GWRank.com.</c>");
         return;
     }
-    
-    // Check if API key is configured
+
     if (Instance().gwrank_api_key.empty()) {
         GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GWCA1, L"<c=#FF0000>API key not configured. Please set it in the Observer Export settings.</c>");
         return;
     }
-    
-    // Generate JSON v1.0
+
     nlohmann::json json = ToJSON_V_1_0();
     json["verson"] = "1.0";
-    std::string json_str = json.dump(4);
-    
-    // Initialize curl
-    CURL* curl = curl_easy_init();
-    if (!curl) {
-        GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GWCA1, L"<c=#FF0000>Failed to initialize CURL for upload.</c>");
-        return;
-    }
-    
-    // Create multipart form
-    curl_mime* form = curl_mime_init(curl);
-    curl_mimepart* field = curl_mime_addpart(form);
-    curl_mime_name(field, "json_file");
-    curl_mime_data(field, json_str.c_str(), CURL_ZERO_TERMINATED);
-    curl_mime_filename(field, "match.json");
-    curl_mime_type(field, "application/json");
-    
-    // Prepare headers
-    struct curl_slist* headers = nullptr;
-    std::string auth_header = "Authorization: Bearer " + Instance().gwrank_api_key;
-    headers = curl_slist_append(headers, auth_header.c_str());
-    
-    // Configure curl
-    curl_easy_setopt(curl, CURLOPT_URL, Instance().gwrank_endpoint.c_str());
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-    curl_easy_setopt(curl, CURLOPT_MIMEPOST, form);
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
-    
-    // SSL configuration - disable verification for compatibility
-    // Note: This makes the connection less secure but avoids CA certificate issues
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
-    
-    // Response buffer
-    std::string response_data;
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, +[](char* ptr, size_t size, size_t nmemb, void* userdata) -> size_t {
-        size_t total = size * nmemb;
-        static_cast<std::string*>(userdata)->append(ptr, total);
-        return total;
-    });
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_data);
-    
-    // Perform request
+    const std::string json_str = json.dump(4);
+
+    RestClient client;
+    client.SetUrl(Instance().gwrank_endpoint.c_str());
+    const std::string auth_header = "Bearer " + Instance().gwrank_api_key;
+    client.SetHeader("Authorization", auth_header.c_str());
+    client.SetTimeoutSec(30);
+    client.SetVerifyPeer(false);
+    client.SetVerifyHost(false);
+    client.AddMimePart("json_file", json_str.c_str(), json_str.size(), "match.json", "application/json");
+
     GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GWCA1, L"<c=#00FF00>Uploading match data to GWRank.com...</c>");
-    CURLcode res = curl_easy_perform(curl);
-    
-    // Check result
-    if (res != CURLE_OK) {
+    client.Execute();
+
+    const int status_code = client.GetStatusCode();
+    if (client.GetStatus() != ResponseStatus::Completed) {
         wchar_t error_msg[512];
-        swprintf(error_msg, 512, L"<c=#FF0000>Failed to upload: %S</c>", curl_easy_strerror(res));
+        swprintf(error_msg, 512, L"<c=#FF0000>Failed to upload: %S</c>", client.GetStatusStr());
         GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GWCA1, error_msg);
-    } else {
-        long response_code = 0;
-        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-        
-        if (response_code >= 200 && response_code < 300) {
-            GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GWCA1, L"<c=#00FF00>Successfully uploaded match to GWRank.com!</c>");
-        } else {
-            wchar_t error_msg[256];
-            swprintf(error_msg, 256, L"<c=#FF0000>Upload failed with HTTP status %ld. Response: %S</c>", 
-                     response_code, response_data.substr(0, 100).c_str());
-            GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GWCA1, error_msg);
-        }
     }
-    
-    // Cleanup
-    curl_slist_free_all(headers);
-    curl_mime_free(form);
-    curl_easy_cleanup(curl);
+    else if (status_code >= 200 && status_code < 300) {
+        GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GWCA1, L"<c=#00FF00>Successfully uploaded match to GWRank.com!</c>");
+    }
+    else {
+        wchar_t error_msg[512];
+        const std::string response_preview = client.GetContent().substr(0, 100);
+        swprintf(error_msg, 512, L"<c=#FF0000>Upload failed with HTTP status %d. Response: %S</c>",
+                 status_code, response_preview.c_str());
+        GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GWCA1, error_msg);
+    }
 }
 
 

--- a/RestClient/CurlWrapper.cpp
+++ b/RestClient/CurlWrapper.cpp
@@ -72,6 +72,7 @@ CurlEasy::CurlEasy()
     : m_Headers(nullptr)
     , m_File(nullptr)
     , m_UploadFile(nullptr)
+    , m_MimeForm(nullptr)
     , m_Status(ResponseStatus::None)
     , m_StatusCode(0)
     , m_MultiHandle(nullptr)
@@ -316,6 +317,22 @@ void CurlEasy::SetUploadFile(const char* path)
     }
 }
 
+void CurlEasy::AddMimePart(const char* name, const char* data, const size_t size, const char* filename, const char* content_type)
+{
+    if (!m_MimeForm) {
+        m_MimeForm = curl_mime_init(m_Handle);
+    }
+    curl_mimepart* part = curl_mime_addpart(m_MimeForm);
+    curl_mime_name(part, name);
+    curl_mime_data(part, data, size);
+    if (filename) {
+        curl_mime_filename(part, filename);
+    }
+    if (content_type) {
+        curl_mime_type(part, content_type);
+    }
+}
+
 void CurlEasy::Clear()
 {
     m_Header.clear();
@@ -341,6 +358,11 @@ void CurlEasy::Reset()
     m_UploadBuffer.size = 0;
     m_UploadBuffer.rpos = 0;
 
+    if (m_MimeForm) {
+        curl_mime_free(m_MimeForm);
+        m_MimeForm = nullptr;
+    }
+
     if (m_Headers) {
         curl_slist_free_all(m_Headers);
         m_Headers = nullptr;
@@ -360,6 +382,9 @@ bool CurlEasy::Perform()
 {
     Clear();
     CHECK_CURL_EASY_SETOPT(this, CURLOPT_HTTPHEADER, m_Headers);
+    if (m_MimeForm) {
+        CHECK_CURL_EASY_SETOPT(this, CURLOPT_MIMEPOST, m_MimeForm);
+    }
     const CURLcode status = curl_easy_perform(m_Handle);
     UpdateStatus(status);
     OnPerformed();
@@ -511,6 +536,9 @@ void CurlMulti::AddHandle(CurlEasy* easy) const
     assert(!easy->m_MultiHandle);
 
     CHECK_CURL_EASY_SETOPT(easy, CURLOPT_HTTPHEADER, easy->m_Headers);
+    if (easy->m_MimeForm) {
+        CHECK_CURL_EASY_SETOPT(easy, CURLOPT_MIMEPOST, easy->m_MimeForm);
+    }
     const CURLMcode code = curl_multi_add_handle(m_Handle, easy->m_Handle);
     assert(code == CURLM_OK);
     if (code == CURLM_OK) {

--- a/RestClient/CurlWrapper.h
+++ b/RestClient/CurlWrapper.h
@@ -93,6 +93,9 @@ public:
     void SetUploadFile(FILE* file, size_t size);
     void SetUploadFile(const char* path);
 
+    // Add a part to a multipart/form-data POST. Initializes the mime form on first call.
+    void AddMimePart(const char* name, const char* data, size_t size, const char* filename = nullptr, const char* content_type = nullptr);
+
     // Clear the response data and status flag
     void Clear();
 
@@ -159,6 +162,7 @@ protected:
 
     std::string m_UploadContent;
     UploadBuffer m_UploadBuffer;
+    curl_mime* m_MimeForm;
 
     // Those std::string can be replaced, but keep in mind that the small string optimisation
     // make those free if you don't use them (i.e. override OnHeader & OnContent) and that


### PR DESCRIPTION
Add `AddMimePart()` to `CurlEasy` to support multipart/form-data POSTs, then rewrite `ExportToGWRank()` to use `RestClient` instead of raw libcurl.

Closes #2023

Generated with [Claude Code](https://claude.ai/code)