### PR TITLE
Fix /tp prefix matching preferring non-outpost maps over outposts

### DIFF
--- a/GWToolboxdll/Windows/TravelWindow.cpp
+++ b/GWToolboxdll/Windows/TravelWindow.cpp
@@ -389,6 +389,7 @@ namespace {
         auto FindMatchingMapVec = [](const char* compare, std::vector<SearchableArea*>& maps) -> GW::Constants::MapID {
             const char* bestMatchMapName = nullptr;
             auto bestMatchMapID = GW::Constants::MapID::None;
+            bool bestMatchIsOutpost = false;
 
             const auto searchStringLength = compare ? strlen(compare) : 0;
             if (!searchStringLength) {
@@ -408,9 +409,12 @@ namespace {
                 if (thisMapLength == searchStringLength) {
                     return map.map_id; // Exact match, break.
                 }
-                if (!bestMatchMapName || strcmp(map.Name(), bestMatchMapName) < 0) {
+                const bool thisIsOutpost = IsValidOutpost(map.map_id);
+                if (!bestMatchMapName || (thisIsOutpost && !bestMatchIsOutpost) ||
+                    (thisIsOutpost == bestMatchIsOutpost && strcmp(map.Name(), bestMatchMapName) < 0)) {
                     bestMatchMapID = map.map_id;
                     bestMatchMapName = map.Name();
+                    bestMatchIsOutpost = thisIsOutpost;
                 }
             }
             return bestMatchMapID;


### PR DESCRIPTION
When multiple maps share a prefix (e.g. "imperial" matches both "Imperial Isle" and "Imperial Sanctum"), prefer valid outposts over explorable zones/dungeons. Previously the lexicographically first match won, causing /tp imperial to resolve to the GvG arena Imperial Isle (then silently fail) instead of Imperial Sanctum.

Regressed in 84eb6f22 which added non-outpost maps to the search list.