### PR TITLE
docs: document both encoded string types in TeamBuildEncoder.h

### DIFF
--- a/GWToolboxdll/Utils/TeamBuildEncoder.h
+++ b/GWToolboxdll/Utils/TeamBuildEncoder.h
@@ -40,11 +40,27 @@ struct TeamHeroBuild {
 namespace TeamBuildEncoder {
 
     // ---------------------------------------------------------------------------
-    // Types
+    // Overview
     //
-    // TeamHeroBuild      - decoded in-memory representation (HeroBuildsWindow structs)
-    // DaybreakTeamBuild  - GW's native base64 party loadout string e.g. "OwFj0..."
-    // EncodedTeamBuild   - our compressed wstring, safe for GW whisper transport
+    // This namespace handles two distinct encoded representations of a hero team
+    // build, plus the in-memory struct that both convert to/from:
+    //
+    //   TeamHeroBuild      Decoded in-memory representation (HeroBuildsWindow structs).
+    //                      Holds up to 8 HeroBuild entries, each containing a
+    //                      skill-template code string ("OwFj0..."), a HeroID, and
+    //                      behaviour/panel settings.
+    //
+    //   DaybreakTeamBuild  GW's own party-loadout format: a narrow (char) string
+    //                      using GW's base64 alphabet.  The game itself produces and
+    //                      consumes these; the first character always encodes magic
+    //                      byte 0x1F (header=15, type=1 packed LSB-first).
+    //                      Example: "OwFj0dKEAAAAAAAA..."
+    //
+    //   EncodedTeamBuild   Our own compact wstring format designed to survive GW's
+    //                      in-game chat/whisper transport within the 120-wchar link
+    //                      budget.  Every 9 raw bits map to one wchar chosen from
+    //                      a set of Unicode ranges that GW accepts in chat.
+    //                      An 8-hero build fits in at most ~117 wchars.
     // ---------------------------------------------------------------------------
 
     using TeamHeroBuild     = TeamHeroBuild;
@@ -52,7 +68,44 @@ namespace TeamBuildEncoder {
     using EncodedTeamBuild  = std::wstring;
 
     // ---------------------------------------------------------------------------
-    // EncodedTeamBuild: our compressed format (9 bits/wchar, <122 wchars worst case)
+    // EncodedTeamBuild  –  compact wstring, safe for GW whisper transport
+    // ---------------------------------------------------------------------------
+    //
+    // Bit-stream layout (LSB-first throughout):
+    //
+    //   [ 4 bits ] magic = 0xF   (identifies the format; checked by IsEncodedTeamBuild)
+    //   [ 4 bits ] hero count N  (0–8)
+    //
+    //   For each of the N heroes:
+    //     [ 6 bits ] HeroID
+    //     [ 4 bits ] primary profession   (0–10)
+    //     [ 4 bits ] secondary profession (0–10)
+    //     [ 8 bits ] total attribute points spent (sum of kAttrCost[rank] over all attrs)
+    //
+    //     Attributes – written in the canonical order defined by kProfessionAttributes,
+    //     primary profession first then secondary, stopping early when the remaining
+    //     point budget reaches zero:
+    //       [ BitsForAttrValue(remaining) bits ] rank for each attribute
+    //       (BitsForAttrValue returns 4/3/2/0 bits depending on how many points remain)
+    //
+    //     Skills (8 slots, one per bar position):
+    //       [ 9 bits ] 1-based index into the deterministic accessible-skill list
+    //                  produced by GetAccessibleSkills(primary, secondary); 0 = empty slot.
+    //                  The list is sorted and excludes PvP skills, so the index is
+    //                  stable across clients as long as skill data is identical.
+    //
+    // wchar encoding:
+    //   The raw byte buffer is re-packed 9 bits at a time.  Each 9-bit value (0–511)
+    //   maps to a single wchar_t drawn from six GW-safe Unicode sub-ranges:
+    //     val   0– 26  → U+0020–U+003A  (space … colon)
+    //     val  27– 57  → U+003C–U+005A  (< = > ? @ A–Z)
+    //     val  58– 58  → U+005C         (backslash)
+    //     val  59– 91  → U+005E–U+007E  (^ _ ` a–z { | } ~)
+    //     val  92–314  → U+00A1–U+017F  (Latin-1 Supplement + Latin Extended-A)
+    //     val 315–511  → U+0391–U+0455  (Greek + Cyrillic)
+    //   The characters '[', ']', and ';' are excluded so the string is safe inside
+    //   a [label;encoded] chat link without escaping.
+    //   512 values = exactly 2^9, so every 9-bit group maps cleanly to one wchar.
     // ---------------------------------------------------------------------------
 
     // Encode a TeamHeroBuild into an EncodedTeamBuild for whisper transport.
@@ -69,7 +122,35 @@ namespace TeamBuildEncoder {
     bool IsSkillEquippable(const GW::Constants::SkillID);
 
     // ---------------------------------------------------------------------------
-    // DaybreakTeamBuild: GW's native base64 party loadout format
+    // DaybreakTeamBuild  –  GW's native base64 party-loadout format
+    // ---------------------------------------------------------------------------
+    //
+    // Bit-stream layout (LSB-first throughout):
+    //
+    //   [ 4 bits ] header = 15
+    //   [ 4 bits ] type   =  1  (party loadout; first byte is therefore 0x1F)
+    //   [ 4 bits ] hero count N (0–8)
+    //
+    //   For each of the N heroes:
+    //     [  8 bits ] HeroID
+    //     [  2 bits ] prof_code  (0 if both professions fit in 4 bits, 1 if 6 bits needed)
+    //       [ p bits ] primary profession    where p = prof_code*2 + 4  (4 or 6 bits)
+    //       [ p bits ] secondary profession
+    //     [  4 bits ] attribute count A  (0–12)
+    //     [  4 bits ] attr_code  (0 if all attribute IDs fit in 4 bits, 2 if 6 bits needed)
+    //       For each of the A attributes:
+    //         [ a bits ] attribute ID     where a = attr_code + 4  (4 or 6 bits)
+    //         [ 4 bits ] attribute rank   (0–12)
+    //     [  4 bits ] skill_code  (0 if all skill IDs fit in 8 bits, 1 if 9 bits needed)
+    //       For each of 8 skill slots:
+    //         [ s bits ] SkillID           where s = skill_code + 8  (8 or 9 bits)
+    //
+    // Character encoding:
+    //   The raw byte buffer is packed 6 bits at a time, LSB-first.  Each 6-bit value
+    //   (0–63) is mapped to GW's own base64 alphabet:
+    //     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    //   This is identical to standard RFC 4648 base64 and is the format the game
+    //   uses natively for its in-game skill/build template codes.
     // ---------------------------------------------------------------------------
 
     // Encode a TeamHeroBuild into a DaybreakTeamBuild (GW base64 party loadout string).


### PR DESCRIPTION
Add detailed comment blocks to TeamBuildEncoder.h describing the full bit-stream layout and character-encoding scheme for both EncodedTeamBuild (wstring) and DaybreakTeamBuild (GW native base64).

Closes #2039

Generated with [Claude Code](https://claude.ai/code)