### PR TITLE
fix: collapsed window height reset when resizing width

### DIFF
--- a/GWToolboxdll/ToolboxUIElement.cpp
+++ b/GWToolboxdll/ToolboxUIElement.cpp
@@ -182,7 +182,7 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
     const auto window = ImGui::FindWindowByName(Name());
     if (window) {
         pos = window->Pos;
-        size = window->Size;
+        size = window->SizeFull;
     }
     if (is_movable || is_resizable) {
         char buf[128];


### PR DESCRIPTION
When a window is collapsed and the user changes its width via the Size drag control in settings, the expanded height was silently overwritten with the collapsed (title-bar) height.

The root cause was reading `window->Size` (which equals the collapsed height when the window is collapsed) instead of `window->SizeFull` (the full expanded dimensions) in `DrawSizeAndPositionSettings()`.

Fixes #2028

Generated with [Claude Code](https://claude.ai/code)