### PR TITLE
Replace nlohmann::json with glaze, bump to C++26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ add_compile_definitions(
 	
 add_compile_options(/MP /permissive-)
 
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
@@ -63,7 +63,7 @@ find_path(EARCUT_HPP_INCLUDE_DIRS "mapbox/earcut.hpp")
 find_path(SIMPLEINI_INCLUDE_DIRS "ConvertUTF.c")
 find_package(wolfssl CONFIG REQUIRED)
 find_package(minhook CONFIG REQUIRED)
-find_package(nlohmann_json CONFIG REQUIRED)
+find_package(glaze CONFIG REQUIRED)
 find_package(ctre CONFIG REQUIRED)
 find_package(directxtex CONFIG REQUIRED)
 

--- a/GWToolbox/CMakeLists.txt
+++ b/GWToolbox/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries(GWToolbox PRIVATE
     Core
     RestClient
     directxtex
-    nlohmann_json::nlohmann_json
+    glaze::glaze
 
     version.lib # for GetFileVersionInfo
     )

--- a/GWToolbox/Download.cpp
+++ b/GWToolbox/Download.cpp
@@ -73,63 +73,56 @@ struct Release {
 
 static bool ParseRelease(const std::string& json_text, Release* release)
 {
-    nlohmann::json json;
-    try {
-        json = nlohmann::json::parse(json_text.c_str());
-    } catch (nlohmann::json::exception&) {
+    glz::json_t json;
+    if (auto ec = glz::read_json(json, json_text); ec) {
         fprintf(stderr, "Json::parse failed\n");
         return false;
     }
 
-    const auto it_tag_name = json.find("tag_name");
-    if (it_tag_name == json.end() || !it_tag_name->is_string()) {
+    if (!json.contains("tag_name") || !json.at("tag_name").is_string()) {
         fprintf(stderr, "Key 'tag_name' not found or not a string in '%s'\n", json_text.c_str());
         return false;
     }
 
-    const auto it_body = json.find("body");
-    if (it_body == json.end() || !it_body->is_string()) {
+    if (!json.contains("body") || !json.at("body").is_string()) {
         fprintf(stderr, "Key 'body' not found or not a string in '%s'\n", json_text.c_str());
         return false;
     }
 
-    const auto it_assets = json.find("assets");
-    if (it_assets == json.end() || !it_assets->is_array()) {
+    if (!json.contains("assets") || !json.at("assets").is_array()) {
         fprintf(stderr, "Key 'assets' not found or not an array in '%s'\n", json_text.c_str());
         return false;
     }
 
-    release->tag_name = it_tag_name->get<std::string>();
-    release->body = it_body->get<std::string>();
+    release->tag_name = json.at("tag_name").get<std::string>();
+    release->body = json.at("body").get<std::string>();
 
-    for (size_t i = 0; i < it_assets->size(); i++) {
-        nlohmann::json& entry = it_assets->at(i);
+    const auto& assets = json.at("assets").get_array();
+    for (size_t i = 0; i < assets.size(); i++) {
+        const auto& entry = assets[i];
 
-        auto it_name = entry.find("name");
-        if (it_name == entry.end() || !it_name->is_string()) {
+        if (!entry.contains("name") || !entry.at("name").is_string()) {
             fprintf(stderr, "Key 'name' not found or not a string in (assert:%zu) '%s'\n",
                     i, json_text.c_str());
             return false;
         }
 
-        auto it_size = entry.find("size");
-        if (it_size == entry.end() || !it_size->is_number()) {
+        if (!entry.contains("size") || !entry.at("size").is_number()) {
             fprintf(stderr, "Key 'size' not found or not a number in (assert:%zu) '%s'\n",
                     i, json_text.c_str());
             return false;
         }
 
-        auto it_browser_download_url = entry.find("browser_download_url");
-        if (it_browser_download_url == entry.end() || !it_browser_download_url->is_string()) {
+        if (!entry.contains("browser_download_url") || !entry.at("browser_download_url").is_string()) {
             fprintf(stderr, "Key 'browser_download_url' not found or not a string in (assert:%zu) '%s'\n",
                     i, json_text.c_str());
             return false;
         }
 
         Asset asset;
-        asset.name = it_name->get<std::string>();
-        asset.size = it_size->get<size_t>();
-        asset.browser_download_url = it_browser_download_url->get<std::string>();
+        asset.name = entry.at("name").get<std::string>();
+        asset.size = static_cast<size_t>(entry.at("size").get<double>());
+        asset.browser_download_url = entry.at("browser_download_url").get<std::string>();
 
         release->assets.emplace_back(std::move(asset));
     }

--- a/GWToolbox/stdafx.h
+++ b/GWToolbox/stdafx.h
@@ -52,7 +52,7 @@
 #include <ranges>
 #include <regex>
 
-#include <nlohmann/json.hpp>
+#include <glaze/glaze.hpp>
 
 #include "resource.h"
 #pragma warning(pop)

--- a/GWToolboxdll/CMakeLists.txt
+++ b/GWToolboxdll/CMakeLists.txt
@@ -84,7 +84,7 @@ target_link_libraries(GWToolboxdll PRIVATE
     steamworks_sdk
     easywsclient
     ${CPP_GAME_SDK}
-    nlohmann_json::nlohmann_json
+    glaze::glaze
     imgui::fonts
     IconFontCppHeaders
     nativefiledialog

--- a/GWToolboxdll/Modules/PartyBroadcastModule.cpp
+++ b/GWToolboxdll/Modules/PartyBroadcastModule.cpp
@@ -18,7 +18,7 @@
 #include <Utils/TextUtils.h>
 
 #include <Utils/ThreadedWebSocket.h>
-#include <nlohmann/json.hpp>
+#include <glaze/glaze.hpp>
 
 #include <GWCA/Managers/GameThreadMgr.h>
 #include <GWCA/Managers/UIMgr.h>
@@ -26,7 +26,7 @@
 #include <Utils/ToolboxUtils.h>
 #include "ToolboxSettings.h"
 
-using json = nlohmann::json;
+using json = glz::json_t;
 
 namespace {
     clock_t last_update_timestamp = 0;
@@ -67,27 +67,29 @@ namespace {
 
     bool send_payload(const std::string& payload);
 
-    void to_json(nlohmann::json& j, const PartySearchAdvertisement& p)
+    glz::json_t ToJson(const PartySearchAdvertisement& p)
     {
-        j = nlohmann::json{{"i", p.party_id}};
+        glz::json_t j;
+        j["i"] = static_cast<double>(p.party_id);
         if (!p.party_size) {
             // Aka "remove"
-            j["r"] = 1;
-            return;
+            j["r"] = 1.0;
+            return j;
         }
-        j["t"] = p.search_type;
-        j["p"] = p.primary;
+        j["t"] = static_cast<double>(p.search_type);
+        j["p"] = static_cast<double>(p.primary);
         j["s"] = p.sender;
 
         // The following fields can be assumed to be reasonable defaults by the server, so only need to send if they're not standard.
-        if (p.party_size > 1) j["ps"] = p.party_size;
-        if (p.hero_count) j["hc"] = p.hero_count;
-        if (p.hardmode) j["hm"] = p.hardmode;
-        if (p.language) j["dl"] = p.language;
-        if (p.secondary) j["sc"] = p.secondary;
-        if (p.district_number) j["dn"] = p.district_number;
+        if (p.party_size > 1) j["ps"] = static_cast<double>(p.party_size);
+        if (p.hero_count) j["hc"] = static_cast<double>(p.hero_count);
+        if (p.hardmode) j["hm"] = static_cast<double>(p.hardmode);
+        if (p.language) j["dl"] = static_cast<double>(p.language);
+        if (p.secondary) j["sc"] = static_cast<double>(p.secondary);
+        if (p.district_number) j["dn"] = static_cast<double>(p.district_number);
         if (!p.message.empty()) j["ms"] = p.message;
-        if (p.level != 20) j["l"] = p.level;
+        if (p.level != 20) j["l"] = static_cast<double>(p.level);
+        return j;
     }
 
     bool get_api_key(std::string& out)
@@ -218,11 +220,14 @@ namespace {
 
         json j;
         j["type"] = "client_parties";
-        j["map_id"] = (uint32_t)GW::Map::GetMapID();
-        j["district_region"] = (int)GW::Map::GetRegion();
-        j["parties"] = parties;
+        j["map_id"] = static_cast<double>(static_cast<uint32_t>(GW::Map::GetMapID()));
+        j["district_region"] = static_cast<double>(static_cast<int>(GW::Map::GetRegion()));
+        glz::json_t::array_t parties_arr;
+        parties_arr.reserve(parties.size());
+        for (const auto& p : parties) parties_arr.push_back(ToJson(p));
+        j["parties"] = std::move(parties_arr);
 
-        const auto payload = j.dump();
+        const auto payload = glz::write_json(j).value_or(std::string{});
         if (!send_payload(payload)) return false;
         last_sent_district_info = GetDistrictInfo();
 
@@ -278,11 +283,14 @@ namespace {
         if (to_send.empty()) return true; // No change
         json j;
         j["type"] = "updated_parties";
-        j["map_id"] = (uint32_t)GW::Map::GetMapID();
-        j["district_region"] = (int)GW::Map::GetRegion();
-        j["parties"] = to_send;
+        j["map_id"] = static_cast<double>(static_cast<uint32_t>(GW::Map::GetMapID()));
+        j["district_region"] = static_cast<double>(static_cast<int>(GW::Map::GetRegion()));
+        glz::json_t::array_t parties_arr;
+        parties_arr.reserve(to_send.size());
+        for (const auto& p : to_send) parties_arr.push_back(ToJson(p));
+        j["parties"] = std::move(parties_arr);
 
-        const auto payload = j.dump();
+        const auto payload = glz::write_json(j).value_or(std::string{});
         if (!send_payload(payload)) return false;
         last_sent_district_info = GetDistrictInfo();
         for (auto& party : to_send) {

--- a/GWToolboxdll/Modules/PriceCheckerModule.cpp
+++ b/GWToolboxdll/Modules/PriceCheckerModule.cpp
@@ -19,7 +19,7 @@
 #include <Utils/TextUtils.h>
 #include <Utils/ToolboxUtils.h>
 
-using nlohmann::json;
+using json = glz::json_t;
 
 namespace {
 
@@ -297,18 +297,17 @@ namespace {
 
     bool ParsePriceJson(const std::string& prices_json_str)
     {
-        const json& prices_json = json::parse(prices_json_str, nullptr, false);
-        if (prices_json == json::value_t::discarded) return false;
+        json prices_json;
+        if (auto ec = glz::read_json(prices_json, prices_json_str); ec) return false;
 
         prices_by_identifier.clear();
-        const auto& it_buy = prices_json.find("sell");
-        if (it_buy == prices_json.end() || !it_buy->is_object()) return false;
+        if (!prices_json.contains("sell") || !prices_json.at("sell").is_object()) return false;
 
-        for (auto it = it_buy.value().begin(); it != it_buy.value().end(); ++it) {
-            if (!it->is_object()) continue;
-            const auto& price_value = it->find("p");
-            if (price_value == it->end() || !price_value->is_number_unsigned()) continue;
-            prices_by_identifier[it.key()] = price_value->get<uint32_t>();
+        const auto& sell_obj = prices_json.at("sell").get_object();
+        for (const auto& [key, value] : sell_obj) {
+            if (!value.is_object()) continue;
+            if (!value.contains("p") || !value.at("p").is_number()) continue;
+            prices_by_identifier[std::string{key}] = static_cast<uint32_t>(value.at("p").get<double>());
         }
         return !prices_by_identifier.empty();
     }

--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -709,7 +709,14 @@ bool Resources::Post(const std::string& url, const std::string& payload, std::st
     r.SetMethod(HttpMethod::Post);
     r.SetPostContent(payload.c_str(), payload.size(), ContentFlag::ByRef);
 
-    std::string content_type = nlohmann::json::accept(payload) ? "application/json" : "application/x-www-form-urlencoded";
+    // No direct equivalent of an "accept" / probe-only parse in glaze; do a parse-and-discard.
+    std::string content_type = "application/x-www-form-urlencoded";
+    {
+        glz::json_t tmp;
+        if (!glz::read_json(tmp, payload)) {
+            content_type = "application/json";
+        }
+    }
     r.SetHeader("Content-Type", content_type.c_str());
     r.SetUrl(url.c_str());
     r.Execute();

--- a/GWToolboxdll/Modules/Teamspeak5Module.cpp
+++ b/GWToolboxdll/Modules/Teamspeak5Module.cpp
@@ -28,7 +28,7 @@
 #include <Utils/TextUtils.h>
 
 using easywsclient::WebSocket;
-using nlohmann::json;
+using json = glz::json_t;
 using json_vec = std::vector<json>;
 
 namespace {
@@ -76,51 +76,49 @@ namespace {
 
     bool GetValue(const json& content, const char* key, uint32_t* out)
     {
-        const auto found = content.find(key);
-        if (!(found != content.end() && found->is_number_unsigned())) {
+        if (!content.is_object() || !content.contains(key) || !content.at(key).is_number()) {
             return false;
         }
-        *out = *found;
+        *out = static_cast<uint32_t>(content.at(key).get<double>());
         return true;
     }
 
     bool GetValue(const json& content, const char* key, std::string* out)
     {
-        const auto found = content.find(key);
-        if (!(found != content.end() && found->is_string())) {
+        if (!content.is_object() || !content.contains(key) || !content.at(key).is_string()) {
             return false;
         }
-        *out = *found;
+        *out = content.at(key).get<std::string>();
         return true;
     }
 
     bool GetValue(const json& content, const char* key, bool* out)
     {
-        const auto found = content.find(key);
-        if (!(found != content.end() && found->is_boolean())) {
+        if (!content.is_object() || !content.contains(key) || !content.at(key).is_boolean()) {
             return false;
         }
-        *out = *found;
+        *out = content.at(key).get<bool>();
         return true;
     }
 
     bool GetValue(const json& content, const char* key, json* out)
     {
-        const auto found = content.find(key);
-        if (!(found != content.end() && found->is_object())) {
+        if (!content.is_object() || !content.contains(key) || !content.at(key).is_object()) {
             return false;
         }
-        *out = *found;
+        *out = content.at(key);
         return true;
     }
 
     bool GetValue(const json& content, const char* key, json_vec* out)
     {
-        const auto found = content.find(key);
-        if (!(found != content.end() && found->is_array())) {
+        if (!content.is_object() || !content.contains(key) || !content.at(key).is_array()) {
             return false;
         }
-        *out = found->get<json_vec>();
+        const auto& arr = content.at(key).get_array();
+        out->clear();
+        out->reserve(arr.size());
+        for (const auto& item : arr) out->push_back(item);
         return true;
     }
 
@@ -170,19 +168,19 @@ namespace {
         json packet;
         packet["address"] = std::format("{}:{}", server->host, server->port);
         packet["name"] = server->name;
-        packet["password"] = NULL;
+        packet["password"] = nullptr;
         packet["channel_id"] = channel_id;
         packet["channel_name"] = channel_id;
-        packet["expires_in_days"] = 1;
+        packet["expires_in_days"] = 1.0;
 
-        Resources::Post("https://invites.teamspeak.com/servers/create", packet.dump(), [callback](const bool success, const std::string& response, void*) {
+        Resources::Post("https://invites.teamspeak.com/servers/create", glz::write_json(packet).value_or(std::string{}), [callback](const bool success, const std::string& response, void*) {
             if (!success) {
                 Log::Error("Failed to get teamspeak invite link (1)");
                 Log::Log("%s", response.c_str());
                 return;
             }
-            const json& res = json::parse(response.c_str(), nullptr, false);
-            if (res == json::value_t::discarded) {
+            json res;
+            if (auto ec = glz::read_json(res, response); ec) {
                 Log::Error("Failed to get teamspeak invite link (2)");
                 return;
             }
@@ -239,7 +237,7 @@ namespace {
         payload["content"] = content;
         packet["payload"] = payload;
 
-        websocket->send(packet.dump());
+        websocket->send(glz::write_json(packet).value_or(std::string{}));
     }
 
     bool Connect(bool user_invoked = false)
@@ -439,8 +437,8 @@ namespace {
     bool OnWebsocketMessage(const std::string& data)
     {
         //Log::Log("%s\n", data.c_str());
-        const json& res = json::parse(data.c_str(), nullptr, false);
-        if (res == json::value_t::discarded) {
+        json res;
+        if (auto ec = glz::read_json(res, data); ec) {
             Log::Log("ERROR: Failed to parse res JSON from response in websocket->dispatch\n");
             return false;
         }

--- a/GWToolboxdll/Modules/TeamspeakModule.cpp
+++ b/GWToolboxdll/Modules/TeamspeakModule.cpp
@@ -351,35 +351,34 @@ namespace {
         return true;
     }
 
-    bool GetValue(const nlohmann::json& content, const char* key, std::string* out)
+    bool GetValue(const glz::json_t& content, const char* key, std::string* out)
     {
-        const auto found = content.find(key);
-        if (!(found != content.end() && found->is_string())) {
+        if (!content.contains(key) || !content.at(key).is_string()) {
             return false;
         }
-        *out = *found;
+        *out = content.at(key).get<std::string>();
         return true;
     }
 
     void GetServerInviteLink(TS3Server* server, std::string channel_id, std::function<void(const std::string&)> callback)
     {
-        using nlohmann::json;
+        using json = glz::json_t;
         json packet;
         packet["address"] = std::format("{}:{}", server->host, server->port);
         packet["name"] = server->name;
-        packet["password"] = NULL;
+        packet["password"] = nullptr;
         packet["channel_id"] = channel_id;
         packet["channel_name"] = channel_id;
-        packet["expires_in_days"] = 1;
+        packet["expires_in_days"] = 1.0;
 
-        Resources::Post("https://invites.teamspeak.com/servers/create", packet.dump(), [callback](const bool success, const std::string& response, void*) {
+        Resources::Post("https://invites.teamspeak.com/servers/create", glz::write_json(packet).value_or(std::string{}), [callback](const bool success, const std::string& response, void*) {
             if (!success) {
                 Log::Error("Failed to get teamspeak invite link (1)");
                 Log::Log("%s", response.c_str());
                 return;
             }
-            const json& res = json::parse(response.c_str(), nullptr, false);
-            if (res == json::value_t::discarded) {
+            json res;
+            if (auto ec = glz::read_json(res, response); ec) {
                 Log::Error("Failed to get teamspeak invite link (2)");
                 return;
             }

--- a/GWToolboxdll/Modules/TextToSpeechModule.cpp
+++ b/GWToolboxdll/Modules/TextToSpeechModule.cpp
@@ -1022,11 +1022,11 @@ Gender GetGenderByFileId(const uint32_t file_id)
         return total_size;
     }
 
-    std::string PostJson(RestClient& client, const std::string& url, const nlohmann::json& request_body, const std::string& service_name = "API")
+    std::string PostJson(RestClient& client, const std::string& url, const glz::json_t& request_body, const std::string& service_name = "API")
     {
         client.SetUrl(url.c_str());
         client.SetHeader("Content-Type", "application/json");
-        client.SetPostContent(request_body.dump(), ContentFlag::Copy);
+        client.SetPostContent(glz::write_json(request_body).value_or(std::string{}), ContentFlag::Copy);
         client.SetFollowLocation(true);
         client.SetVerifyHost(false);
         client.SetVerifyPeer(false);
@@ -1047,7 +1047,7 @@ Gender GetGenderByFileId(const uint32_t file_id)
         const auto api_config = GetCurrentAPIConfig();
         if (!(api_config && *api_config->api_key)) return VoiceLog("No API Key"), "";
 
-        nlohmann::json request_body;
+        glz::json_t request_body;
         request_body["model"] = "gpt-4o-mini-tts";
         request_body["input"] = TextUtils::WStringToString(audio->decoded_message);
         request_body["voice"] = (audio->profile->voice_id == voice_id_human_female) ? "nova" : "onyx";
@@ -1068,13 +1068,13 @@ Gender GetGenderByFileId(const uint32_t file_id)
         const auto api_config = GetCurrentAPIConfig();
         if (!(api_config && *api_config->api_key)) return VoiceLog("No API Key"), "";
 
-        nlohmann::json voice_settings;
+        glz::json_t voice_settings;
         voice_settings["stability"] = audio->profile->stability;
         voice_settings["similarity_boost"] = audio->profile->similarity;
         voice_settings["style"] = audio->profile->style;
         voice_settings["use_speaker_boost"] = true;
 
-        nlohmann::json request_body;
+        glz::json_t request_body;
         request_body["text"] = TextUtils::WStringToString(audio->decoded_message);
         request_body["model_id"] = "eleven_flash_v2_5";
         request_body["voice_settings"] = voice_settings;
@@ -1090,26 +1090,26 @@ Gender GetGenderByFileId(const uint32_t file_id)
 
     std::string GenerateVoiceGWDevHub(PendingNPCAudio* audio)
     {
-        nlohmann::json encoded_array = nlohmann::json::array();
+        glz::json_t::array_t encoded_array;
         for (const auto& c : audio->encoded_message)
-            encoded_array.push_back(static_cast<uint32_t>(c));
+            encoded_array.push_back(glz::json_t{static_cast<double>(static_cast<uint32_t>(c))});
 
-        nlohmann::json decoded_array = nlohmann::json::array();
+        glz::json_t::array_t decoded_array;
         for (const auto& c : audio->decoded_message)
-            decoded_array.push_back(static_cast<uint32_t>(c));
+            decoded_array.push_back(glz::json_t{static_cast<double>(static_cast<uint32_t>(c))});
 
-        nlohmann::json request_body = nlohmann::json::object();
-        request_body["encoded"] = encoded_array;
-        request_body["decoded"] = decoded_array;
+        glz::json_t request_body = glz::json_t::object_t{};
+        request_body["encoded"] = std::move(encoded_array);
+        request_body["decoded"] = std::move(decoded_array);
 
         if (!audio->encoded_npc_name.empty()) {
-            nlohmann::json encoded_npc_name_arr = nlohmann::json::array();
+            glz::json_t::array_t encoded_npc_name_arr;
             for (const auto& c : audio->encoded_npc_name)
-                encoded_npc_name_arr.push_back(static_cast<uint32_t>(c));
-            request_body["npc_name"] = encoded_npc_name_arr;
+                encoded_npc_name_arr.push_back(glz::json_t{static_cast<double>(static_cast<uint32_t>(c))});
+            request_body["npc_name"] = std::move(encoded_npc_name_arr);
         }
 
-        request_body["language"] = static_cast<uint32_t>(audio->language);
+        request_body["language"] = static_cast<double>(static_cast<uint32_t>(audio->language));
         request_body["speaker_gender"] = audio->gender == Gender::Male ? "m" : "f";
         request_body["speaker_race"] = GetRaceName(GetRaceByFileId(audio->model_file_id));
         request_body["player_gender"] = GetPlayerGender() == Gender::Male ? "m" : "f";
@@ -1155,7 +1155,7 @@ Gender GetGenderByFileId(const uint32_t file_id)
                 break;
         }
 
-        nlohmann::json request_body;
+        glz::json_t request_body;
         request_body["model"] = "kokoro";
         request_body["input"] = TextUtils::WStringToString(audio->decoded_message);
         request_body["voice"] = (audio->gender == Gender::Female) ? "af_bella" : "am_adam";
@@ -1177,7 +1177,7 @@ Gender GetGenderByFileId(const uint32_t file_id)
 
         const std::string voice_name = (audio->profile->voice_id == voice_id_human_female) ? "en-US-Studio-O" : "en-US-Studio-Q";
 
-        nlohmann::json request_body = nlohmann::json::object();
+        glz::json_t request_body = glz::json_t::object_t{};
         request_body["input"]["text"] = TextUtils::WStringToString(audio->decoded_message);
         request_body["voice"]["name"] = voice_name;
         request_body["voice"]["languageCode"] = "en-US";
@@ -1189,13 +1189,13 @@ Gender GetGenderByFileId(const uint32_t file_id)
         const auto response_str = PostJson(client, "https://texttospeech.googleapis.com/v1/text:synthesize?key=" + std::string(api_config->api_key), request_body, api_config->name);
         if (response_str.empty()) return response_str;
 
-        const auto json_response = nlohmann::json::parse(response_str, nullptr, false);
-        if (!(!json_response.is_discarded() && json_response.contains("audioContent") && json_response["audioContent"].is_string())) {
+        glz::json_t json_response;
+        if (auto ec = glz::read_json(json_response, response_str); ec || !json_response.contains("audioContent") || !json_response.at("audioContent").is_string()) {
             VoiceLog("Failed to parse Google TTS response JSON");
             return "";
         }
 
-        std::string base64_audio = json_response["audioContent"].get<std::string>();
+        std::string base64_audio = json_response.at("audioContent").get<std::string>();
         if (base64_audio.empty()) {
             VoiceLog("Google TTS returned empty audio content");
             return "";
@@ -1216,7 +1216,7 @@ Gender GetGenderByFileId(const uint32_t file_id)
         const std::string voice_id = (GetAgentGender(audio->agent_id) == Gender::Female) ? playht_voice_female_default : playht_voice_male_default;
         const std::string lang_code = LanguageToAbbreviation(audio->language);
 
-        nlohmann::json request_body = nlohmann::json::object();
+        glz::json_t request_body = glz::json_t::object_t{};
         request_body["text"] = TextUtils::WStringToString(audio->decoded_message);
         request_body["output_format"] = "mp3";
         request_body["quality"] = "medium";

--- a/GWToolboxdll/Modules/TwitchModule.cpp
+++ b/GWToolboxdll/Modules/TwitchModule.cpp
@@ -55,14 +55,17 @@ namespace {
                 return Log::Warning(response.c_str()), fetch_oauth_token = false;
             }
 
-            const auto json = nlohmann::json::parse(response);
+            glz::json_t json;
+            if (auto ec = glz::read_json(json, response); ec) {
+                return Log::Warning("Failed to parse Twitch auth response"), fetch_oauth_token = false;
+            }
             if (!json.contains("verification_uri") || !json.contains("device_code") || !json.contains("interval")) {
                 return Log::Warning("Invalid or missing response fields for Twitch auth"), fetch_oauth_token = false;
             }
 
-            auto verification_uri = json["verification_uri"].get<std::string>();
-            auto device_code = json["device_code"].get<std::string>();
-            auto interval = json["interval"].get<int>();
+            auto verification_uri = json.at("verification_uri").get<std::string>();
+            auto device_code = json.at("device_code").get<std::string>();
+            auto interval = static_cast<int>(json.at("interval").get<double>());
 
             ShellExecuteA(nullptr, "open", verification_uri.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 
@@ -89,13 +92,16 @@ namespace {
                     continue;
                 }
 
-                auto token_json = nlohmann::json::parse(token_response);
+                glz::json_t token_json;
+                if (auto ec = glz::read_json(token_json, token_response); ec) {
+                    continue;
+                }
                 if (token_json.contains("access_token")) {
-                    access_token = token_json["access_token"].get<std::string>();
+                    access_token = token_json.at("access_token").get<std::string>();
                     break;
                 }
                 if (token_json.contains("error")) {
-                    std::string error = token_json["error"].get<std::string>();
+                    std::string error = token_json.at("error").get<std::string>();
                     if (error == "authorization_pending") {
                         continue;
                     }

--- a/GWToolboxdll/Modules/Updater.cpp
+++ b/GWToolboxdll/Modules/Updater.cpp
@@ -59,48 +59,54 @@ namespace {
             Log::Log("Failed to download %s\n%s", url, response.c_str());
             return nullptr;
         }
-        using Json = nlohmann::json;
-        Json json = Json::parse(response.c_str(), nullptr, false);
-        if (json == Json::value_t::discarded || json.empty() || !json.is_array()) {
+        using Json = glz::json_t;
+        Json json;
+        if (auto ec = glz::read_json(json, response); ec) {
             return nullptr;
         }
-        for (const auto& js : json) {
-            if (!(js.contains("tag_name") && js["tag_name"].is_string())) {
+        if (!json.is_array() || json.get_array().empty()) {
+            return nullptr;
+        }
+        for (const auto& js : json.get_array()) {
+            if (!(js.contains("tag_name") && js.at("tag_name").is_string())) {
                 continue;
             }
-            const auto is_prerelease = js["prerelease"].get<bool>();
+            const auto is_prerelease = js.contains("prerelease") && js.at("prerelease").is_boolean()
+                ? js.at("prerelease").get<bool>()
+                : false;
             if (is_prerelease && release_type == ReleaseType::Stable) {
                 continue;
             }
-            auto tag_name = js["tag_name"].get<std::string>();
+            auto tag_name = js.at("tag_name").get<std::string>();
             const auto version_number_len = tag_name.find(tag_name.contains("_Release") ? "_Release" : "_Beta", 0);
             if (version_number_len == std::string::npos) {
                 continue;
             }
-            if (!(js.contains("assets") && js["assets"].is_array() && js["assets"].size() > 0)) {
+            if (!(js.contains("assets") && js.at("assets").is_array() && !js.at("assets").get_array().empty())) {
                 continue;
             }
-            if (!(js.contains("body") && js["body"].is_string())) {
+            if (!(js.contains("body") && js.at("body").is_string())) {
                 continue;
             }
-            for (unsigned int j = 0; j < js["assets"].size(); j++) {
-                const Json& asset = js["assets"][j];
-                if (!(asset.contains("name") && asset["name"].is_string())
-                    || !(asset.contains("browser_download_url") && asset["browser_download_url"].is_string())) {
+            const auto& assets = js.at("assets").get_array();
+            for (size_t j = 0; j < assets.size(); j++) {
+                const Json& asset = assets[j];
+                if (!(asset.contains("name") && asset.at("name").is_string())
+                    || !(asset.contains("browser_download_url") && asset.at("browser_download_url").is_string())) {
                     continue;
                 }
-                auto asset_name = asset["name"].get<std::string>();
+                auto asset_name = asset.at("name").get<std::string>();
                 if (asset_name != "GWToolbox.dll" && asset_name != "GWToolboxdll.dll") {
                     continue; // This release doesn't have a dll download.
                 }
-                release->download_url = asset["browser_download_url"].get<std::string>();
+                release->download_url = asset.at("browser_download_url").get<std::string>();
                 release->version = tag_name.substr(0, version_number_len);
                 if (is_prerelease) {
                     release->version += tag_name.substr(version_number_len + 1);
                 }
                 std::ranges::transform(release->version, release->version.begin(), [](const auto chr) { return static_cast<char>(std::tolower(chr)); });
-                release->body = js["body"].get<std::string>();
-                auto size_bytes = asset["size"].get<uintmax_t>(); // Slight rounding, GitHub isn't always correct down to the byte.
+                release->body = js.at("body").get<std::string>();
+                auto size_bytes = static_cast<uintmax_t>(asset.at("size").get<double>()); // Slight rounding, GitHub isn't always correct down to the byte.
                 release->size = static_cast<uintmax_t>(std::ceil(size_bytes / 16.0) * 16);
                 return release;
             }

--- a/GWToolboxdll/Utils/GuiUtils.h
+++ b/GWToolboxdll/Utils/GuiUtils.h
@@ -2,7 +2,7 @@
 
 // ReSharper disable once CppUnusedIncludeDirective
 #include <ImGuiAddons.h>
-#include <nlohmann/json.hpp>
+#include <glaze/glaze.hpp>
 #include <ToolboxIni.h>
 
 namespace GW::Constants {
@@ -90,8 +90,7 @@ namespace GuiUtils {
     template <map_type T>
     void MapToIni(ToolboxIni* ini, const char* section, const char* name, const T& map)
     {
-        const auto map_json = nlohmann::json(map);
-        const auto map_str = map_json.dump();
+        const auto map_str = glz::write_json(map).value_or(std::string{});
         ini->SetValue(section, name, map_str.c_str());
     }
 
@@ -99,12 +98,11 @@ namespace GuiUtils {
     T IniToMap(ToolboxIni* ini, const char* section, const char* name)
     {
         std::string map_str = ini->GetValue(section, name, "");
-        try {
-            const auto map_json = nlohmann::json::parse(map_str);
-            return map_json.get<T>();
-        } catch (nlohmann::json::exception e) {
+        T out{};
+        if (glz::read_json(out, map_str)) {
             return {};
         }
+        return out;
     }
 
     template <map_type T>

--- a/GWToolboxdll/Utils/TextUtils.cpp
+++ b/GWToolboxdll/Utils/TextUtils.cpp
@@ -71,42 +71,58 @@ namespace {
 }
 
 namespace TextUtils {
-    std::string parseStringFromJson(const nlohmann::json& j, const char* key, const std::string& default_val)
+    std::string parseStringFromJson(const glz::json_t& j, const char* key, const std::string& default_val)
     {
-        if (!j.is_discarded() && j.contains(key) && j[key].is_string()) {
-            return j[key].get<std::string>();
+        if (j.contains(key) && j.at(key).is_string()) {
+            return j.at(key).get<std::string>();
         }
         return default_val;
     };
-    int parseIntFromJson(const nlohmann::json& j, const char* key, const int& default_val)
+    int parseIntFromJson(const glz::json_t& j, const char* key, const int& default_val)
     {
-        if (!j.is_discarded() && j.contains(key) && j[key].is_number_integer()) {
-            return j[key].get<int>();
+        if (j.contains(key) && j.at(key).is_number()) {
+            return static_cast<int>(j.at(key).get<double>());
         }
         return default_val;
     };
-    bool parseBoolFromJson(const nlohmann::json& j, const char* key, const bool& default_val)
+    bool parseBoolFromJson(const glz::json_t& j, const char* key, const bool& default_val)
     {
-        if (!j.is_discarded() && j.contains(key) && j[key].is_boolean()) {
-            return j[key].get<bool>();
+        if (j.contains(key) && j.at(key).is_boolean()) {
+            return j.at(key).get<bool>();
         }
         return default_val;
     };
-    uint64_t parseUint64FromJson(const nlohmann::json& j, const char* key, const uint64_t& default_val)
+    uint64_t parseUint64FromJson(const glz::json_t& j, const char* key, const uint64_t& default_val)
     {
-        if (!j.is_discarded() && j.contains(key) && j[key].is_number_unsigned()) {
-            return j[key].get<uint64_t>();
+        if (j.contains(key) && j.at(key).is_number()) {
+            return static_cast<uint64_t>(j.at(key).get<double>());
         }
         return default_val;
     };
-    float parseFloatFromJson(const nlohmann::json& j, const char* key, const float& default_val)
+    float parseFloatFromJson(const glz::json_t& j, const char* key, const float& default_val)
     {
-        if (!j.is_discarded() && j.contains(key)) {
-            if (j[key].is_number_float()) return j[key].get<float>();
-            if (j[key].is_number_integer()) return (float)j[key].get<int>();
+        if (j.contains(key) && j.at(key).is_number()) {
+            return static_cast<float>(j.at(key).get<double>());
         }
         return default_val;
     };
+
+    glz::json_t ParseJson(std::string_view s, bool* ok)
+    {
+        glz::json_t j;
+        const auto ec = glz::read_json(j, s);
+        if (ok) *ok = !ec;
+        if (ec) j = nullptr;
+        return j;
+    }
+
+    std::string DumpJson(const glz::json_t& j, bool prettify)
+    {
+        if (prettify) {
+            return glz::write<glz::opts{.prettify = true}>(j).value_or(std::string{});
+        }
+        return glz::write_json(j).value_or(std::string{});
+    }
 
     std::string VStrPrintf(const char* format, va_list argv)
     {

--- a/GWToolboxdll/Utils/TextUtils.h
+++ b/GWToolboxdll/Utils/TextUtils.h
@@ -87,11 +87,16 @@ namespace TextUtils {
     bool StringToGuid(const std::string& str, GUID* guid);
     GUID ConvertWStringToGuid(const std::wstring& str);
 
-    std::string parseStringFromJson(const nlohmann::json& j, const char* key, const std::string& default_val);
-    int parseIntFromJson(const nlohmann::json& j, const char* key, const int& default_val);
-    bool parseBoolFromJson(const nlohmann::json& j, const char* key, const bool& default_val);
-    uint64_t parseUint64FromJson(const nlohmann::json& j, const char* key, const uint64_t& default_val);
-    float parseFloatFromJson(const nlohmann::json& j, const char* key, const float& default_val);
+    std::string parseStringFromJson(const glz::json_t& j, const char* key, const std::string& default_val);
+    int parseIntFromJson(const glz::json_t& j, const char* key, const int& default_val);
+    bool parseBoolFromJson(const glz::json_t& j, const char* key, const bool& default_val);
+    uint64_t parseUint64FromJson(const glz::json_t& j, const char* key, const uint64_t& default_val);
+    float parseFloatFromJson(const glz::json_t& j, const char* key, const float& default_val);
+
+    // Parse JSON; on failure returns a default-constructed (null) json_t and sets *ok to false.
+    glz::json_t ParseJson(std::string_view s, bool* ok = nullptr);
+    // Serialize json_t to string; on failure returns empty.
+    std::string DumpJson(const glz::json_t& j, bool prettify = false);
 
 
     std::string VStrPrintf(const char* format, va_list argv);

--- a/GWToolboxdll/Widgets/ServerInfoWidget.cpp
+++ b/GWToolboxdll/Widgets/ServerInfoWidget.cpp
@@ -110,15 +110,16 @@ void ServerInfoWidget::Update(float)
                 return;
             }
             if (!response.empty()) {
-                using Json = nlohmann::json;
-                Json json = Json::parse(response.c_str());
-                if (current_server_info->city.empty() && json["city"].is_string()) {
-                    current_server_info->city = json["city"];
+                glz::json_t json;
+                if (auto ec = glz::read_json(json, response); !ec) {
+                    if (current_server_info->city.empty() && json.contains("city") && json.at("city").is_string()) {
+                        current_server_info->city = json.at("city").get<std::string>();
+                    }
+                    if (current_server_info->country.empty() && json.contains("country_name") && json.at("country_name").is_string()) {
+                        current_server_info->country = json.at("country_name").get<std::string>();
+                    }
+                    server_string_dirty = true;
                 }
-                if (current_server_info->country.empty() && json["country_name"].is_string()) {
-                    current_server_info->country = json["country_name"];
-                }
-                server_string_dirty = true;
             }
         });
     }

--- a/GWToolboxdll/Windows/ArmoryWindow.cpp
+++ b/GWToolboxdll/Windows/ArmoryWindow.cpp
@@ -926,27 +926,28 @@ namespace GWArmory {
                 }
 
                 // Build JSON output
-                nlohmann::json output_json = nlohmann::json::array();
+                glz::json_t::array_t output_arr;
                 for (auto& it : pending_decodes) {
                     const auto item = pending_items[it.first];
                     const std::string& item_name_decoded = it.second->string();
 
-                    nlohmann::json item_json = {
-                        {"name", item_name_decoded},
-                        {"model_file_id", item->model_file_id},
-                        {"type", static_cast<uint8_t>(item->type)},
-                        {"interaction", item->interaction},
-                        {"dye_tint", item->dye.dye_tint}
-                    };
+                    glz::json_t item_json;
+                    item_json["name"] = item_name_decoded;
+                    item_json["model_file_id"] = static_cast<double>(item->model_file_id);
+                    item_json["type"] = static_cast<double>(static_cast<uint8_t>(item->type));
+                    item_json["interaction"] = static_cast<double>(item->interaction);
+                    item_json["dye_tint"] = static_cast<double>(item->dye.dye_tint);
 
-                    output_json.push_back(item_json);
+                    output_arr.push_back(item_json);
                 }
+
+                glz::json_t output_json{std::move(output_arr)};
 
                 // Write to file
                 const auto filename = Resources::GetPath("weapon_snapshot.json");
                 std::ofstream file(filename);
                 if (file.is_open()) {
-                    file << output_json.dump(2); // Pretty print with 2 space indent
+                    file << glz::write<glz::opts{.prettify = true}>(output_json).value_or(std::string{}); // Pretty print
                     file.close();
                     Log::Info("Weapon snapshot saved to %s", filename.string().c_str());
                 }

--- a/GWToolboxdll/Windows/GWMarketWindow.cpp
+++ b/GWToolboxdll/Windows/GWMarketWindow.cpp
@@ -20,7 +20,7 @@
 #include <Utils/RateLimiter.h>
 
 #include <Utils/ThreadedWebSocket.h>
-#include <nlohmann/json.hpp>
+#include <glaze/glaze.hpp>
 
 
 #include <Modules/GwDatTextureModule.h>
@@ -44,7 +44,7 @@
 #define GWMARKET_SELLING_ENABLED 0
 
 namespace {
-    using json = nlohmann::json;
+    using json = glz::json_t;
 
     const char* market_host = "gwmarket.net";
     const char* market_name = "GWMarket.net";
@@ -214,10 +214,10 @@ namespace {
         {
             json j;
             if (!valid()) return j;
-            j["type"] = static_cast<int>(type);
-            j["quantity"] = quantity;
-            j["unit"] = quantity;
-            j["price"] = price;
+            j["type"] = static_cast<double>(static_cast<int>(type));
+            j["quantity"] = static_cast<double>(quantity);
+            j["unit"] = static_cast<double>(quantity);
+            j["price"] = static_cast<double>(price);
             return j;
         }
         bool valid() const { return quantity && price; }
@@ -259,7 +259,7 @@ namespace {
             if (!valid()) return {};
             json j;
             j["attribute"] = *GetAttributeName(attribute);
-            j["requirement"] = requirement;
+            j["requirement"] = static_cast<double>(requirement);
             j["inscription"] = inscribable;
             return j;
         }
@@ -282,7 +282,7 @@ namespace {
         static MarketItem FromJson(const json& j)
         {
             MarketItem item;
-            if (j.is_discarded()) return item;
+            if (!j.is_object()) return item;
 
             item.name = TextUtils::parseStringFromJson(j, "name", "");
             item.player = TextUtils::parseStringFromJson(j, "player", "");
@@ -290,15 +290,15 @@ namespace {
             item.orderType = static_cast<OrderType>(TextUtils::parseIntFromJson(j, "orderType", 0));
             item.quantity = TextUtils::parseIntFromJson(j, "quantity", 0);
 
-            if (j.contains("weaponDetails") && j["weaponDetails"].is_object()) {
-                item.weaponDetails = WeaponDetails::FromJson(j["weaponDetails"]);
+            if (j.contains("weaponDetails") && j.at("weaponDetails").is_object()) {
+                item.weaponDetails = WeaponDetails::FromJson(j.at("weaponDetails"));
             }
 
             uint64_t lastRefresh_ms = TextUtils::parseUint64FromJson(j, "lastRefresh", 0ULL);
             item.lastRefresh = lastRefresh_ms ? lastRefresh_ms / 1000 : 0;
 
-            if (j.contains("prices") && j["prices"].is_array()) {
-                for (const auto& price_json : j["prices"]) {
+            if (j.contains("prices") && j.at("prices").is_array()) {
+                for (const auto& price_json : j.at("prices").get_array()) {
                     auto p = Price::FromJson(price_json);
                     if (p.valid()) item.prices.push_back(p);
                 }
@@ -313,18 +313,19 @@ namespace {
             j["name"] = name;
             j["player"] = player;
             j["description"] = description;
-            j["orderType"] = static_cast<int>(orderType);
-            j["quantity"] = quantity;
-            j["lastRefresh"] = static_cast<uint64_t>(lastRefresh) * 1000; // Convert to milliseconds
+            j["orderType"] = static_cast<double>(static_cast<int>(orderType));
+            j["quantity"] = static_cast<double>(quantity);
+            j["lastRefresh"] = static_cast<double>(static_cast<uint64_t>(lastRefresh) * 1000); // Convert to milliseconds
 
             if (has_weapon_details()) {
                 j["weaponDetails"] = weaponDetails.ToJson();
             }
 
-            j["prices"] = json::array();
+            glz::json_t::array_t prices_arr;
             for (const auto& price : prices) {
-                j["prices"].push_back(price.ToJson());
+                prices_arr.push_back(price.ToJson());
             }
+            j["prices"] = std::move(prices_arr);
 
             return j;
         }
@@ -356,8 +357,8 @@ namespace {
         static ShopItem FromJson(const json& j)
         {
             ShopItem item = MarketItem::FromJson(j);
-            if (j.contains("orderDetails") && j["orderDetails"].is_object()) {
-                const auto& od = j["orderDetails"];
+            if (j.contains("orderDetails") && j.at("orderDetails").is_object()) {
+                const auto& od = j.at("orderDetails");
                 item.dedicated = TextUtils::parseBoolFromJson(od, "dedicated", false);
                 item.pre = TextUtils::parseBoolFromJson(od, "pre", false);
             }
@@ -377,7 +378,7 @@ namespace {
         static MarketShop FromJson(const json& j)
         {
             MarketShop shop;
-            if (j.is_discarded()) return shop;
+            if (!j.is_object()) return shop;
 
             shop.player = TextUtils::parseStringFromJson(j, "player", "");
             shop.uuid = TextUtils::parseStringFromJson(j, "uuid", "");
@@ -385,16 +386,16 @@ namespace {
             uint64_t lastRefresh_ms = TextUtils::parseUint64FromJson(j, "lastRefresh", 0ULL);
             shop.lastRefresh = lastRefresh_ms ? lastRefresh_ms / 1000 : 0;
 
-            if (j.contains("items") && j["items"].is_array()) {
-                for (const auto& item_json : j["items"]) {
+            if (j.contains("items") && j.at("items").is_array()) {
+                for (const auto& item_json : j.at("items").get_array()) {
                     auto item = ShopItem::FromJson(item_json);
                     if (item.valid()) {
                         shop.items.push_back(item);
                     }
                 }
             }
-            if (j.contains("certified") && j["certified"].is_array()) {
-                for (const auto& player_name : j["certified"]) {
+            if (j.contains("certified") && j.at("certified").is_array()) {
+                for (const auto& player_name : j.at("certified").get_array()) {
                     if (player_name.is_string()) shop.certified.push_back(player_name.get<std::string>());
                 }
             }
@@ -408,19 +409,19 @@ namespace {
             if (!valid()) return j;
             j["player"] = player;
             j["uuid"] = uuid;
-            j["lastRefresh"] = (uint64_t)(lastRefresh * 1000);
+            j["lastRefresh"] = static_cast<double>(static_cast<uint64_t>(lastRefresh * 1000));
             j["authCertified"] = certified.size() > 0;
-            std::vector<json> certified_json;
+            glz::json_t::array_t certified_arr;
             for (auto& player_name : certified) {
-                certified_json.push_back(player_name);
+                certified_arr.push_back(json{player_name});
             }
-            j["certified"] = certified_json;
+            j["certified"] = std::move(certified_arr);
             j["daybreakOnline"] = true;
-            std::vector<json> items_json;
+            glz::json_t::array_t items_arr;
             for (auto& item : items) {
-                items_json.push_back(item.ToJson());
+                items_arr.push_back(item.ToJson());
             }
-            j["items"] = items_json;
+            j["items"] = std::move(items_arr);
             return j;
         }
         bool valid() const { return !uuid.empty(); }
@@ -563,32 +564,36 @@ namespace {
 
     std::string EncodeSocketIOMessage(const std::string& event, const std::string& data = "")
     {
-        json msg = json::array();
-        msg.push_back(event);
+        glz::json_t::array_t msg_arr;
+        msg_arr.push_back(json{event});
         if (!data.empty()) {
-            msg.push_back(data);
+            msg_arr.push_back(json{data});
         }
-        return "42" + msg.dump();
+        json msg{std::move(msg_arr)};
+        return "42" + glz::write_json(msg).value_or(std::string{});
     }
 
     std::string EncodeSocketIOMessage(const std::string& event, const json& data)
     {
-        json msg = json::array();
-        msg.push_back(event);
-        msg.push_back(data);
-        return "42" + msg.dump();
+        glz::json_t::array_t msg_arr;
+        msg_arr.push_back(json{event});
+        msg_arr.push_back(data);
+        json msg{std::move(msg_arr)};
+        return "42" + glz::write_json(msg).value_or(std::string{});
     }
 
     bool ParseSocketIOMessage(const std::string& message, std::string& event, json& data)
     {
         if (message.length() < 2 || message.substr(0, 2) != "42") return false;
 
-        json parsed = json::parse(message.substr(2), nullptr, false);
-        if (!parsed.is_discarded() && parsed.is_array() && parsed.size() >= 1) {
-            if (!parsed[0].is_string()) return false;
-            event = parsed[0].get<std::string>();
-            if (parsed.size() >= 2) {
-                data = parsed[1];
+        json parsed;
+        if (auto ec = glz::read_json(parsed, message.substr(2)); ec) return true;
+        if (parsed.is_array() && parsed.get_array().size() >= 1) {
+            const auto& arr = parsed.get_array();
+            if (!arr[0].is_string()) return false;
+            event = arr[0].get<std::string>();
+            if (arr.size() >= 2) {
+                data = arr[1];
                 return true;
             }
         }
@@ -598,14 +603,15 @@ namespace {
     void OnGetAvailableOrders(const json& orders)
     {
         available_items.clear();
-        available_items.reserve(orders.size());
+        if (!orders.is_object()) return;
+        const auto& obj = orders.get_object();
+        available_items.reserve(obj.size());
         for (auto& i : favorite_items) {
             i.second = {};
         }
-        for (auto it = orders.begin(); it != orders.end(); ++it) {
+        for (const auto& [key, j] : obj) {
             AvailableItem item;
-            const auto& j = it.value();
-            item.name = InternString(it.key());
+            item.name = InternString(std::string{key});
             item.sellOrders = TextUtils::parseIntFromJson(j, "sellWeek", 0);
             item.buyOrders = TextUtils::parseIntFromJson(j, "buyWeek", 0);
             available_items.push_back(item);
@@ -621,8 +627,9 @@ namespace {
     {
         last_items.clear();
         if (items.is_array()) {
-            last_items.reserve(items.size());
-            for (const auto& item_json : items) {
+            const auto& arr = items.get_array();
+            last_items.reserve(arr.size());
+            for (const auto& item_json : arr) {
                 last_items.push_back(MarketItem::FromJson(item_json));
             }
         }
@@ -633,8 +640,9 @@ namespace {
     {
         std::vector<MarketItem> _orders;
         if (orders.is_array()) {
-            _orders.reserve(orders.size());
-            for (const auto& order_json : orders) {
+            const auto& arr = orders.get_array();
+            _orders.reserve(arr.size());
+            for (const auto& order_json : arr) {
                 _orders.push_back(MarketItem::FromJson(order_json));
             }
         }
@@ -696,12 +704,13 @@ namespace {
     {
         if (message[0] != '0') return;
 
-        json handshake = json::parse(message.substr(1));
+        json handshake;
+        if (auto ec = glz::read_json(handshake, message.substr(1)); ec) return;
         if (handshake.contains("pingInterval")) {
-            ping_interval = handshake["pingInterval"].get<int>();
+            ping_interval = static_cast<int>(handshake.at("pingInterval").get<double>());
         }
         if (handshake.contains("pingTimeout")) {
-            ping_timeout = handshake["pingTimeout"].get<int>();
+            ping_timeout = static_cast<int>(handshake.at("pingTimeout").get<double>());
         }
 
         Log::Log("Handshake: ping %dms, timeout %dms", ping_interval, ping_timeout);

--- a/GWToolboxdll/Windows/ObjectiveTimerWindow.cpp
+++ b/GWToolboxdll/Windows/ObjectiveTimerWindow.cpp
@@ -1134,18 +1134,21 @@ void ObjectiveTimerWindow::LoadRuns()
                 std::wstring fn = Resources::GetPath(L"runs", *it);
                 file.open(fn);
                 if (file.is_open()) {
-                    nlohmann::json os_json_arr;
-                    file >> os_json_arr;
-                    for (auto json_it = os_json_arr.begin(); json_it != os_json_arr.end(); ++json_it) {
-                        ObjectiveSet* os = ObjectiveSet::FromJson(json_it.value());
-                        if (instance.objective_sets.contains(os->system_time)) {
-                            delete os;
-                            continue; // Don't load in a run that already exists
+                    std::stringstream ss;
+                    ss << file.rdbuf();
+                    glz::json_t os_json_arr;
+                    if (auto ec = glz::read_json(os_json_arr, ss.str()); !ec && os_json_arr.is_array()) {
+                        for (auto& elem : os_json_arr.get_array()) {
+                            ObjectiveSet* os = ObjectiveSet::FromJson(elem);
+                            if (instance.objective_sets.contains(os->system_time)) {
+                                delete os;
+                                continue; // Don't load in a run that already exists
+                            }
+                            os->StopObjectives();
+                            os->need_to_collapse = true;
+                            os->from_disk = true;
+                            instance.objective_sets.emplace(os->system_time, os);
                         }
-                        os->StopObjectives();
-                        os->need_to_collapse = true;
-                        os->from_disk = true;
-                        instance.objective_sets.emplace(os->system_time, os);
                     }
                     file.close();
                 }
@@ -1188,11 +1191,12 @@ void ObjectiveTimerWindow::SaveRuns()
                 std::ofstream file;
                 file.open(Resources::GetPath(L"runs", it.first));
                 if (file.is_open()) {
-                    nlohmann::json os_json_arr;
+                    glz::json_t::array_t os_json_arr;
                     for (const auto os : it.second) {
                         os_json_arr.push_back(os->ToJson());
                     }
-                    file << os_json_arr << std::endl;
+                    glz::json_t wrapper{os_json_arr};
+                    file << glz::write_json(wrapper).value_or(std::string{}) << std::endl;
                     file.close();
                 }
             } catch (const std::exception&) {
@@ -1564,64 +1568,64 @@ ObjectiveTimerWindow::ObjectiveSet::~ObjectiveSet()
     objectives.clear();
 }
 
-ObjectiveTimerWindow::ObjectiveSet* ObjectiveTimerWindow::ObjectiveSet::FromJson(const nlohmann::json& json)
+ObjectiveTimerWindow::ObjectiveSet* ObjectiveTimerWindow::ObjectiveSet::FromJson(const glz::json_t& json)
 {
     const auto os = new ObjectiveSet;
     os->active = false;
-    os->system_time = json.at("utc_start").get<DWORD>();
+    os->system_time = static_cast<DWORD>(json.at("utc_start").get<double>());
     os->name = json.at("name").get<std::string>();
-    os->run_start_time_point = json.at("instance_start").get<DWORD>();
+    os->run_start_time_point = static_cast<DWORD>(json.at("instance_start").get<double>());
     if (json.contains("duration")) {
-        os->duration = json.at("duration").get<DWORD>();
+        os->duration = static_cast<DWORD>(json.at("duration").get<double>());
     }
-    nlohmann::json json_objs = json.at("objectives");
-    for (auto it = json_objs.begin(); it != json_objs.end(); ++it) {
-        const nlohmann::json& o = it.value();
-        os->objectives.emplace_back(Objective::FromJson(o));
+    if (json.contains("objectives") && json.at("objectives").is_array()) {
+        for (const auto& o : json.at("objectives").get_array()) {
+            os->objectives.emplace_back(Objective::FromJson(o));
+        }
     }
     os->StopObjectives();
     return os;
 }
 
-nlohmann::json ObjectiveTimerWindow::ObjectiveSet::ToJson()
+glz::json_t ObjectiveTimerWindow::ObjectiveSet::ToJson()
 {
-    nlohmann::json json;
+    glz::json_t json;
     json["name"] = name;
-    json["instance_start"] = run_start_time_point;
-    json["utc_start"] = system_time;
-    nlohmann::json json_objectives;
+    json["instance_start"] = static_cast<double>(run_start_time_point);
+    json["utc_start"] = static_cast<double>(system_time);
+    glz::json_t::array_t json_objectives;
     for (auto* obj : objectives) {
         json_objectives.push_back(obj->ToJson());
     }
-    json["objectives"] = json_objectives;
-    json["duration"] = GetDuration();
+    json["objectives"] = std::move(json_objectives);
+    json["duration"] = static_cast<double>(GetDuration());
     return json;
 }
 
-nlohmann::json ObjectiveTimerWindow::Objective::ToJson()
+glz::json_t ObjectiveTimerWindow::Objective::ToJson()
 {
-    nlohmann::json json;
+    glz::json_t json;
     json["name"] = name;
-    json["status"] = status;
-    json["start"] = start;
-    json["done"] = done;
-    json["indent"] = indent;
-    json["duration"] = GetDuration();
+    json["status"] = static_cast<double>(std::to_underlying(status));
+    json["start"] = static_cast<double>(start);
+    json["done"] = static_cast<double>(done);
+    json["indent"] = static_cast<double>(indent);
+    json["duration"] = static_cast<double>(GetDuration());
     return json;
 }
 
-ObjectiveTimerWindow::Objective* ObjectiveTimerWindow::Objective::FromJson(const nlohmann::json& json)
+ObjectiveTimerWindow::Objective* ObjectiveTimerWindow::Objective::FromJson(const glz::json_t& json)
 {
     const auto name = json.at("name").get<std::string>();
     const auto obj = new Objective(name.c_str());
-    obj->status = json.at("status").get<Status>();
-    obj->start = json.at("start").get<DWORD>();
-    obj->done = json.at("done").get<DWORD>();
+    obj->status = static_cast<Status>(static_cast<int>(json.at("status").get<double>()));
+    obj->start = static_cast<DWORD>(json.at("start").get<double>());
+    obj->done = static_cast<DWORD>(json.at("done").get<double>());
     if (json.contains("indent")) {
-        obj->indent = json.at("indent").get<DWORD>();
+        obj->indent = static_cast<DWORD>(json.at("indent").get<double>());
     }
     if (json.contains("duration")) {
-        obj->duration = json.at("duration").get<DWORD>();
+        obj->duration = static_cast<DWORD>(json.at("duration").get<double>());
     }
     return obj;
 }

--- a/GWToolboxdll/Windows/ObjectiveTimerWindow.h
+++ b/GWToolboxdll/Windows/ObjectiveTimerWindow.h
@@ -127,8 +127,8 @@ private:
         Objective* SetStarted();
         Objective* SetDone();
         Objective* AddChild(Objective* child);
-        static Objective* FromJson(const nlohmann::json& json);
-        nlohmann::json ToJson();
+        static Objective* FromJson(const glz::json_t& json);
+        glz::json_t ToJson();
 
         [[nodiscard]] bool IsStarted() const;
         [[nodiscard]] bool IsDone() const;
@@ -193,8 +193,8 @@ private:
         void CheckSetDone();
         bool Draw(); // returns false when should be deleted
         void StopObjectives();
-        static ObjectiveSet* FromJson(const nlohmann::json& json);
-        nlohmann::json ToJson();
+        static ObjectiveSet* FromJson(const glz::json_t& json);
+        glz::json_t ToJson();
         void Update() const;
         void GetStartTime(tm* timeinfo) const;
 

--- a/GWToolboxdll/Windows/ObserverExportWindow.cpp
+++ b/GWToolboxdll/Windows/ObserverExportWindow.cpp
@@ -18,14 +18,14 @@ void ObserverExportWindow::Initialize()
 }
 
 // Convert to JSON (Version 0.1)
-nlohmann::json ObserverExportWindow::ToJSON_V_0_1()
+glz::json_t ObserverExportWindow::ToJSON_V_0_1()
 {
-    nlohmann::json json;
+    glz::json_t json;
     ObserverModule& observer_module = ObserverModule::Instance();
     const std::vector<uint32_t>& party_ids = observer_module.GetObservablePartyIds();
 
     auto shared_stats_to_json = [](const ObserverModule::SharedStats& stats) {
-        nlohmann::json shared_json;
+        glz::json_t shared_json;
         shared_json["total_crits_received"] = stats.total_crits_received;
         shared_json["total_crits_dealt"] = stats.total_crits_dealt;
         shared_json["total_party_crits_received"] = stats.total_party_crits_received;
@@ -42,56 +42,60 @@ nlohmann::json ObserverExportWindow::ToJSON_V_0_1()
         return shared_json;
     };
 
+    json["parties"] = glz::json_t::array_t{};
+    json["skills"] = glz::json_t::array_t{};
+
     for (const uint32_t party_id : party_ids) {
         // parties
         const ObserverModule::ObservableParty* party = observer_module.GetObservablePartyById(party_id);
         if (!party) {
-            json["parties"].push_back(nlohmann::json::value_t::null);
+            json["parties"].get_array().push_back(glz::json_t{nullptr});
             continue;
         }
-        json["parties"].push_back([&] {
+        json["parties"].get_array().push_back([&] {
             // parties -> party
-            nlohmann::json json_party;
+            glz::json_t json_party;
             json_party["party_id"] = party->party_id;
             json_party["stats"] = shared_stats_to_json(party->stats);
             
             // Party aggregate health snapshots (recorded every 15 seconds)
-            json_party["health_snapshots"] = nlohmann::json::array();
+            json_party["health_snapshots"] = glz::json_t::array_t{};
             for (const auto& snapshot : party->health_snapshots) {
-                nlohmann::json snapshot_json;
+                glz::json_t snapshot_json;
                 snapshot_json["timestamp_ms"] = snapshot.timestamp_ms;
                 snapshot_json["hp_percentage"] = snapshot.hp_percentage;
                 snapshot_json["hp_value"] = snapshot.hp_value;
                 snapshot_json["max_hp"] = snapshot.max_hp;
-                json_party["health_snapshots"].push_back(snapshot_json);
+                json_party["health_snapshots"].get_array().push_back(snapshot_json);
             }
-            
+
             // Shrine captures (captured shrines by this party)
-            json_party["shrine_captures"] = nlohmann::json::array();
+            json_party["shrine_captures"] = glz::json_t::array_t{};
             for (const auto& shrine_capture : party->shrine_captures) {
-                nlohmann::json shrine_json;
+                glz::json_t shrine_json;
                 shrine_json["timestamp_ms"] = shrine_capture.timestamp_ms;
-                json_party["shrine_captures"].push_back(shrine_json);
+                json_party["shrine_captures"].get_array().push_back(shrine_json);
             }
-            
+
             // Tower captures (captured towers/flags by this party)
-            json_party["tower_captures"] = nlohmann::json::array();
+            json_party["tower_captures"] = glz::json_t::array_t{};
             for (const auto& tower_capture : party->tower_captures) {
-                nlohmann::json tower_json;
+                glz::json_t tower_json;
                 tower_json["timestamp_ms"] = tower_capture.timestamp_ms;
-                json_party["tower_captures"].push_back(tower_json);
+                json_party["tower_captures"].get_array().push_back(tower_json);
             }
-            
+
+            json_party["members"] = glz::json_t::array_t{};
             for (const uint32_t agent_id : party->agent_ids) {
                 // parties -> party -> agents
                 ObserverModule::ObservableAgent* agent = observer_module.GetObservableAgentById(agent_id);
                 if (!agent) {
-                    json_party["members"].push_back(nlohmann::json::value_t::null);
+                    json_party["members"].get_array().push_back(glz::json_t{nullptr});
                     continue;
                 }
-                json_party["members"].push_back([&] {
+                json_party["members"].get_array().push_back([&] {
                     // parties -> party -> agents -> agent
-                    nlohmann::json json_agent;
+                    glz::json_t json_agent;
                     json_agent["display_name"] = agent->DisplayName();
                     json_agent["raw_name"] = agent->RawName();
                     json_agent["debug_name"] = agent->DebugName();
@@ -104,25 +108,25 @@ nlohmann::json ObserverExportWindow::ToJSON_V_0_1()
                     json_agent["stats"] = shared_stats_to_json(agent->stats);
 
                     // Death events (all deaths for this agent)
-                    json_agent["death_events"] = nlohmann::json::array();
+                    json_agent["death_events"] = glz::json_t::array_t{};
                     for (const auto& death : agent->death_events) {
-                        nlohmann::json death_json;
+                        glz::json_t death_json;
                         death_json["timestamp_ms"] = death.timestamp_ms;
                         death_json["position_x"] = death.position_x;
                         death_json["position_y"] = death.position_y;
                         death_json["killer_agent_id"] = death.killer_agent_id;
                         death_json["killing_skill_id"] = death.killing_skill_id;
                         death_json["is_npc"] = death.is_npc;
-                        json_agent["death_events"].push_back(death_json);
+                        json_agent["death_events"].get_array().push_back(death_json);
                     }
-                    
+
                     // Resurrection events (all resurrections for this agent)
-                    json_agent["resurrection_events"] = nlohmann::json::array();
+                    json_agent["resurrection_events"] = glz::json_t::array_t{};
                     for (const auto& rez : agent->resurrection_events) {
-                        nlohmann::json rez_json;
+                        glz::json_t rez_json;
                         rez_json["timestamp_ms"] = rez.timestamp_ms;
                         rez_json["resurrector_agent_id"] = rez.resurrector_agent_id;
-                        
+
                         // Add resurrection type
                         const char* res_type_str = "unknown";
                         switch (rez.resurrection_type) {
@@ -131,20 +135,20 @@ nlohmann::json ObserverExportWindow::ToJSON_V_0_1()
                             default: res_type_str = "unknown"; break;
                         }
                         rez_json["resurrection_type"] = res_type_str;
-                        
-                        json_agent["resurrection_events"].push_back(rez_json);
+
+                        json_agent["resurrection_events"].get_array().push_back(rez_json);
                     }
-                    
+
                     for (const auto skill_id : agent->stats.skill_ids_used) {
                         // parties -> party -> agents -> agent -> skills
                         ObserverModule::ObservableSkill* skill = ObserverModule::Instance().GetObservableSkillById(skill_id);
                         if (!skill) {
-                            json["skills"].push_back(nlohmann::json::value_t::null);
+                            json["skills"].get_array().push_back(glz::json_t{nullptr});
                             continue;
                         }
-                        json["skills"].push_back([&] {
+                        json["skills"].get_array().push_back([&] {
                             // parties -> party -> agents -> agent -> skills -> skill
-                            nlohmann::json json_skill;
+                            glz::json_t json_skill;
                             json_skill["name"] = skill->Name();
                             return json_skill;
                         }());
@@ -161,9 +165,9 @@ nlohmann::json ObserverExportWindow::ToJSON_V_0_1()
 }
 
 // Convert to JSON (Version 1.0)
-nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
+glz::json_t ObserverExportWindow::ToJSON_V_1_0()
 {
-    nlohmann::json json;
+    glz::json_t json;
     ObserverModule& om = ObserverModule::Instance();
 
     // name is built by iterating over the parties
@@ -183,7 +187,7 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
     // Use the map from when the match started (if available), otherwise fall back to current map
     ObserverModule::ObservableMap* map = om.match_start_map ? om.match_start_map : om.GetMap();
     
-    json["map"] = nlohmann::json::value_t::null;
+    json["map"] = glz::json_t{nullptr};
     if (map) {
         json["map"] = {};
         json["map"]["map_id"] = static_cast<uint32_t>(map->map_id);
@@ -201,7 +205,7 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
     }
 
     auto action_to_json = [](const ObserverModule::ObservedAction& action) {
-        nlohmann::json action_json;
+        glz::json_t action_json;
         action_json["started"] = action.started;
         action_json["stopped"] = action.stopped;
         action_json["interrupted"] = action.interrupted;
@@ -211,7 +215,7 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
     };
 
     auto shared_stats_to_json = [&action_to_json](const ObserverModule::SharedStats& stats) {
-        nlohmann::json stats_json;
+        glz::json_t stats_json;
         stats_json["total_crits_received"] = stats.total_crits_received;
         stats_json["total_crits_dealt"] = stats.total_crits_dealt;
         stats_json["total_party_crits_received"] = stats.total_party_crits_received;
@@ -262,7 +266,7 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
         std::string guild_id_s = std::to_string(guild_id);
         ObserverModule::ObservableGuild* guild = om.GetObservableGuildById(guild_id);
         if (!guild) {
-            json["guilds"]["by_id"][guild_id_s] = nlohmann::json::value_t::null;
+            json["guilds"]["by_id"][guild_id_s] = glz::json_t{nullptr};
             continue;
         }
         json["guilds"]["by_id"][guild_id_s]["guild_id"] = guild->guild_id;
@@ -285,7 +289,7 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
         std::string skill_id_s = std::to_string(std::to_underlying(skill_id));
         ObserverModule::ObservableSkill* skill = om.GetObservableSkillById(skill_id);
         if (!skill) {
-            json["skills"]["by_id"][skill_id_s] = nlohmann::json::value_t::null;
+            json["skills"]["by_id"][skill_id_s] = glz::json_t{nullptr};
             continue;
         }
         json["skills"]["by_id"][skill_id_s]["skill_id"] = skill->gw_skill.skill_id;
@@ -336,7 +340,7 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
         std::string party_id_s = std::to_string(party_id);
         ObserverModule::ObservableParty* party = om.GetObservablePartyById(party_id);
         if (!party) {
-            json["parties"]["by_id"][party_id_s] = nlohmann::json::value_t::null;
+            json["parties"]["by_id"][party_id_s] = glz::json_t{nullptr};
             continue;
         }
         if (name_prepend_vs) {
@@ -357,38 +361,38 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
         json["parties"]["by_id"][party_id_s]["stats"] = shared_stats_to_json(party->stats);
         
         // Morale boost events (with timestamps)
-        json["parties"]["by_id"][party_id_s]["morale_boosts"] = nlohmann::json::array();
+        json["parties"]["by_id"][party_id_s]["morale_boosts"] = glz::json_t::array_t{};
         for (const auto& morale_boost : party->morale_boosts) {
-            nlohmann::json morale_json;
+            glz::json_t morale_json;
             morale_json["timestamp_ms"] = morale_boost.timestamp_ms;
-            json["parties"]["by_id"][party_id_s]["morale_boosts"].push_back(morale_json);
+            json["parties"]["by_id"][party_id_s]["morale_boosts"].get_array().push_back(morale_json);
         }
         
         // Shrine capture events (with timestamps)
-        json["parties"]["by_id"][party_id_s]["shrine_captures"] = nlohmann::json::array();
+        json["parties"]["by_id"][party_id_s]["shrine_captures"] = glz::json_t::array_t{};
         for (const auto& shrine_capture : party->shrine_captures) {
-            nlohmann::json shrine_json;
+            glz::json_t shrine_json;
             shrine_json["timestamp_ms"] = shrine_capture.timestamp_ms;
-            json["parties"]["by_id"][party_id_s]["shrine_captures"].push_back(shrine_json);
+            json["parties"]["by_id"][party_id_s]["shrine_captures"].get_array().push_back(shrine_json);
         }
         
         // Tower capture events (with timestamps)
-        json["parties"]["by_id"][party_id_s]["tower_captures"] = nlohmann::json::array();
+        json["parties"]["by_id"][party_id_s]["tower_captures"] = glz::json_t::array_t{};
         for (const auto& tower_capture : party->tower_captures) {
-            nlohmann::json tower_json;
+            glz::json_t tower_json;
             tower_json["timestamp_ms"] = tower_capture.timestamp_ms;
-            json["parties"]["by_id"][party_id_s]["tower_captures"].push_back(tower_json);
+            json["parties"]["by_id"][party_id_s]["tower_captures"].get_array().push_back(tower_json);
         }
         
         // Party aggregate health snapshots (recorded every 15 seconds)
-        json["parties"]["by_id"][party_id_s]["health_snapshots"] = nlohmann::json::array();
+        json["parties"]["by_id"][party_id_s]["health_snapshots"] = glz::json_t::array_t{};
         for (const auto& snapshot : party->health_snapshots) {
-            nlohmann::json snapshot_json;
+            glz::json_t snapshot_json;
             snapshot_json["timestamp_ms"] = snapshot.timestamp_ms;
             snapshot_json["hp_percentage"] = snapshot.hp_percentage;
             snapshot_json["hp_value"] = snapshot.hp_value;
             snapshot_json["max_hp"] = snapshot.max_hp;
-            json["parties"]["by_id"][party_id_s]["health_snapshots"].push_back(snapshot_json);
+            json["parties"]["by_id"][party_id_s]["health_snapshots"].get_array().push_back(snapshot_json);
         }
     }
 
@@ -399,7 +403,7 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
         std::string agent_id_s = std::to_string(agent_id);
         ObserverModule::ObservableAgent* agent = om.GetObservableAgentById(agent_id);
         if (!agent) {
-            json["agents"]["by_id"][agent_id_s] = nlohmann::json::value_t::null;
+            json["agents"]["by_id"][agent_id_s] = glz::json_t{nullptr};
             continue;
         }
         json["agents"]["by_id"][agent_id_s]["agent_id"] = agent->agent_id;
@@ -421,7 +425,7 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
         for (auto& [target_id, action] : agent->stats.attacks_dealt_to_agents) {
             std::string target_id_s = std::to_string(target_id);
             if (!action) {
-                json["agents"]["by_id"][agent_id_s]["stats"]["attacks_dealt_to_agents"][target_id_s] = nlohmann::json::value_t::null;
+                json["agents"]["by_id"][agent_id_s]["stats"]["attacks_dealt_to_agents"][target_id_s] = glz::json_t{nullptr};
                 continue;
             }
             json["agents"]["by_id"][agent_id_s]["stats"]["attacks_dealt_to_agents"][target_id_s] = action_to_json(*action);
@@ -431,7 +435,7 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
         for (auto& [caster_id, action] : agent->stats.attacks_received_from_agents) {
             std::string caster_id_s = std::to_string(caster_id);
             if (!action) {
-                json["agents"]["by_id"][agent_id_s]["stats"]["attacks_received_from_agents"][caster_id_s] = nlohmann::json::value_t::null;
+                json["agents"]["by_id"][agent_id_s]["stats"]["attacks_received_from_agents"][caster_id_s] = glz::json_t{nullptr};
                 continue;
             }
             json["agents"]["by_id"][agent_id_s]["stats"]["attacks_received_from_agents"][caster_id_s] = action_to_json(*action);
@@ -445,7 +449,7 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
             std::string skill_id_s = std::to_string(std::to_underlying(skill_id));
             const auto it_skill = agent->stats.skills_used.find(skill_id);
             if (it_skill == agent->stats.skills_used.end()) {
-                json["agents"]["by_id"][agent_id_s]["stats"]["skills_used"][skill_id_s] = nlohmann::json::value_t::null;
+                json["agents"]["by_id"][agent_id_s]["stats"]["skills_used"][skill_id_s] = glz::json_t{nullptr};
                 continue;
             }
             json["agents"]["by_id"][agent_id_s]["stats"]["skills_used"][skill_id_s] = action_to_json(*it_skill->second);
@@ -458,7 +462,7 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
             std::string skill_id_s = std::to_string(std::to_underlying(skill_id));
             const auto it_skill = agent->stats.skills_received.find(skill_id);
             if (it_skill == agent->stats.skills_received.end()) {
-                json["agents"]["by_id"][agent_id_s]["stats"]["skills_received"][skill_id_s] = nlohmann::json::value_t::null;
+                json["agents"]["by_id"][agent_id_s]["stats"]["skills_received"][skill_id_s] = glz::json_t{nullptr};
                 continue;
             }
             json["agents"]["by_id"][agent_id_s]["stats"]["skills_received"][skill_id_s] = action_to_json(*it_skill->second);
@@ -470,14 +474,14 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
             std::string target_id_s = std::to_string(target_id);
             auto it_target = agent->stats.skills_used_on_agents.find(target_id);
             if (it_target == agent->stats.skills_used_on_agents.end()) {
-                json["agents"]["by_id"][agent_id_s]["stats"]["skills_used_on_agents"][target_id_s] = nlohmann::json::value_t::null;
+                json["agents"]["by_id"][agent_id_s]["stats"]["skills_used_on_agents"][target_id_s] = glz::json_t{nullptr};
                 continue;
             }
             for (auto skill_id : agent_skill_ids) {
                 std::string skill_id_s = std::to_string(std::to_underlying(skill_id));
                 auto it_skill = it_target->second.find(skill_id);
                 if (it_skill == it_target->second.end()) {
-                    json["agents"]["by_id"][agent_id_s]["stats"]["skills_used_on_agents"][target_id_s][skill_id_s] = nlohmann::json::value_t::null;
+                    json["agents"]["by_id"][agent_id_s]["stats"]["skills_used_on_agents"][target_id_s][skill_id_s] = glz::json_t{nullptr};
                     continue;
                 }
                 json["agents"]["by_id"][agent_id_s]["stats"]["skills_used_on_agents"][target_id_s][skill_id_s] = action_to_json(*it_skill->second);
@@ -489,14 +493,14 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
             std::string caster_id_s = std::to_string(caster_id);
             auto it_target = agent->stats.skills_received_from_agents.find(caster_id);
             if (it_target == agent->stats.skills_received_from_agents.end()) {
-                json["agents"]["by_id"][agent_id_s]["stats"]["skills_received_from_agents"][caster_id_s] = nlohmann::json::value_t::null;
+                json["agents"]["by_id"][agent_id_s]["stats"]["skills_received_from_agents"][caster_id_s] = glz::json_t{nullptr};
                 continue;
             }
             for (auto skill_id : agent_skill_ids) {
                 std::string skill_id_s = std::to_string(std::to_underlying(skill_id));
                 auto it_skill = it_target->second.find(skill_id);
                 if (it_skill == it_target->second.end()) {
-                    json["agents"]["by_id"][agent_id_s]["stats"]["skills_received_from_agents"][caster_id_s][skill_id_s] = nlohmann::json::value_t::null;
+                    json["agents"]["by_id"][agent_id_s]["stats"]["skills_received_from_agents"][caster_id_s][skill_id_s] = glz::json_t{nullptr};
                     continue;
                 }
                 json["agents"]["by_id"][agent_id_s]["stats"]["skills_received_from_agents"][caster_id_s][skill_id_s] = action_to_json(*it_skill->second);
@@ -576,22 +580,22 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
         }
 
         // Death events (all deaths for this agent)
-        json["agents"]["by_id"][agent_id_s]["death_events"] = nlohmann::json::array();
+        json["agents"]["by_id"][agent_id_s]["death_events"] = glz::json_t::array_t{};
         for (const auto& death : agent->death_events) {
-            nlohmann::json death_json;
+            glz::json_t death_json;
             death_json["timestamp_ms"] = death.timestamp_ms;
             death_json["position_x"] = death.position_x;
             death_json["position_y"] = death.position_y;
             death_json["killer_agent_id"] = death.killer_agent_id;
             death_json["killing_skill_id"] = death.killing_skill_id;
             death_json["is_npc"] = death.is_npc;
-            json["agents"]["by_id"][agent_id_s]["death_events"].push_back(death_json);
+            json["agents"]["by_id"][agent_id_s]["death_events"].get_array().push_back(death_json);
         }
         
         // Resurrection events (all resurrections for this agent)
-        json["agents"]["by_id"][agent_id_s]["resurrection_events"] = nlohmann::json::array();
+        json["agents"]["by_id"][agent_id_s]["resurrection_events"] = glz::json_t::array_t{};
         for (const auto& rez : agent->resurrection_events) {
-            nlohmann::json rez_json;
+            glz::json_t rez_json;
             rez_json["timestamp_ms"] = rez.timestamp_ms;
             rez_json["resurrector_agent_id"] = rez.resurrector_agent_id;
             
@@ -604,7 +608,7 @@ nlohmann::json ObserverExportWindow::ToJSON_V_1_0()
             }
             rez_json["resurrection_type"] = res_type_str;
             
-            json["agents"]["by_id"][agent_id_s]["resurrection_events"].push_back(rez_json);
+            json["agents"]["by_id"][agent_id_s]["resurrection_events"].get_array().push_back(rez_json);
         }
     }
 
@@ -638,9 +642,9 @@ void ObserverExportWindow::ExportToGWRank()
     }
     
     // Generate JSON v1.0
-    nlohmann::json json = ToJSON_V_1_0();
+    glz::json_t json = ToJSON_V_1_0();
     json["verson"] = "1.0";
-    std::string json_str = json.dump(4);
+    std::string json_str = glz::write<glz::opts{.prettify = true}>(json).value_or(std::string{});
     
     // Initialize curl
     CURL* curl = curl_easy_init();
@@ -715,7 +719,7 @@ void ObserverExportWindow::ExportToGWRank()
 // Export as JSON
 void ObserverExportWindow::ExportToJSON(Version version)
 {
-    nlohmann::json json;
+    glz::json_t json;
     std::string filename;
     SYSTEMTIME time;
     GetLocalTime(&time);
@@ -734,7 +738,7 @@ void ObserverExportWindow::ExportToJSON(Version version)
             json = ToJSON_V_1_0();
             json["verson"] = "1.0";
             json["exported_at_local"] = export_time;
-            std::string name = json["name"].dump();
+            std::string name = glz::write_json(json["name"]).value_or(std::string{});
             // remove quotation marks (come in from json.dump())
             std::erase(name, '"');
             // replace spaces with _
@@ -757,7 +761,7 @@ void ObserverExportWindow::ExportToJSON(Version version)
     }
 
     std::ofstream out(file_location);
-    out << json.dump();
+    out << glz::write_json(json).value_or(std::string{});
     out.close();
     wchar_t file_location_wc[512];
     size_t msg_len = 0;

--- a/GWToolboxdll/Windows/ObserverExportWindow.h
+++ b/GWToolboxdll/Windows/ObserverExportWindow.h
@@ -19,8 +19,8 @@ public:
     };
 
     static std::string PadLeft(std::string input, uint8_t count, char c);
-    static nlohmann::json ToJSON_V_0_1();
-    static nlohmann::json ToJSON_V_1_0();
+    static glz::json_t ToJSON_V_0_1();
+    static glz::json_t ToJSON_V_1_0();
     static void ExportToJSON(Version version);
 
     [[nodiscard]] const char* Name() const override { return "Observer Export"; };

--- a/GWToolboxdll/Windows/PacketLoggerWindow.cpp
+++ b/GWToolboxdll/Windows/PacketLoggerWindow.cpp
@@ -38,20 +38,20 @@ namespace {
         std::wstring description;
         GW::AreaInfo* map_info{};
 
-        nlohmann::json ToJson() const
+        glz::json_t ToJson() const
         {
-            nlohmann::json json;
+            glz::json_t json;
             if (!name.empty()) {
                 json["name"] = TextUtils::WStringToString(name);
             }
             if (!description.empty()) {
                 json["description"] = TextUtils::WStringToString(description);
             }
-            json["campaign"] = map_info->campaign;
-            json["type"] = map_info->type;
-            json["region"] = map_info->region;
-            json["flags"] = map_info->flags;
-            json["continent"] = map_info->continent;
+            json["campaign"] = static_cast<double>(map_info->campaign);
+            json["type"] = static_cast<double>(map_info->type);
+            json["region"] = static_cast<double>(map_info->region);
+            json["flags"] = static_cast<double>(map_info->flags);
+            json["continent"] = static_cast<double>(map_info->continent);
             return json;
         };
     };
@@ -81,9 +81,9 @@ namespace {
 
     void ExportMapInfo()
     {
-        nlohmann::json json;
+        glz::json_t json;
         for (const auto& it : maps) {
-            json[it.first] = it.second->ToJson();
+            json[std::to_string(it.first)] = it.second->ToJson();
             delete it.second;
         }
         maps.clear();
@@ -93,7 +93,7 @@ namespace {
         }
 
         std::ofstream out(file_location);
-        out << json.dump();
+        out << glz::write_json(json).value_or(std::string{});
         out.close();
         Log::Info("Maps exported to %ls", file_location.c_str());
     }

--- a/GWToolboxdll/Windows/PartySearchWindow.cpp
+++ b/GWToolboxdll/Windows/PartySearchWindow.cpp
@@ -37,7 +37,7 @@
 static constexpr uint32_t COST_PER_CONNECTION_MS = 30 * 1000;
 static constexpr uint32_t COST_PER_CONNECTION_MAX_MS = 60 * 1000;
 using easywsclient::WebSocket;
-using nlohmann::json;
+using json = glz::json_t;
 using json_vec = std::vector<json>;
 
 static constexpr char ws_host[] = "wss://lfg.gwtoolbox.com";
@@ -514,18 +514,17 @@ void PartySearchWindow::Update(const float)
 
 bool PartySearchWindow::parse_json_message(const json& js, Message* msg)
 {
-    if (js == json::value_t::discarded) {
+    if (!js.is_object()) {
         return false;
     }
-    if (!(js.contains("s") && js["s"].is_string())
-        || !(js.contains("m") && js["m"].is_string())
-        || !(js.contains("t") && js["t"].is_number_unsigned())) {
+    if (!(js.contains("s") && js.at("s").is_string())
+        || !(js.contains("m") && js.at("m").is_string())
+        || !(js.contains("t") && js.at("t").is_number())) {
         return false;
     }
-    msg->name = js["s"].get<std::string>();
-    msg->message = js["m"].get<std::string>();
-    msg->name = js["s"].get<std::string>();
-    msg->timestamp = static_cast<uint32_t>(js["t"].get<uint64_t>() / 1000); // Messy?
+    msg->name = js.at("s").get<std::string>();
+    msg->message = js.at("m").get<std::string>();
+    msg->timestamp = static_cast<uint32_t>(js.at("t").get<double>() / 1000.0); // Messy?
     return true;
 }
 
@@ -536,8 +535,8 @@ void PartySearchWindow::fetch()
     }
 
     ws_window->dispatch([this](const std::string& data) {
-        const json& res = json::parse(data.c_str(), nullptr, false);
-        if (res == json::value_t::discarded) {
+        json res;
+        if (auto ec = glz::read_json(res, data); ec) {
             Log::Log("ERROR: Failed to parse res JSON from response in ws_window->dispatch\n");
             return;
         }

--- a/GWToolboxdll/Windows/PartySearchWindow.h
+++ b/GWToolboxdll/Windows/PartySearchWindow.h
@@ -117,7 +117,7 @@ private:
     void DrawAlertsWindowContent(bool ownwindow);
     void AsyncWindowConnect(bool force = false);
     void fetch();
-    static bool parse_json_message(const nlohmann::json& js, Message* msg);
+    static bool parse_json_message(const glz::json_t& js, Message* msg);
     static void ParseBuffer(const char* text, std::vector<std::string>& words);
     static void DeleteWebSocket(easywsclient::WebSocket* ws);
     bool IsLfpAlert(std::string& message) const;

--- a/GWToolboxdll/Windows/Pathfinding/PathfindingWindow.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/PathfindingWindow.cpp
@@ -134,13 +134,13 @@ namespace {
                     }
                     Resources::EnqueueWorkerTask([from_dat, from_context]() {
                         auto write_to = std::format(L"pathing_map_data_from_file_{:#}.json", from_dat->map_file_id);
-                        nlohmann::json json = *from_dat;
-                        auto str = json.dump(2);
+                        glz::json_t json = Pathing::ToJson(*from_dat);
+                        auto str = glz::write<glz::opts{.prettify = true}>(json).value_or(std::string{});
                         Resources::WriteFile(Resources::GetPath(write_to), str);
 
                         write_to = std::format(L"pathing_map_data_from_context_{:#}.json", from_context->map_file_id);
-                        json = *from_dat;
-                        str = json.dump(2);
+                        json = Pathing::ToJson(*from_dat);
+                        str = glz::write<glz::opts{.prettify = true}>(json).value_or(std::string{});
                         Resources::WriteFile(Resources::GetPath(write_to), str);
                         delete from_dat;
                         delete from_context;

--- a/GWToolboxdll/Windows/Pathfinding/PathingMapData.h
+++ b/GWToolboxdll/Windows/Pathfinding/PathingMapData.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <vector>
-#include <nlohmann/json.hpp>
+#include <glaze/glaze.hpp>
 
 // =============================================================================
 // PathingMapData
@@ -101,63 +101,113 @@ namespace Pathing {
     //   - Web-based map viewers
     // =========================================================================
 
-    inline void to_json(nlohmann::json& j, const Vec2f& v)
+    inline glz::json_t ToJson(const Vec2f& v)
     {
-        j = nlohmann::json::array({v.x, v.y});
+        glz::json_t::array_t arr;
+        arr.emplace_back(v.x);
+        arr.emplace_back(v.y);
+        return arr;
     }
 
-    inline void to_json(nlohmann::json& j, const Trapezoid& t)
+    inline glz::json_t IndexOrNull(uint32_t idx)
     {
-        j = nlohmann::json{
-            {"geometry", nlohmann::json::array({
-                             t.XTL, // Top left
-                             t.XTR, // Top right
-                             t.YT,  // Top Y
-                             t.XBL, // Bottom left
-                             t.XBR, // Bottom right,
-                             t.YB   // Bottom y
-                         })},
-             {"neighbors", nlohmann::json::array({
-                               t.neighbors[0] == INVALID_INDEX ? nullptr : nlohmann::json(t.neighbors[0]), // top left
-                               t.neighbors[1] == INVALID_INDEX ? nullptr : nlohmann::json(t.neighbors[1]), // top right
-                               t.neighbors[2] == INVALID_INDEX ? nullptr : nlohmann::json(t.neighbors[2]), // bottom left
-                               t.neighbors[3] == INVALID_INDEX ? nullptr : nlohmann::json(t.neighbors[3])  // bottom right
-                           })},
-                     {"portals", nlohmann::json::array({t.portal_left == INVALID_INDEX16 ? nullptr : nlohmann::json(t.portal_left), t.portal_right == INVALID_INDEX16 ? nullptr : nlohmann::json(t.portal_right)})}
-        };
+        return idx == INVALID_INDEX ? glz::json_t{nullptr} : glz::json_t{static_cast<double>(idx)};
     }
 
-    inline void to_json(nlohmann::json& j, const Portal& p)
+    inline glz::json_t Index16OrNull(uint16_t idx)
     {
-        j = nlohmann::json{
-            {"trap_index_start", p.trapezoid_index_start},
-            {"trap_count", p.trapezoid_count},
-            {"neighbor_plane", p.neighbor_plane == INVALID_INDEX16 ? nullptr : nlohmann::json(p.neighbor_plane)},
-            {"shared_id", p.shared_id == INVALID_INDEX16 ? nullptr : nlohmann::json(p.shared_id)},
-            {"flags", p.flags},
-            {"blocked", (p.flags & 0x04) != 0}
-        };
+        return idx == INVALID_INDEX16 ? glz::json_t{nullptr} : glz::json_t{static_cast<double>(idx)};
     }
 
-    inline void to_json(nlohmann::json& j, const NavPlane& plane)
+    inline glz::json_t ToJson(const Trapezoid& t)
     {
+        glz::json_t::array_t geometry;
+        geometry.emplace_back(t.XTL);
+        geometry.emplace_back(t.XTR);
+        geometry.emplace_back(t.YT);
+        geometry.emplace_back(t.XBL);
+        geometry.emplace_back(t.XBR);
+        geometry.emplace_back(t.YB);
 
-        j = nlohmann::json{
-            {"zplane", plane.zplane == UINT32_MAX ? "ground" : nlohmann::json(plane.zplane)},
-            {"trapezoids", plane.trapezoids},
-            {"portals", plane.portals},
-            {"portal_trapezoid_indices", plane.portal_trapezoid_indices},
-            {"stats", {{"trapezoid_count", plane.trapezoids.size()}, {"portal_count", plane.portals.size()}}}
-        };
+        glz::json_t::array_t neighbors;
+        neighbors.emplace_back(IndexOrNull(t.neighbors[0]));
+        neighbors.emplace_back(IndexOrNull(t.neighbors[1]));
+        neighbors.emplace_back(IndexOrNull(t.neighbors[2]));
+        neighbors.emplace_back(IndexOrNull(t.neighbors[3]));
+
+        glz::json_t::array_t portals;
+        portals.emplace_back(Index16OrNull(t.portal_left));
+        portals.emplace_back(Index16OrNull(t.portal_right));
+
+        glz::json_t j;
+        j["geometry"] = std::move(geometry);
+        j["neighbors"] = std::move(neighbors);
+        j["portals"] = std::move(portals);
+        return j;
     }
 
-    inline void to_json(nlohmann::json& j, const PathingMapData& data)
+    inline glz::json_t ToJson(const Portal& p)
     {
-        j = nlohmann::json{
-            {"map_file_id", data.map_file_id},
-            {"bounds", {{"min", data.bounds_min}, {"max", data.bounds_max}}},
-            {"planes", data.planes},
-            {"stats", {{"plane_count", data.planes.size()}, {"total_trapezoids", data.GetTotalTrapezoidCount()}, {"is_valid", data.IsValid()}}}
-        };
+        glz::json_t j;
+        j["trap_index_start"] = static_cast<double>(p.trapezoid_index_start);
+        j["trap_count"] = static_cast<double>(p.trapezoid_count);
+        j["neighbor_plane"] = Index16OrNull(p.neighbor_plane);
+        j["shared_id"] = Index16OrNull(p.shared_id);
+        j["flags"] = static_cast<double>(p.flags);
+        j["blocked"] = (p.flags & 0x04) != 0;
+        return j;
+    }
+
+    inline glz::json_t ToJson(const NavPlane& plane)
+    {
+        glz::json_t::array_t trapezoids;
+        trapezoids.reserve(plane.trapezoids.size());
+        for (const auto& t : plane.trapezoids) trapezoids.emplace_back(ToJson(t));
+
+        glz::json_t::array_t portals;
+        portals.reserve(plane.portals.size());
+        for (const auto& p : plane.portals) portals.emplace_back(ToJson(p));
+
+        glz::json_t::array_t portal_trapezoid_indices;
+        portal_trapezoid_indices.reserve(plane.portal_trapezoid_indices.size());
+        for (auto idx : plane.portal_trapezoid_indices)
+            portal_trapezoid_indices.emplace_back(static_cast<double>(idx));
+
+        glz::json_t stats;
+        stats["trapezoid_count"] = static_cast<double>(plane.trapezoids.size());
+        stats["portal_count"] = static_cast<double>(plane.portals.size());
+
+        glz::json_t j;
+        j["zplane"] = plane.zplane == UINT32_MAX
+            ? glz::json_t{std::string{"ground"}}
+            : glz::json_t{static_cast<double>(plane.zplane)};
+        j["trapezoids"] = std::move(trapezoids);
+        j["portals"] = std::move(portals);
+        j["portal_trapezoid_indices"] = std::move(portal_trapezoid_indices);
+        j["stats"] = std::move(stats);
+        return j;
+    }
+
+    inline glz::json_t ToJson(const PathingMapData& data)
+    {
+        glz::json_t::array_t planes;
+        planes.reserve(data.planes.size());
+        for (const auto& p : data.planes) planes.emplace_back(ToJson(p));
+
+        glz::json_t bounds;
+        bounds["min"] = ToJson(data.bounds_min);
+        bounds["max"] = ToJson(data.bounds_max);
+
+        glz::json_t stats;
+        stats["plane_count"] = static_cast<double>(data.planes.size());
+        stats["total_trapezoids"] = static_cast<double>(data.GetTotalTrapezoidCount());
+        stats["is_valid"] = data.IsValid();
+
+        glz::json_t j;
+        j["map_file_id"] = static_cast<double>(data.map_file_id);
+        j["bounds"] = std::move(bounds);
+        j["planes"] = std::move(planes);
+        j["stats"] = std::move(stats);
+        return j;
     }
 } // namespace Pathing

--- a/GWToolboxdll/Windows/SkillListingWindow.cpp
+++ b/GWToolboxdll/Windows/SkillListingWindow.cpp
@@ -88,12 +88,12 @@ const wchar_t* SkillListingWindow::Skill::GWWConcise()
 
 void SkillListingWindow::ExportToJSON() const
 {
-    nlohmann::json json;
+    glz::json_t json;
     for (size_t i = 0; i < skills.size(); i++) {
         if (!skills[i]) {
             continue;
         }
-        json[std::to_underlying(skills[i]->skill->skill_id)] = skills[i]->ToJson();
+        json[std::to_string(std::to_underlying(skills[i]->skill->skill_id))] = skills[i]->ToJson();
     }
     const auto file_location = Resources::GetPath(L"skills.json");
     if (exists(file_location)) {
@@ -101,7 +101,7 @@ void SkillListingWindow::ExportToJSON() const
     }
 
     std::ofstream out(file_location);
-    out << json.dump();
+    out << glz::write_json(json).value_or(std::string{});
     out.close();
     wchar_t file_location_wc[512];
     size_t msg_len = 0;
@@ -248,45 +248,45 @@ void SkillListingWindow::Draw(IDirect3DDevice9*)
     ImGui::End();
 }
 
-nlohmann::json SkillListingWindow::Skill::ToJson()
+glz::json_t SkillListingWindow::Skill::ToJson()
 {
-    nlohmann::json json;
+    glz::json_t json;
     json["n"] = TextUtils::WStringToString(Name());
     json["d"] = TextUtils::WStringToString(GWWDescription());
     json["cd"] = TextUtils::WStringToString(GWWConcise());
-    json["t"] = skill->type;
-    json["p"] = skill->profession;
-    json["a"] = IsPvE() ? 255 - skill->title : (int)skill->attribute;
+    json["t"] = static_cast<double>(skill->type);
+    json["p"] = static_cast<double>(skill->profession);
+    json["a"] = static_cast<double>(IsPvE() ? 255 - skill->title : (int)skill->attribute);
     if (IsElite()) {
-        json["e"] = 1;
+        json["e"] = 1.0;
     }
-    json["c"] = skill->campaign;
-    nlohmann::json z_json;
+    json["c"] = static_cast<double>(skill->campaign);
+    glz::json_t z_json;
     if (HasExhaustion()) {
-        z_json["x"] = skill->overcast;
+        z_json["x"] = static_cast<double>(skill->overcast);
     }
     if (skill->recharge) {
-        z_json["r"] = skill->recharge;
+        z_json["r"] = static_cast<double>(skill->recharge);
     }
     if (skill->activation) {
-        z_json["c"] = skill->activation;
+        z_json["c"] = static_cast<double>(skill->activation);
     }
     if (IsMaintained()) {
-        z_json["d"] = 1;
+        z_json["d"] = 1.0;
     }
     if (skill->adrenaline) {
-        z_json["a"] = skill->adrenaline;
+        z_json["a"] = static_cast<double>(skill->adrenaline);
     }
     if (skill->energy_cost) {
-        z_json["e"] = skill->GetEnergyCost();
+        z_json["e"] = static_cast<double>(skill->GetEnergyCost());
     }
     if (skill->health_cost) {
-        z_json["s"] = skill->health_cost;
+        z_json["s"] = static_cast<double>(skill->health_cost);
     }
-    z_json["sp"] = skill->special;
-    z_json["co"] = skill->combo;
-    z_json["q"] = skill->weapon_req;
-    if (z_json.size()) {
+    z_json["sp"] = static_cast<double>(skill->special);
+    z_json["co"] = static_cast<double>(skill->combo);
+    z_json["q"] = static_cast<double>(skill->weapon_req);
+    if (z_json.is_object() && !z_json.get_object().empty()) {
         json["z"] = z_json;
     }
     return json;

--- a/GWToolboxdll/Windows/SkillListingWindow.h
+++ b/GWToolboxdll/Windows/SkillListingWindow.h
@@ -34,7 +34,7 @@ public:
         Skill(GW::Skill* _gw_skill)
             : skill(_gw_skill) { }
 
-        nlohmann::json ToJson();
+        glz::json_t ToJson();
         const wchar_t* Name();
         const wchar_t* GWWDescription();
         const wchar_t* GWWConcise();

--- a/GWToolboxdll/Windows/TradeWindow.cpp
+++ b/GWToolboxdll/Windows/TradeWindow.cpp
@@ -34,7 +34,7 @@ namespace {
     constexpr uint32_t COST_PER_CONNECTION_MAX_MS = 60 * 1000;
     static const char* months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
     using easywsclient::WebSocket;
-    using nlohmann::json;
+    using json = glz::json_t;
     using json_vec = std::vector<json>;
 
     constexpr char ws_host_kmd[] = "wss://kamadan.gwtoolbox.com";
@@ -111,27 +111,27 @@ namespace {
 
     bool parse_json_message(const json& js, Message* msg)
     {
-        if (js == json::value_t::discarded) {
+        if (!js.is_object()) {
             return false;
         }
-        if (!(js.contains("s") && js["s"].is_string())) {
+        if (!(js.contains("s") && js.at("s").is_string())) {
             return false;
         }
-        msg->name = js["s"].get<std::string>();
-        if (!(js.contains("m") && js["m"].is_string())) {
+        msg->name = js.at("s").get<std::string>();
+        if (!(js.contains("m") && js.at("m").is_string())) {
             return false;
         }
-        msg->message = js["m"].get<std::string>();
+        msg->message = js.at("m").get<std::string>();
         if (!js.contains("t")) {
             return false;
         }
         unsigned long long timestamp_ull = 0ull;
-        if (js["t"].is_string()) {
-            const auto str = js["t"].get<std::string>();
+        if (js.at("t").is_string()) {
+            const auto str = js.at("t").get<std::string>();
             timestamp_ull = strtoull(str.c_str(), nullptr, 10);
         }
-        else if (js["t"].is_number_unsigned()) {
-            timestamp_ull = js["t"].get<uint64_t>();
+        else if (js.at("t").is_number()) {
+            timestamp_ull = static_cast<uint64_t>(js.at("t").get<double>());
         }
         if (timestamp_ull == 0ull) {
             return false;
@@ -353,38 +353,38 @@ void TradeWindow::fetch()
         json request;
         request["query"] = pending_query_string;
         pending_query_sent = clock();
-        ws_window->send(request.dump());
+        ws_window->send(glz::write_json(request).value_or(std::string{}));
     }
 
     ws_window->dispatch([this](const std::string& data) {
-        const json& res = json::parse(data.c_str(), nullptr, false);
-        if (res == json::value_t::discarded) {
+        json res;
+        if (auto ec = glz::read_json(res, data); ec) {
             Log::Log("ERROR: Failed to parse res JSON from response in ws_window->dispatch\n");
             return;
         }
-        if (res.find("query") != res.end() && res["query"].is_string()) {
-            auto query_string = res["query"].get<std::string>();
+        if (res.contains("query") && res.at("query").is_string()) {
+            auto query_string = res.at("query").get<std::string>();
             if (query_string != pending_query_string) {
                 return; // Different query has been made since this search.
             }
             pending_query_string.clear();
-            if (!(res.contains("num_results") && res["num_results"].is_number_unsigned())) {
+            if (!(res.contains("num_results") && res.at("num_results").is_number())) {
                 Log::Log("ERROR: Failed to parse search results in TradeWindow::fetch\n");
                 print_search_results = false;
                 return;
             }
-            size_t num_results = res["num_results"].get<size_t>();
+            size_t num_results = static_cast<size_t>(res.at("num_results").get<double>());
             if (print_search_results && !num_results) {
                 Log::Warning("No results found for %s", query_string.c_str());
                 print_search_results = false;
                 return;
             }
-            if (!(res.contains("results") && res["results"].is_array())) {
+            if (!(res.contains("results") && res.at("results").is_array())) {
                 Log::Log("ERROR: Failed to parse search results in TradeWindow::fetch\n");
                 print_search_results = false;
                 return;
             }
-            auto results = res["results"].get<json_vec>();
+            auto& results = res.at("results").get_array();
             messages.clear();
             if (print_search_results && !results.size()) {
                 Log::Warning("No results found for %s", query_string.c_str());

--- a/GWToolboxdll/stdafx.h
+++ b/GWToolboxdll/stdafx.h
@@ -71,7 +71,7 @@
 #include <discord-game-sdk/discord_game_sdk.h>
 #include <ToolboxIni.h>
 
-#include <nlohmann/json.hpp>
+#include <glaze/glaze.hpp>
 #include <easywsclient.hpp>
 #include <mp3.h>
 #include <IconsFontAwesome5.h>

--- a/cmake/gwtoolboxdll_plugins.cmake
+++ b/cmake/gwtoolboxdll_plugins.cmake
@@ -15,7 +15,7 @@ target_include_directories(plugin_base INTERFACE
     )
 target_link_libraries(plugin_base INTERFACE
     imgui
-    nlohmann_json::nlohmann_json
+    glaze::glaze
     gwca
     IconFontCppHeaders
     GWToolboxdll # for GetFont

--- a/plugins/Base/PluginUtils.h
+++ b/plugins/Base/PluginUtils.h
@@ -2,7 +2,7 @@
 
 #include <GWCA/Constants/Constants.h>
 #include <ToolboxIni.h>
-#include <nlohmann/json.hpp>
+#include <glaze/glaze.hpp>
 
 namespace PluginUtils {
     template <typename T>
@@ -71,8 +71,7 @@ namespace PluginUtils {
     template <map_type T>
     void MapToIni(ToolboxIni* ini, const char* section, const char* name, const T& map)
     {
-        const auto map_json = nlohmann::json(map);
-        const auto map_str = map_json.dump();
+        const auto map_str = glz::write_json(map).value_or(std::string{});
         ini->SetValue(section, name, map_str.c_str());
     }
 
@@ -80,12 +79,11 @@ namespace PluginUtils {
     T IniToMap(ToolboxIni* ini, const char* section, const char* name)
     {
         std::string map_str = ini->GetValue(section, name, "");
-        try {
-            const auto map_json = nlohmann::json::parse(map_str);
-            return map_json.get<T>();
-        } catch (nlohmann::json::exception e) {
+        T out{};
+        if (glz::read_json(out, map_str)) {
             return {};
         }
+        return out;
     }
 
     template <map_type T>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,8 +10,8 @@
     "directxtex",
     "discord-game-sdk",
     "earcut-hpp",
+    "glaze",
     "minhook",
-    "nlohmann-json",
     "simpleini",
     "uwebsockets",
     "wolfssl"


### PR DESCRIPTION
Swaps nlohmann::json for stephenberry/glaze across the codebase and
moves CMAKE_CXX_STANDARD from 23 to 26 so the project can opt into
Glaze's static-reflection mode when toolchains support it (P2996
support in MSVC is still pending; until then Glaze falls back to its
default aggregate reflection on the v143 toolset).

Highlights:
- Dependency swap: vcpkg.json and all CMake target_link_libraries
  switched from nlohmann_json::nlohmann_json to glaze::glaze.
- Dynamic JSON: all nlohmann::json types replaced with glz::json_t.
  json::value_t::null becomes nullptr, json::array() becomes
  glz::json_t::array_t{}, .dump() becomes glz::write_json(j).value_or().
- Parsing: json::parse(..., nullptr, false) replaced with
  glz::read_json(j, s) returning an error code (idiomatic glaze).
- Number-type predicates: is_number_unsigned/integer/float collapsed
  to is_number()+double cast since glz::json_t's default storage is
  variant<null,bool,double,string,array,object>.
- Iteration: nlohmann iterator .key()/.value() patterns rewritten to
  structured bindings over .get_object()/.get_array().
- push_back: where nlohmann auto-promoted null->array, calls now go
  through .get_array().push_back() after explicit array_t init.
- Pathing: the ADL to_json overloads in PathingMapData.h were rewritten
  as free Pathing::ToJson functions that build glz::json_t directly,
  since the custom shape (conditional null sentinels, "ground" string)
  doesn't fit Glaze's reflection-driven serialization.
- Helpers: TextUtils' parseXxxFromJson helpers now take glz::json_t;
  GuiUtils/PluginUtils MapToIni/IniToMap templates use glz::write_json
  and glz::read_json directly instead of the implicit-construct trick.

Known follow-ups (this is an initial conversion; the project was not
compile-tested on MSVC in this environment):
- Some uintN_t->json_t implicit conversions may need explicit
  static_cast<double>(...) on the v143 toolset.
- json_t fields are stored as double by default; ints over 2^53 lose
  precision (no current call sites hit this).
- Output formatting differs from nlohmann; existing INI/JSON config
  files written by older builds may parse but not byte-match.