### PR TITLE
Add unified Build and TeamBuild structs (Utils/TeamBuild.h/cpp)

### DIFF
--- a/GWToolboxdll/Utils/TeamBuild.cpp
+++ b/GWToolboxdll/Utils/TeamBuild.cpp
@@ -1,0 +1,645 @@
+#include "stdafx.h"
+
+#include <Utils/TeamBuild.h>
+
+#include <GWCA/Constants/Skills.h>
+#include <GWCA/GameEntities/Skill.h>
+#include <GWCA/Managers/GameThreadMgr.h>
+#include <GWCA/Managers/SkillbarMgr.h>
+#include <GWCA/Managers/UIMgr.h>
+
+#include <Color.h>
+#include <Modules/Resources.h>
+#include <Utils/GuiUtils.h>
+#include <Utils/TextUtils.h>
+#include <Windows/PconsWindow.h>
+
+namespace {
+
+    IDirect3DTexture9** skill_toggle_sprite = nullptr;
+
+    const Color build_edit_pcon_enabled_color = Colors::ARGB(102, 0, 255, 0);
+
+    using GW::Constants::HeroID;
+
+    // Hero IDs in the same order as the GW client hero panel.
+    // Razah appears after mesmers because most players without mercenaries have it set as mesmer.
+    constexpr std::array HeroIndexToID = {
+        HeroID::NoHero,
+        HeroID::Goren,
+        HeroID::Koss,
+        HeroID::Jora,
+        HeroID::AcolyteJin,
+        HeroID::MargridTheSly,
+        HeroID::PyreFierceshot,
+        HeroID::Tahlkora,
+        HeroID::Dunkoro,
+        HeroID::Ogden,
+        HeroID::MasterOfWhispers,
+        HeroID::Olias,
+        HeroID::Livia,
+        HeroID::Norgu,
+        HeroID::Razah,
+        HeroID::Gwen,
+        HeroID::AcolyteSousuke,
+        HeroID::ZhedShadowhoof,
+        HeroID::Vekk,
+        HeroID::Zenmai,
+        HeroID::Anton,
+        HeroID::Miku,
+        HeroID::Xandra,
+        HeroID::ZeiRi,
+        HeroID::GeneralMorgahn,
+        HeroID::KeiranThackeray,
+        HeroID::Hayda,
+        HeroID::Melonni,
+        HeroID::MOX,
+        HeroID::Kahmu,
+        HeroID::Merc1,
+        HeroID::Merc2,
+        HeroID::Merc3,
+        HeroID::Merc4,
+        HeroID::Merc5,
+        HeroID::Merc6,
+        HeroID::Merc7,
+        HeroID::Merc8,
+        HeroID::Devona,
+        HeroID::GhostOfAlthea
+    };
+
+    // Returns hero IDs sorted by name; re-sorts each frame until all names are decoded.
+    const std::vector<HeroID>& SortedHeroIDs()
+    {
+        static std::vector<HeroID> sorted;
+        static bool is_sorted = false;
+        if (!is_sorted) {
+            sorted.clear();
+            for (const auto id : HeroIndexToID) {
+                if (id != HeroID::NoHero) sorted.push_back(id);
+            }
+            bool all_decoded = true;
+            for (const auto id : sorted) {
+                if (Resources::GetHeroName(id)->string().empty()) {
+                    all_decoded = false;
+                    break;
+                }
+            }
+            std::ranges::sort(sorted, [](const HeroID a, const HeroID b) {
+                return _stricmp(Resources::GetHeroName(a)->string().c_str(),
+                                Resources::GetHeroName(b)->string().c_str()) < 0;
+            });
+            is_sorted = all_decoded;
+        }
+        return sorted;
+    }
+
+    void DefaultView(const Build& build)
+    {
+        GW::GameThread::Enqueue([code = build.code, name = build.name] {
+            GW::UI::ChatTemplate t{};
+            auto code_ws = TextUtils::StringToWString(code);
+            t.code.m_buffer = code_ws.data();
+            t.code.m_size = t.code.m_capacity = code_ws.size() + 1;
+            auto name_ws = TextUtils::StringToWString(name);
+            t.name = name_ws.data();
+            GW::UI::SendUIMessage(GW::UI::UIMessage::kOpenTemplate, &t);
+        });
+    }
+
+} // namespace
+
+// ============================================================
+// Build
+// ============================================================
+
+Build::Build(std::string_view n, std::string_view c,
+             GW::Constants::HeroID hero_id_, int show_panel_,
+             uint32_t behavior_, uint8_t disabled_skills_)
+    : name(n)
+    , code(c)
+    , hero_id(hero_id_)
+    , behavior(behavior_)
+    , show_panel(show_panel_ != 0)
+    , disabled_skills(disabled_skills_)
+{
+}
+
+std::string Build::GetFallbackBuildName() const
+{
+    if (code.empty()) return {};
+    GW::SkillbarMgr::SkillTemplate st{};
+    if (!GW::SkillbarMgr::DecodeSkillTemplate(st, code.c_str())) return {};
+    for (const auto skill_id : st.skills) {
+        if (skill_id == GW::Constants::SkillID::No_Skill) continue;
+        const auto* skill = GW::SkillbarMgr::GetSkillConstantData(skill_id);
+        if (!skill || !skill->IsElite()) continue;
+        return Resources::GetSkillName(skill_id)->string();
+    }
+    return {};
+}
+
+const GW::SkillbarMgr::SkillTemplate* Build::Decode()
+{
+    if (!IsDecoded() && !GW::SkillbarMgr::DecodeSkillTemplate(skill_template_, code.c_str())) {
+        skill_template_.primary = skill_template_.secondary = GW::Constants::Profession::None;
+    }
+    return IsDecoded() ? &skill_template_ : nullptr;
+}
+
+bool Build::IsDecoded() const
+{
+    return !(skill_template_.primary == GW::Constants::Profession::None &&
+             skill_template_.secondary == GW::Constants::Profession::None);
+}
+
+const GW::Constants::SkillID* Build::Skills()
+{
+    return Decode() ? skill_template_.skills : nullptr;
+}
+
+void Build::ResetDecodeCache()
+{
+    skill_template_.primary = skill_template_.secondary = GW::Constants::Profession::None;
+}
+
+// ============================================================
+// TeamBuild
+// ============================================================
+
+uint32_t TeamBuild::s_cur_ui_id = 0;
+
+TeamBuild::TeamBuild(std::string_view n, std::string_view id)
+    : name(n)
+    , ui_id(id.empty() ? std::to_string(++s_cur_ui_id) : std::string(id))
+{
+}
+
+void TeamBuild::SetSkillToggleSprite(IDirect3DTexture9** sprite)
+{
+    skill_toggle_sprite = sprite;
+}
+
+// ------------------------------------------------------------
+// Player-builds layout (BuildsWindow style)
+// ------------------------------------------------------------
+
+void TeamBuild::DrawPlayerBuildsContent(
+    bool& builds_changed,
+    const BuildAction& on_load,
+    const BuildAction& on_send,
+    const BuildAction& on_view)
+{
+    const float font_scale = ImGui::FontScale();
+    const float btn_width  = 50.0f * font_scale;
+    const float del_width  = 24.0f * font_scale;
+    const float spacing    = ImGui::GetStyle().ItemSpacing.y;
+
+    bool tmp = builds_changed;
+    builds_changed = false;
+
+    for (size_t j = 0; j < builds.size(); j++) {
+        Build& build = builds[j];
+        ImGui::PushID(static_cast<int>(j));
+
+        const bool editing   = editing_build_idx_ == static_cast<int>(j);
+        const float btn_offset = ImGui::GetContentRegionAvail().x - del_width - btn_width * 3 - spacing * 3;
+
+        ImGui::Text("#%zu", j + 1);
+        ImGui::PushItemWidth(btn_offset - btn_width - spacing * 2);
+        ImGui::SameLine(btn_width, 0);
+        if (ImGui::InputText("###name", build.name)) {
+            builds_changed = true;
+        }
+        if (ImGui::IsItemHovered() && !build.name.empty()) {
+            ImGui::SetTooltip([&build]() {
+                ImGui::TextUnformatted(build.name.c_str());
+                GuiUtils::DrawSkillbar(build.code.c_str());
+            });
+        }
+        ImGui::PopItemWidth();
+
+        ImGui::SameLine(btn_offset);
+        if (ImGui::Button(ImGui::GetIO().KeyCtrl ? "Send" : "View", ImVec2(btn_width, 0))) {
+            if (ImGui::GetIO().KeyCtrl) {
+                if (on_send) on_send(*this, j);
+            }
+            else {
+                if (on_view) on_view(*this, j);
+                else         DefaultView(build);
+            }
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip(ImGui::GetIO().KeyCtrl
+                ? "Click to send to team chat"
+                : "Click to view build. Ctrl + Click to send to chat.");
+        }
+
+        ImGui::SameLine(0, spacing);
+        if (ImGui::Button("Load", ImVec2(btn_width, 0))) {
+            if (on_load) on_load(*this, j);
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip(!build.pcons.empty()
+                ? "Click to load build template and pcons"
+                : "Click to load build template");
+        }
+
+        ImGui::SameLine(0, spacing);
+        if (editing) {
+            ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyleColorVec4(ImGuiCol_ButtonHovered));
+        }
+        if (ImGui::Button("Edit", ImVec2(btn_width, 0))) {
+            editing_build_idx_ = editing ? -1 : static_cast<int>(j);
+        }
+        if (editing) {
+            ImGui::PopStyleColor();
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Click to edit this build");
+        }
+
+        ImGui::SameLine(0, spacing);
+        bool delete_confirmed = false;
+        if (ImGui::ConfirmButton(ICON_FA_TRASH, &delete_confirmed,
+                "Delete Build\n\nAre you sure you want to delete this build?\nThis operation cannot be undone.")) {
+            if (editing_build_idx_ == static_cast<int>(j))       editing_build_idx_ = -1;
+            else if (editing_build_idx_ > static_cast<int>(j))   editing_build_idx_--;
+            builds.erase(builds.begin() + static_cast<ptrdiff_t>(j));
+            builds_changed = true;
+            ImGui::PopID();
+            break;
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Delete build");
+        }
+
+        if (editing) {
+            const float indent = btn_width;
+            ImGui::Indent(indent);
+
+            ImGui::TextUnformatted("Build Code:");
+            ImGui::SameLine();
+            if (ImGui::InputText("###code", build.code)) {
+                build.ResetDecodeCache();
+                builds_changed = true;
+            }
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip([&build]() {
+                    GuiUtils::DrawSkillbar(build.code.c_str());
+                });
+            }
+
+            // Pcons (player builds only)
+            ImGui::TextUnformatted("Pcons:");
+            ImGui::ShowHelp("Enable or disable pcons activated in the Pcons window when this build is loaded");
+            const auto& pcons = PconsWindow::Instance().pcons;
+            const float skill_h = ImGui::CalcTextSize(" ").y * 2.f;
+            ImGui::StartSpacedElements(skill_h + ImGui::GetStyle().ItemSpacing.x);
+            for (const auto pcon : pcons) {
+                ImGui::PushID(pcon);
+                const bool active = build.pcons.contains(pcon->ini);
+                ImGui::NextSpacedElement();
+                if (active) ImGui::PushStyleColor(ImGuiCol_Button, build_edit_pcon_enabled_color);
+                if (ImGui::IconButton("", *pcon->GetTexture(), {skill_h, skill_h})) {
+                    if (!active) build.pcons.emplace(pcon->ini);
+                    else         build.pcons.erase(pcon->ini);
+                    builds_changed = true;
+                }
+                if (active) ImGui::PopStyleColor();
+                if (ImGui::IsItemHovered()) ImGui::SetTooltip(pcon->chat.c_str());
+                ImGui::PopID();
+            }
+
+            ImGui::Unindent(indent);
+        }
+
+        ImGui::PopID();
+        if (builds_changed) break;
+    }
+
+    builds_changed |= tmp;
+
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    if (ImGui::Checkbox("Show numbers", &show_numbers)) {
+        builds_changed = true;
+    }
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Prefix build names with their index when sending to chat");
+    }
+
+    ImGui::SameLine();
+    const float add_btn_width = 140.f;
+    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x - add_btn_width);
+    if (ImGui::Button("Add Build", ImVec2(add_btn_width, 0))) {
+        builds.emplace_back("", "");
+        editing_build_idx_ = static_cast<int>(builds.size()) - 1;
+        builds_changed = true;
+    }
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Add another build row");
+    }
+}
+
+// ------------------------------------------------------------
+// Hero-builds layout (HeroBuildsWindow style)
+// ------------------------------------------------------------
+
+void TeamBuild::DrawHeroBuildsContent(
+    bool& builds_changed,
+    const BuildAction& on_load,
+    const BuildAction& on_send,
+    const BuildAction& on_view)
+{
+    const float btn_width      = 50.0f * ImGui::FontScale();
+    const float icon_btn_width = btn_width / 1.75f;
+    const float panel_width    = btn_width + 12.0f;
+    const float item_spacing   = ImGui::GetStyle().ItemInnerSpacing.x;
+    const float text_item_width =
+        (ImGui::GetContentRegionAvail().x - btn_width - btn_width - btn_width
+         - panel_width - icon_btn_width - item_spacing * 4) / 3.f;
+
+    float offset = btn_width;
+    ImGui::SetCursorPosX(offset);
+    ImGui::Text("Name");
+    ImGui::SameLine(offset += text_item_width + item_spacing);
+    ImGui::Text("Template");
+
+    for (size_t j = 0; j < builds.size(); ++j) {
+        offset = btn_width;
+        Build& build = builds[j];
+        ImGui::PushID(static_cast<int>(j));
+
+        if (j == 0) ImGui::Text("P");
+        else        ImGui::Text("H#%zu", j);
+
+        ImGui::SameLine(offset);
+        ImGui::PushItemWidth(text_item_width);
+        if (ImGui::InputText("###name", build.name)) {
+            builds_changed = true;
+        }
+        if (ImGui::IsItemHovered() && !build.name.empty()) {
+            ImGui::SetTooltip("%s", build.name.c_str());
+        }
+
+        ImGui::SameLine(offset += text_item_width + item_spacing);
+        if (ImGui::InputText("###code", build.code)) {
+            build.ResetDecodeCache();
+            builds_changed = true;
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip([&build]() {
+                GuiUtils::DrawSkillbar(build.code.c_str());
+            });
+        }
+
+        ImGui::SameLine(offset += text_item_width + item_spacing);
+
+        if (j == 0) {
+            // Player slot: no hero controls, no pcons in this layout
+            ImGui::TextDisabled("Player");
+            ImGui::SameLine(offset += text_item_width + item_spacing + btn_width + 10.0f + icon_btn_width + item_spacing * 2);
+            ImGui::PopItemWidth();
+        }
+        else {
+            // Hero slot: hero selector, show_panel, behavior, disabled_skills
+            {
+                const auto& sorted_heroes = SortedHeroIDs();
+                const auto hero_it = std::ranges::find(sorted_heroes, build.hero_id);
+                int combo_idx = hero_it != sorted_heroes.end()
+                    ? static_cast<int>(std::distance(sorted_heroes.begin(), hero_it)) : -1;
+                if (ImGui::MyCombo(
+                        "###heroid", "Choose Hero", &combo_idx,
+                        [](void*, const int idx, const char** out_text) -> bool {
+                            const auto& heroes = SortedHeroIDs();
+                            if (idx < 0 || idx >= static_cast<int>(heroes.size())) return false;
+                            *out_text = Resources::GetHeroName(heroes[idx])->string().c_str();
+                            return true;
+                        },
+                        nullptr, static_cast<int>(sorted_heroes.size()))) {
+                    build.hero_id = (combo_idx >= 0 && combo_idx < static_cast<int>(sorted_heroes.size()))
+                        ? sorted_heroes[combo_idx] : HeroID::NoHero;
+                    builds_changed = true;
+                }
+            }
+
+            ImGui::PopItemWidth();
+            ImGui::SameLine(offset += text_item_width + item_spacing);
+
+            // Show-panel toggle
+            const auto* panel_icon = reinterpret_cast<const char*>(build.show_panel ? ICON_FA_EYE : ICON_FA_EYE_SLASH);
+            if (ImGui::Button(panel_icon, ImVec2(icon_btn_width, 0))) {
+                build.show_panel = !build.show_panel;
+                builds_changed = true;
+            }
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip(build.show_panel ? "Hero panel: Show" : "Hero panel: Hide");
+            }
+
+            ImGui::SameLine(offset += icon_btn_width + item_spacing);
+
+            // Behavior cycle
+            const char* behavior_icon    = reinterpret_cast<const char*>(ICON_FA_SHIELD_ALT);
+            const char* behavior_tooltip = "Hero behaviour: Guard";
+            switch (build.behavior) {
+                case 2:
+                    behavior_icon    = reinterpret_cast<const char*>(ICON_FA_DOVE);
+                    behavior_tooltip = "Hero behaviour: Avoid Combat";
+                    break;
+                case 0:
+                    behavior_icon    = reinterpret_cast<const char*>(ICON_FA_FIST_RAISED);
+                    behavior_tooltip = "Hero behaviour: Fight";
+                    break;
+            }
+            if (ImGui::Button(behavior_icon, ImVec2(icon_btn_width, 0))) {
+                if (++build.behavior > 2) build.behavior = 0;
+                builds_changed = true;
+            }
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip(behavior_tooltip);
+            }
+
+            ImGui::SameLine(offset += icon_btn_width + item_spacing);
+
+            // Disabled-skills button + popup
+            int enabled_count = 8;
+            for (int k = 0; k < 8; k++) {
+                if ((build.disabled_skills >> k) & 1) enabled_count--;
+            }
+            char skills_label[8];
+            snprintf(skills_label, sizeof(skills_label), "%d/8", enabled_count);
+            if (ImGui::Button(skills_label, ImVec2(icon_btn_width, 0))) {
+                ImGui::OpenPopup("SkillsPopup");
+            }
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Click to toggle which skills are disabled when loading this build");
+            }
+            if (ImGui::BeginPopup("SkillsPopup")) {
+                GW::SkillbarMgr::SkillTemplate st{};
+                const bool decoded = !build.code.empty() && GW::SkillbarMgr::DecodeSkillTemplate(st, build.code.c_str());
+                constexpr float skill_px = 48.0f;
+                const ImVec2 btn_size(skill_px, skill_px);
+                for (int k = 0; k < 8; k++) {
+                    if (k > 0) ImGui::SameLine(0, 0);
+                    const bool is_disabled = (build.disabled_skills >> k) & 1;
+                    const auto skill_id = decoded ? st.skills[k] : GW::Constants::SkillID::No_Skill;
+                    auto* skill_tex = *Resources::GetSkillImage(skill_id);
+                    ImGui::PushID(k);
+                    const ImVec2 pos = ImGui::GetCursorScreenPos();
+                    if (ImGui::InvisibleButton("##skill_slot", btn_size)) {
+                        if (is_disabled) build.disabled_skills &= static_cast<uint8_t>(~(1u << k));
+                        else             build.disabled_skills |=  static_cast<uint8_t>(1u << k);
+                        builds_changed = true;
+                    }
+                    const bool hovered = ImGui::IsItemHovered();
+                    const ImVec2 p_max(pos.x + skill_px, pos.y + skill_px);
+                    auto* dl = ImGui::GetWindowDrawList();
+                    if (skill_id != GW::Constants::SkillID::No_Skill && skill_tex)
+                        dl->AddImage(reinterpret_cast<ImTextureID>(skill_tex), pos, p_max);
+                    else
+                        dl->AddRectFilled(pos, p_max, IM_COL32(50, 50, 50, 255));
+                    if (is_disabled) {
+                        dl->AddRectFilled(pos, p_max, IM_COL32(0, 0, 0, 140));
+                        if (skill_toggle_sprite && *skill_toggle_sprite) {
+                            dl->AddImage(reinterpret_cast<ImTextureID>(*skill_toggle_sprite),
+                                pos, p_max, ImVec2(0.0f, 0.5f), ImVec2(0.5f, 1.0f));
+                        }
+                    }
+                    if (hovered) dl->AddRect(pos, p_max, IM_COL32(255, 255, 255, 200), 0.f, 0, 2.f);
+                    ImGui::PopID();
+                }
+                ImGui::EndPopup();
+            }
+
+            ImGui::SameLine(offset += icon_btn_width + item_spacing);
+        }
+
+        // View / Load buttons (both player and hero rows)
+        if (ImGui::Button(ImGui::GetIO().KeyCtrl ? "Send" : "View", ImVec2(btn_width, 0))) {
+            if (ImGui::GetIO().KeyCtrl) {
+                if (on_send) on_send(*this, j);
+            }
+            else {
+                if (on_view) on_view(*this, j);
+                else         DefaultView(build);
+            }
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip(ImGui::GetIO().KeyCtrl
+                ? "Click to send to team chat"
+                : "Click to view build. Ctrl + Click to send to chat.");
+        }
+
+        ImGui::SameLine(offset += btn_width + item_spacing);
+        if (ImGui::Button("Load", ImVec2(btn_width, 0))) {
+            if (on_load) on_load(*this, j);
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip(j == 0 ? "Load Build on Player" : "Load Build on Hero");
+        }
+
+        ImGui::PopID();
+    }
+
+    ImGui::Spacing();
+}
+
+// ------------------------------------------------------------
+// DrawEditWindow
+// ------------------------------------------------------------
+
+bool TeamBuild::DrawEditWindow(
+    size_t index,
+    std::vector<TeamBuild>& all_builds,
+    bool& builds_changed,
+    const BuildAction& on_load,
+    const BuildAction& on_send,
+    const BuildAction& on_view)
+{
+    const auto winname = std::format("{}###teambuild_{}", name, ui_id);
+    ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(500, 0), ImGuiCond_FirstUseEver);
+    if (focus_next_frame) {
+        ImGui::SetNextWindowFocus();
+        ImGui::SetNextWindowCollapsed(false);
+        focus_next_frame = false;
+    }
+
+    if (!ImGui::Begin(winname.c_str(), &edit_open)) {
+        ImGui::End();
+        return true;
+    }
+
+    if (has_hero_slots) {
+        builds_changed |= ImGui::InputText("Hero Build Name", name);
+        builds_changed |= ImGui::InputText("Group", group);
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Assign to a group. Builds sharing a group name are shown together under a collapsible header.");
+        }
+        DrawHeroBuildsContent(builds_changed, on_load, on_send, on_view);
+    }
+    else {
+        ImGui::PushItemWidth(-120.f);
+        builds_changed |= ImGui::InputText("Build Name", name);
+        ImGui::PopItemWidth();
+        DrawPlayerBuildsContent(builds_changed, on_load, on_send, on_view);
+    }
+
+    ImGui::Spacing();
+
+    // Teambuild reordering and deletion
+    if (ImGui::Button("Up") && index > 0) {
+        std::swap(all_builds[index - 1], all_builds[index]);
+        builds_changed = true;
+    }
+    if (ImGui::IsItemHovered()) ImGui::SetTooltip("Move the teambuild up in the list");
+
+    ImGui::SameLine();
+    if (ImGui::Button("Down") && index + 1 < all_builds.size()) {
+        std::swap(all_builds[index], all_builds[index + 1]);
+        builds_changed = true;
+    }
+    if (ImGui::IsItemHovered()) ImGui::SetTooltip("Move the teambuild down in the list");
+
+    ImGui::SameLine();
+    bool deleted = false;
+    if (ImGui::ConfirmButton("Delete", &deleted,
+            "Delete Teambuild?\n\nAre you sure?\nThis operation cannot be undone.\n\n")) {
+        all_builds.erase(all_builds.begin() + static_cast<ptrdiff_t>(index));
+        builds_changed = true;
+        ImGui::End();
+        return false;
+    }
+    if (ImGui::IsItemHovered()) ImGui::SetTooltip("Delete the teambuild");
+
+    if (has_hero_slots) {
+        ImGui::SameLine();
+        ImGui::PushItemWidth(110.f);
+        constexpr const char* modes[] = {"Don't change", "Normal Mode", "Hard Mode"};
+        if (ImGui::Combo("Mode", &mode, modes, 3)) {
+            builds_changed = true;
+        }
+        ImGui::PopItemWidth();
+
+        ImGui::SameLine(ImGui::GetContentRegionAvail().x + ImGui::GetCursorPosX() - 40);
+        if (ImGui::Button("Close", ImVec2(ImGui::GetContentRegionAvail().x, 0))) {
+            edit_open = false;
+        }
+        if (ImGui::IsItemHovered()) ImGui::SetTooltip("Close this window");
+
+        // "Send to chat" is a teambuild-level action that requires encoding.
+        // Call on_send with SIZE_MAX as a sentinel to indicate the whole teambuild.
+        if (on_send) {
+            ImGui::Spacing();
+            ImGui::Separator();
+            if (ImGui::Button("Send to chat")) {
+                on_send(*this, SIZE_MAX);
+            }
+        }
+    }
+
+    ImGui::End();
+    return true;
+}

--- a/GWToolboxdll/Utils/TeamBuild.h
+++ b/GWToolboxdll/Utils/TeamBuild.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <functional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <GWCA/Constants/Constants.h>
+#include <GWCA/Managers/SkillbarMgr.h>
+
+struct IDirect3DTexture9;
+
+// Unified build entry used by both BuildsWindow and HeroBuildsWindow.
+//   hero_id == NoHero  →  player build: shows pcons; hides hero controls.
+//   hero_id != NoHero  →  hero build:   shows hero controls; hides pcons.
+struct Build {
+    Build() = default;
+    Build(std::string_view name, std::string_view code,
+          GW::Constants::HeroID hero_id = GW::Constants::HeroID::NoHero,
+          int show_panel = 0, uint32_t behavior = 1, uint8_t disabled_skills = 0);
+
+    std::string name{};
+    std::string code{};
+    GW::Constants::HeroID hero_id = GW::Constants::HeroID::NoHero;
+    uint32_t behavior = 1;
+    bool show_panel = false;
+    uint8_t disabled_skills = 0;
+    std::set<std::string> pcons{};
+
+    bool IsPlayerBuild() const { return hero_id == GW::Constants::HeroID::NoHero; }
+
+    // Returns the elite skill name from the build code as a fallback display name.
+    std::string GetFallbackBuildName() const;
+
+    // Decode skill template from code. Returns nullptr if code is invalid.
+    const GW::SkillbarMgr::SkillTemplate* Decode();
+    bool IsDecoded() const;
+    const GW::Constants::SkillID* Skills();
+
+    // Invalidate the cached decode result (call when code changes).
+    void ResetDecodeCache();
+
+private:
+    GW::SkillbarMgr::SkillTemplate skill_template_{};
+};
+
+// Unified team build used by both BuildsWindow and HeroBuildsWindow.
+//
+//   has_hero_slots == false  →  BuildsWindow layout
+//     · variable number of player builds
+//     · pcons per build, show_numbers flag
+//
+//   has_hero_slots == true   →  HeroBuildsWindow layout
+//     · builds[0] is the player slot, builds[1..N] are hero slots
+//     · group / mode fields; hero selector / behavior / panel per hero build
+struct TeamBuild {
+    static uint32_t s_cur_ui_id;
+
+    TeamBuild() = default;
+    explicit TeamBuild(std::string_view name, std::string_view ui_id = {});
+
+    bool edit_open = false;
+    bool focus_next_frame = false;
+    int mode = 0;              // 0 = don't change, 1 = normal, 2 = hard (hero builds)
+    bool show_numbers = false; // prefix build names with index (player builds layout)
+    bool has_hero_slots = false;
+    std::string name{};
+    std::string group{};
+    std::string ui_id{};
+    std::vector<Build> builds{};
+
+    // Callback signature: (teambuild, build_index)
+    using BuildAction = std::function<void(TeamBuild&, size_t)>;
+
+    // Draw the full ImGui edit window for this teambuild and its builds.
+    //
+    //   index        – position of this TeamBuild in all_builds.
+    //   all_builds   – the owning vector; may be modified (reorder / delete).
+    //   builds_changed – set true when any data is modified.
+    //   on_load / on_send / on_view – module-supplied callbacks invoked when
+    //     the corresponding button is pressed; receive (teambuild, build_index).
+    //
+    // Returns false when this teambuild was deleted (erased from all_builds).
+    bool DrawEditWindow(
+        size_t index,
+        std::vector<TeamBuild>& all_builds,
+        bool& builds_changed,
+        const BuildAction& on_load = {},
+        const BuildAction& on_send = {},
+        const BuildAction& on_view = {}
+    );
+
+    // Provide the 2×2 sprite sheet used to render the disabled-skill overlay.
+    // Call once from HeroBuildsWindow::Initialize().
+    static void SetSkillToggleSprite(IDirect3DTexture9** sprite);
+
+private:
+    int editing_build_idx_ = -1; // which build row is expanded (player-builds layout)
+
+    void DrawPlayerBuildsContent(bool& builds_changed,
+                                 const BuildAction& on_load,
+                                 const BuildAction& on_send,
+                                 const BuildAction& on_view);
+
+    void DrawHeroBuildsContent(bool& builds_changed,
+                               const BuildAction& on_load,
+                               const BuildAction& on_send,
+                               const BuildAction& on_view);
+};

--- a/GWToolboxdll/Utils/TeamBuildEncoder.cpp
+++ b/GWToolboxdll/Utils/TeamBuildEncoder.cpp
@@ -7,7 +7,6 @@
 #include <GWCA/GameEntities/Skill.h>
 #include <GWCA/Managers/SkillbarMgr.h>
 
-#include <Windows/HeroBuildsWindow.h>
 #include "TextUtils.h"
 #include <Modules/Resources.h>
 #include <Utils/GuiUtils.h>
@@ -366,21 +365,21 @@ namespace TeamBuildEncoder {
         if (br.read(4) != kEncodedMagic) return false;
 
         const uint32_t count = br.read(4);
-        out.builds = {};
+        out.builds.clear();
 
         for (uint32_t h = 0; h < count; h++) {
             GW::SkillbarMgr::SkillTemplate tmpl{};
             GW::Constants::HeroID hero_id{};
             if (!ReadHero(br, tmpl, hero_id)) return false;
 
-            HeroBuild build{};
+            Build build{};
             build.hero_id = hero_id;
             char code_buf[64]{};
             if (!GW::SkillbarMgr::EncodeSkillTemplate(tmpl, code_buf, _countof(code_buf))) return false;
             build.code = code_buf;
-            out.builds[h] = build;
+            out.builds.push_back(std::move(build));
         }
-        if (br.ok) out.ui_id = TextUtils ::WStringToString(encoded);
+        if (br.ok) out.ui_id = TextUtils::WStringToString(encoded);
         return br.ok;
     }
 
@@ -458,7 +457,7 @@ namespace TeamBuildEncoder {
         if (br.read(4) != 1u) return false;  // type = party loadout
 
         const uint32_t count = br.read(4);
-        out.builds = {};
+        out.builds.clear();
 
         for (uint32_t h = 0; h < count; h++) {
             GW::SkillbarMgr::SkillTemplate tmpl{};
@@ -485,12 +484,12 @@ namespace TeamBuildEncoder {
 
             if (!br.ok) return false;
 
-            HeroBuild build{};
+            Build build{};
             build.hero_id = static_cast<GW::Constants::HeroID>(hero_id);
             char code_buf[64]{};
             if (!GW::SkillbarMgr::EncodeSkillTemplate(tmpl, code_buf, _countof(code_buf))) return false;
             build.code = code_buf;
-            out.builds[h] = build;
+            out.builds.push_back(std::move(build));
         }
         return br.ok;
     }
@@ -527,17 +526,3 @@ namespace TeamBuildEncoder {
     }
 
 } // namespace TeamBuildEncoder
-
-std::string HeroBuild::GetFallbackBuildName() const
-{
-    if (code.empty()) return {};
-    GW::SkillbarMgr::SkillTemplate st{};
-    if (!GW::SkillbarMgr::DecodeSkillTemplate(st, code.c_str())) return {};
-    for (int k = 0; k < _countof(st.skills); k++) {
-        if (st.skills[k] == GW::Constants::SkillID::No_Skill) continue;
-        const auto* skill = GW::SkillbarMgr::GetSkillConstantData(st.skills[k]);
-        if (!skill || !skill->IsElite()) continue;
-        return Resources::GetSkillName(st.skills[k])->string();
-    }
-    return {};
-}

--- a/GWToolboxdll/Utils/TeamBuildEncoder.h
+++ b/GWToolboxdll/Utils/TeamBuildEncoder.h
@@ -8,34 +8,7 @@
 #include <GWCA/Constants/Constants.h>
 #include <GWCA/Managers/SkillbarMgr.h>
 
-// Forward declarations
-struct HeroBuild {
-    HeroBuild() = default;
-    HeroBuild(std::string_view n, std::string_view c, GW::Constants::HeroID _hero_id = GW::Constants::HeroID::NoHero, int panel = 0, uint32_t _behavior = 1, uint8_t _disabled_skills = 0)
-        : name(n), code(c), hero_id(_hero_id), behavior(_behavior), show_panel(panel), disabled_skills(_disabled_skills)
-    {
-        if (name.empty()) name = GetFallbackBuildName();
-    }
-    std::string name{};
-    std::string code{};
-    GW::Constants::HeroID hero_id = GW::Constants::HeroID::NoHero;
-    uint32_t behavior = 1;
-    bool show_panel = false;
-    uint8_t disabled_skills = 0;
-    std::string GetFallbackBuildName() const;
-};
-
-struct TeamHeroBuild {
-    static unsigned int cur_ui_id;
-    TeamHeroBuild(std::string_view n, std::string_view _ui_id = {}) : name(n), ui_id(_ui_id.empty() ? std::to_string(++cur_ui_id) : std::string(_ui_id)) {}
-    bool edit_open = false;
-    bool focus_next_frame = false;
-    int mode = 0;
-    std::string name{};
-    std::string group{};
-    std::string ui_id{};
-    std::array<HeroBuild, 8> builds{};
-};
+#include <Utils/TeamBuild.h>
 
 namespace TeamBuildEncoder {
 
@@ -63,7 +36,7 @@ namespace TeamBuildEncoder {
     //                      An 8-hero build fits in at most ~117 wchars.
     // ---------------------------------------------------------------------------
 
-    using TeamHeroBuild     = TeamHeroBuild;
+    using TeamHeroBuild     = ::TeamBuild;
     using DaybreakTeamBuild = std::string;
     using EncodedTeamBuild  = std::wstring;
 

--- a/GWToolboxdll/Windows/BuildsWindow.cpp
+++ b/GWToolboxdll/Windows/BuildsWindow.cpp
@@ -23,91 +23,15 @@
 #include <Windows/PconsWindow.h>
 
 #include <GWToolbox.h>
+#include <Utils/TeamBuild.h>
 #include <Utils/TextUtils.h>
 #include <Utils/ToolboxUtils.h>
 #include <Color.h>
 
 namespace {
 
-    struct TeamBuild;
-    struct Build;
-    std::vector<TeamBuild*> teambuilds{};
-    std::vector<Build*> preferred_skill_order_builds{};
-
-    Color build_edit_pcon_enabled_color = Colors::ARGB(102, 0, 255, 0);
-
-    struct Build {
-
-        Build(const std::string_view _name, const std::string_view _code) :
-            name(_name),
-            code(_code) {
-            name.reserve(128);
-            code.reserve(128);
-            memset(&skill_template, 0, sizeof(skill_template));
-        };
-        Build(TeamBuild& _tbuild, const std::string_view _name, const std::string_view _code) : Build(_name, _code) {
-            tbuild = &_tbuild;
-        };
-        ~Build();
-        TeamBuild* tbuild = nullptr;
-        std::string name;
-        std::string code;
-        GW::SkillbarMgr::SkillTemplate skill_template;
-        std::set<std::string> pcons{};
-
-        const GW::Constants::SkillID* skills() {
-            if (!decode()) {
-                return nullptr;
-            }
-            return skill_template.skills;
-        };
-        const GW::SkillbarMgr::SkillTemplate* decode() {
-            if (!decoded() && !DecodeSkillTemplate(skill_template, code.c_str())) {
-                skill_template.primary = skill_template.secondary = GW::Constants::Profession::None;
-            }
-            return decoded() ? &skill_template : nullptr;
-        };
-        bool decoded() const { return !(skill_template.primary == GW::Constants::Profession::None && skill_template.secondary == GW::Constants::Profession::None); }
-        // Vector of pcons to use for this build, listed by ini name e.g. "cupcake"
-        const size_t index() const;
-
-
-    };
-
-    uint32_t cur_ui_id = 0;
-
-    struct TeamBuild {
-        TeamBuild(const std::string_view _name) : name(_name)
-            , ui_id(++cur_ui_id) {
-            name.reserve(128);
-        };
-        ~TeamBuild() {
-            while (!builds.empty()) {
-                delete builds[0];
-            }
-            std::erase(teambuilds, this);
-        }
-
-        bool edit_open = false;
-        int edit_pcons = -1;
-        bool show_numbers = false;
-        std::string name;
-        std::vector<Build*> builds{};
-        unsigned int ui_id; // should be const but then assignment operator doesn't get created automatically, and I'm too lazy to redefine it, so just don't change this value, okay?
-    };
-
-    const size_t Build::index() const {
-        ASSERT(tbuild);
-        const auto& builds = tbuild->builds;
-        const auto found = std::find(builds.begin(), builds.end(), this);
-        ASSERT(found != builds.end());
-        return found - builds.begin();
-    }
-    Build::~Build() {
-        for (auto teambuild : teambuilds)
-            std::erase(teambuild->builds, this);
-        std::erase(preferred_skill_order_builds, this);
-    }
+    std::vector<TeamBuild> teambuilds{};
+    std::vector<Build> preferred_skill_order_builds{};
 
     bool builds_changed = false;
 
@@ -115,10 +39,8 @@ namespace {
     bool order_by_index = !order_by_name;
     bool auto_load_pcons = true;
     bool auto_send_pcons = true;
-    bool delete_builds_without_prompt = false;
     bool hide_when_entering_explorable = false;
     bool one_teambuild_at_a_time = false;
-
 
     clock_t send_timer = 0;
     std::queue<std::string> queue{};
@@ -137,32 +59,31 @@ namespace {
     GW::HookEntry ChatCmd_HookEntry;
     GW::HookEntry OnUIMessage_HookEntry;
 
-    bool PrefillBuildFromAgent(uint32_t agent_id, Build* build)
-    {
-        if (!build) return false;
+    // Locator for a build within a teambuild
+    struct BuildRef {
+        TeamBuild* tb = nullptr;
+        size_t idx = 0;
+        bool valid() const { return tb != nullptr && idx < tb->builds.size(); }
+        Build* build() const { return valid() ? &tb->builds[idx] : nullptr; }
+    };
 
+    bool PrefillBuildFromAgent(uint32_t agent_id, Build& build)
+    {
         const auto current_skill_bar = GW::SkillbarMgr::GetSkillbar(agent_id);
         if (!current_skill_bar || !current_skill_bar->IsValid()) return false;
 
-        // Get current skill template
         GW::SkillbarMgr::SkillTemplate skill_template;
         if (!GW::SkillbarMgr::GetSkillTemplate(agent_id, skill_template)) return false;
 
-        // Encode the skill template to get the build code
         char build_code[128];
         if (GW::SkillbarMgr::EncodeSkillTemplate(skill_template, build_code, sizeof(build_code))) {
-            build->code = build_code;
+            build.code = build_code;
         }
 
-        build->name = std::format("{}/{}", ToolboxUtils::GetProfessionAcronym(skill_template.primary)->string(), ToolboxUtils::GetProfessionAcronym(skill_template.secondary)->string());
-
-
-        // Try to generate a name based on the elite skill or primary profession
-        std::string generated_name;
+        build.name = std::format("{}/{}", ToolboxUtils::GetProfessionAcronym(skill_template.primary)->string(), ToolboxUtils::GetProfessionAcronym(skill_template.secondary)->string());
 
         wchar_t encoded_name[8] = {0};
 
-        // Find the elite skill (position 0-7, elites are typically in slots 0-2 for player builds)
         for (size_t i = 0; i < 8; i++) {
             const auto skill_id = skill_template.skills[i];
             if (skill_id != GW::Constants::SkillID(0)) {
@@ -173,9 +94,9 @@ namespace {
                         encoded_name,
                         [](void* param, const wchar_t* s) {
                             if (s && *s)
-                                ((Build*)param)->name += std::format(" - {}", TextUtils::WStringToString(s));
+                                static_cast<Build*>(param)->name += std::format(" - {}", TextUtils::WStringToString(s));
                         },
-                        build
+                        &build
                     );
                     break;
                 }
@@ -185,18 +106,16 @@ namespace {
     }
 
     void ClearAllBuilds() {
-        while (teambuilds.size())
-            delete teambuilds[0];
-        while (preferred_skill_order_builds.size())
-            delete preferred_skill_order_builds[0];
+        teambuilds.clear();
+        preferred_skill_order_builds.clear();
     }
 
     // Pass array of skills for a bar; if a preferred order is found, returns a new array of skills in order, otherwise nullptr.
     const GW::Constants::SkillID* GetPreferredSkillOrder(const GW::Constants::SkillID* skill_ids, Build** build_out = nullptr)
     {
-        for (auto build : preferred_skill_order_builds) {
+        for (auto& build : preferred_skill_order_builds) {
             bool found = false;
-            const auto skills = build->skills();
+            const auto skills = build.Skills();
             for (size_t i = 0; skills && i < 8; i++) {
                 found = false;
                 for (size_t j = 0; !found && j < 8; j++) {
@@ -209,12 +128,13 @@ namespace {
             }
             if (found) {
                 if (build_out)
-                    *build_out = build;
+                    *build_out = &build;
                 return skills;
             }
         }
         return nullptr;
     }
+
     // Triggered when a set of skills is about to be loaded on player or hero
     void OnUIMessage(GW::HookStatus*, GW::UI::UIMessage message_id, void* wparam, void*) {
         switch (message_id) {
@@ -224,7 +144,6 @@ namespace {
             ASSERT(skills);
             const auto found = GetPreferredSkillOrder(skills);
             if (found && memcmp(skills, found, sizeof(*skills) * 8) != 0) {
-                // Copy across the new order before the send is done
                 memcpy(skills, found, sizeof(*skills) * 8);
                 Log::Flash("Preferred skill order loaded");
             }
@@ -232,49 +151,46 @@ namespace {
         }
     }
 
-    bool BuildSkillTemplateString(const Build* build, std::string* out)
+    bool BuildSkillTemplateString(const TeamBuild& tbuild, size_t idx, std::string* out)
     {
-        if (!(build && out))
+        if (!out || idx >= tbuild.builds.size())
             return false;
-        if (build->name.empty() && build->code.empty())
-            return false; // nothing to do here
+        const Build& build = tbuild.builds[idx];
+        if (build.name.empty() && build.code.empty())
+            return false;
 
-        const auto idx = build->index();
-
-        if (build->name.empty()) {
-            // name is empty, fill it with the teambuild name
-            *out = std::format("[{} {};{}]", build->tbuild->name, idx + 1, build->code);
+        if (build.name.empty()) {
+            *out = std::format("[{} {};{}]", tbuild.name, idx + 1, build.code);
             return true;
         }
-        if (build->code.empty()) {
-            // code is empty, just print the name without template format
-            *out = build->name;
+        if (build.code.empty()) {
+            *out = build.name;
             return true;
         }
-        if (build->tbuild->show_numbers) {
-            // add numbers in front of name
-            *out = std::format("[{} - {};{}]", idx + 1, build->name, build->code);
+        if (tbuild.show_numbers) {
+            *out = std::format("[{} - {};{}]", idx + 1, build.name, build.code);
             return true;
         }
-        *out = std::format("[{};{}]", build->name, build->code);
+        *out = std::format("[{};{}]", build.name, build.code);
         return true;
     }
 
-    void SendPcons(const Build* build, const bool include_build_name = false)
+    void SendPcons(const TeamBuild& tbuild, size_t idx, const bool include_build_name = false)
     {
-        if (!(build && build->pcons.size()))
-            return;
-        const auto idx = build->index();
+        if (idx >= tbuild.builds.size()) return;
+        const Build& build = tbuild.builds[idx];
+        if (build.pcons.empty()) return;
+
         std::string pconsStr("[Pcons] ");
         if (include_build_name) {
-            if (build->name.empty())
-                pconsStr = std::format("[Pcons][{} {}] ", build->tbuild->name, idx + 1);
+            if (build.name.empty())
+                pconsStr = std::format("[Pcons][{} {}] ", tbuild.name, idx + 1);
             else
-                pconsStr = std::format("[Pcons][{}] ", build->name);
+                pconsStr = std::format("[Pcons][{}] ", build.name);
         }
         size_t cnt = 0;
         for (const auto pcon : PconsWindow::Instance().pcons) {
-            if (!build->pcons.contains(pcon->ini))
+            if (!build.pcons.contains(pcon->ini))
                 continue;
             if (cnt)
                 pconsStr += ", ";
@@ -286,46 +202,44 @@ namespace {
         }
     }
 
-    const Build* Find(const char* tbuild_name = nullptr, const char* build_name = nullptr) {
+    BuildRef Find(const char* tbuild_name = nullptr, const char* build_name = nullptr) {
         if (!build_name)
-            return nullptr;
+            return {};
         GW::SkillbarMgr::SkillTemplate t;
         const auto prof = static_cast<GW::Constants::Profession>(GW::Agents::GetControlledCharacter()->primary);
         const bool is_skill_template = DecodeSkillTemplate(t, build_name);
         if (is_skill_template && t.primary != prof) {
             Log::Error("Invalid profession for %s (%s)", build_name, ToolboxUtils::GetProfessionAcronym(t.primary)->string().c_str());
-            return nullptr;
+            return {};
         }
         const std::string tbuild_ws = tbuild_name ? TextUtils::ToLower(tbuild_name) : "";
         const std::string build_ws = TextUtils::ToLower(build_name);
 
-        const Build* best_match = nullptr;
+        BuildRef best_match{};
         size_t best_match_pos = 0;
 
-        std::vector<std::pair<TeamBuild, size_t>> local_teambuilds;
-        for (const auto& tb : teambuilds) {
-            if (tbuild_name && TextUtils::ToLower(tb->name).find(tbuild_ws.c_str()) == std::string::npos)
-                continue; // Teambuild name doesn't match
+        for (auto& tb : teambuilds) {
+            if (tbuild_name && TextUtils::ToLower(tb.name).find(tbuild_ws.c_str()) == std::string::npos)
+                continue;
             if (is_skill_template) {
-                for (const auto build : tb->builds) {
-                    if (build->code == build_name) {
-                        best_match = build;
+                for (size_t j = 0; j < tb.builds.size(); j++) {
+                    if (tb.builds[j].code == build_name) {
+                        best_match = {&tb, j};
                     }
-
                 }
             }
             else {
-                for (const auto build : tb->builds) {
-                    const auto text_match_pos = TextUtils::ToLower(build->name).find(build_ws.c_str());
+                for (size_t j = 0; j < tb.builds.size(); j++) {
+                    const auto text_match_pos = TextUtils::ToLower(tb.builds[j].name).find(build_ws.c_str());
                     if (text_match_pos == std::string::npos)
                         continue;
-                    if (!DecodeSkillTemplate(t, build->code.c_str()))
-                        continue; // Invalid build code
+                    if (!DecodeSkillTemplate(t, tb.builds[j].code.c_str()))
+                        continue;
                     if (t.primary != prof)
-                        continue; // Wrong profession.
-                    if (best_match && text_match_pos < best_match_pos)
-                        continue; // Current match is more accurate name
-                    best_match = build;
+                        continue;
+                    if (best_match.valid() && text_match_pos < best_match_pos)
+                        continue;
+                    best_match = {&tb, j};
                     best_match_pos = text_match_pos;
                 }
             }
@@ -333,62 +247,50 @@ namespace {
         return best_match;
     }
 
-    bool Send(const Build* build)
+    bool Send(const TeamBuild& tbuild, size_t idx)
     {
         std::string buf;
-        if (!(build && BuildSkillTemplateString(build, &buf)))
+        if (!BuildSkillTemplateString(tbuild, idx, &buf))
             return false;
         queue.push(buf);
         if (auto_send_pcons)
-            SendPcons(build);
+            SendPcons(tbuild, idx);
         return true;
     }
 
-    void Send(const TeamBuild* tbuild) {
-        if (!tbuild->name.empty()) {
-            queue.push(tbuild->name);
+    void Send(const TeamBuild& tbuild) {
+        if (!tbuild.name.empty()) {
+            queue.push(tbuild.name);
         }
-        for (const auto build : tbuild->builds) {
-            Send(build);
+        for (size_t j = 0; j < tbuild.builds.size(); j++) {
+            Send(tbuild, j);
         }
     }
 
-    bool View(const Build* build)
+    bool View(const Build& build)
     {
-        if (!build)
-            return false;
-        GW::GameThread::Enqueue([build] {
+        GW::GameThread::Enqueue([code = build.code, name = build.name] {
             GW::UI::ChatTemplate t = { 0 };
 
-            auto code_ws = TextUtils::StringToWString(build->code);
+            auto code_ws = TextUtils::StringToWString(code);
             t.code.m_buffer = code_ws.data();
             t.code.m_size = t.code.m_capacity = code_ws.size() + 1;
 
-            auto name_ws = TextUtils::StringToWString(build->name);
+            auto name_ws = TextUtils::StringToWString(name);
             t.name = name_ws.data();
             SendUIMessage(GW::UI::UIMessage::kOpenTemplate, &t);
-            });
+        });
         return true;
     }
 
-    void Send(const unsigned int idx)
-    {
-        if (idx < teambuilds.size()) {
-            Send(teambuilds[idx]);
-        }
-    }
-
-    bool LoadPcons(const Build* build) {
-        if (!build)
-            return false;
+    bool LoadPcons(const Build& build) {
         std::vector<Pcon*> pcons_loaded;
         std::vector<Pcon*> pcons_not_visible;
         const PconsWindow* pcw = &PconsWindow::Instance();
         for (auto pcon : pcw->pcons) {
-            const bool enable = build->pcons.contains(pcon->ini);
+            const bool enable = build.pcons.contains(pcon->ini);
             if (enable) {
                 if (!pcon->IsVisible()) {
-                    // Don't enable pcons that the user cant see!
                     pcons_not_visible.push_back(pcon);
                     continue;
                 }
@@ -401,49 +303,49 @@ namespace {
             std::string pcons_str;
             size_t i = 0;
             for (const auto pcon : pcons_loaded) {
-                if (i) {
-                    pcons_str += ", ";
-                }
+                if (i) pcons_str += ", ";
                 i = 1;
                 pcons_str += pcon->abbrev;
             }
-            const char* str = pcons_str.c_str();
-            Log::Flash("Pcons loaded: %s", str);
+            Log::Flash("Pcons loaded: %s", pcons_str.c_str());
         }
         if (pcons_not_visible.size()) {
             std::string pcons_str;
             size_t i = 0;
             for (const auto pcon : pcons_not_visible) {
-                if (i) {
-                    pcons_str += ", ";
-                }
+                if (i) pcons_str += ", ";
                 i = 1;
                 pcons_str += pcon->abbrev;
             }
-            const char* str = pcons_str.c_str();
-            Log::Warning("Pcons not loaded: %s.\nOnly pcons visible in the Pcons window will be auto enabled.", str);
+            Log::Warning("Pcons not loaded: %s.\nOnly pcons visible in the Pcons window will be auto enabled.", pcons_str.c_str());
         }
         return true;
     }
 
-    bool Load(const Build* build) {
-        if (!(build && GW::SkillbarMgr::LoadSkillTemplate(build->code.c_str())))
+    bool Load(const TeamBuild& tbuild, size_t idx) {
+        if (idx >= tbuild.builds.size()) return false;
+        const Build& build = tbuild.builds[idx];
+        if (!GW::SkillbarMgr::LoadSkillTemplate(build.code.c_str()))
             return false;
         if (auto_load_pcons)
             LoadPcons(build);
-        if (!build->tbuild->edit_open) {
+        if (!tbuild.edit_open) {
             std::string build_string;
-            if (BuildSkillTemplateString(build, &build_string))
+            if (BuildSkillTemplateString(tbuild, idx, &build_string))
                 Log::Flash("Build loaded: %s", build_string.c_str());
         }
         return true;
     }
 
+    bool Load(BuildRef ref) {
+        if (!ref.valid()) return false;
+        return Load(*ref.tb, ref.idx);
+    }
+
     bool Load(const char* tbuild_name, const char* build_name)
     {
         const auto found = Find(tbuild_name, build_name);
-        // These are now in order of build match.
-        if (!found) {
+        if (!found.valid()) {
             Log::Error("Failed to find build for %s", build_name);
             return false;
         }
@@ -453,148 +355,6 @@ namespace {
     bool Load(const char* build_name)
     {
         return Load(nullptr, build_name);
-    }
-
-    void OnDeleteBuildConfirmed(bool result, void* wparam) {
-        if (!result)
-            return;
-        auto build = (Build*)wparam;
-        delete build;
-        builds_changed = true;
-    }
-    Build* editing_build = 0;
-    void DrawBuildSection(Build* build)
-    {
-        const auto idx = (int)build->index();
-        const float font_scale = ImGui::FontScale();
-        const float btn_width = 50.0f * font_scale;
-        const float del_width = 24.0f * font_scale;
-        const float spacing = ImGui::GetStyle().ItemSpacing.y;
-        const float btn_offset = ImGui::GetContentRegionAvail().x - del_width - btn_width * 3 - spacing * 3;
-        const auto editing = editing_build == build;
-
-        ImGui::Text("#%d", idx + 1);
-        ImGui::PushItemWidth(btn_offset - btn_width - spacing * 2);
-        ImGui::SameLine(btn_width, 0);
-        if (ImGui::InputText("###name", build->name)) {
-            builds_changed = true;
-        }
-        if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip([build]() {
-                ImGui::TextUnformatted(build->name.c_str());
-                GuiUtils::DrawSkillbar(build->code.c_str());
-            });
-        }
-        ImGui::PopItemWidth();
- 
-        ImGui::SameLine(btn_offset);
-        if (ImGui::Button(ImGui::GetIO().KeyCtrl ? "Send" : "View", ImVec2(btn_width, 0))) {
-            if (ImGui::GetIO().KeyCtrl) {
-                Send(build);
-            }
-            else {
-                View(build);
-            }
-        }
-        if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip(ImGui::GetIO().KeyCtrl ? "Click to send to team chat" : "Click to view build. Ctrl + Click to send to chat.");
-        }
-        ImGui::SameLine(0, spacing);
-        if (ImGui::Button("Load", ImVec2(btn_width, 0))) {
-            Load(build);
-        }
-        if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip(!build->pcons.empty() ? "Click to load build template and pcons" : "Click to load build template");
-        }
-        ImGui::SameLine(0, spacing);
-        if (editing) {
-            ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyleColorVec4(ImGuiCol_ButtonHovered));
-        }
-        if (ImGui::Button("Edit", ImVec2(btn_width, 0))) {
-            if (editing_build == build) {
-                editing_build = 0;
-            }
-            else {
-                editing_build = build;
-            }
-        }
-        if (editing) {
-            ImGui::PopStyleColor();
-        }
-        if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip("Click to edit this build");
-        }
-        ImGui::SameLine(0, spacing);
-        bool delete_confirmed = false;
-        if (ImGui::ConfirmButton(ICON_FA_TRASH, &delete_confirmed, "Delete Build\n\nAre you sure you want to delete this build?\nThis operation cannot be undone.")) {
-            OnDeleteBuildConfirmed(true, build);
-            return;
-        }
-        if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip("Delete build");
-        }
-        if (editing) {
-            // Edit mode
-            const float indent = btn_width;
-            ImGui::Indent(indent);
-            ImGui::TextUnformatted("Build Code:");
-            ImGui::SameLine();
-            if (ImGui::InputText("###code", build->code)) {
-                builds_changed = true;
-            }
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip([build]() {
-                    GuiUtils::DrawSkillbar(build->code.c_str());
-                });
-            }
-            // Pcons
-            ImGui::TextUnformatted("Pcons:");
-            ImGui::ShowHelp("Enable or disable pcons that will be activated in the pcons window when this build is loaded");
-            const auto& pcons = PconsWindow::Instance().pcons;
-
-            
-            const float skill_height = ImGui::CalcTextSize(" ").y * 2.f;
-            const auto skill_size = ImVec2(skill_height, skill_height);
-            ImGui::StartSpacedElements(skill_height + ImGui::GetStyle().ItemSpacing.x);
-            for (const auto pcon : pcons) {
-                ImGui::PushID(pcon);
-                const auto active = build->pcons.contains(pcon->ini);
-                ImGui::NextSpacedElement();
-                if (active) {
-                    ImGui::PushStyleColor(ImGuiCol_Button, build_edit_pcon_enabled_color);
-                }
-                if (ImGui::IconButton("", *pcon->GetTexture(), {skill_height, skill_height})) {
-                    if (!active) {
-                        build->pcons.emplace(pcon->ini);
-                    }
-                    else {
-                        build->pcons.erase(pcon->ini);
-                    }
-                    builds_changed = true;
-                }
-                if (active) {
-                    ImGui::PopStyleColor();
-                }
-                if (ImGui::IsItemHovered()) {
-                    ImGui::SetTooltip(pcon->chat.c_str());
-                }
-                ImGui::PopID();
-            }
-            
-            ImGui::Unindent(indent);
-
-        }
-       
-    }
-
-    bool GetCurrentSkillBar(char* out, const size_t out_len)
-    {
-        if (!(out && out_len)) {
-            return false;
-        }
-        GW::SkillbarMgr::SkillTemplate skill_template;
-        return GetSkillTemplate(GW::Agents::GetControlledCharacterId(), skill_template)
-            && EncodeSkillTemplate(skill_template, out, out_len) && DecodeSkillTemplate(skill_template, out);
     }
 
     const char* AddPreferredBuild(const char* code)
@@ -608,8 +368,16 @@ namespace {
             found->code = found->name = code;
             return nullptr;
         }
-        preferred_skill_order_builds.push_back(new Build(code, code));
+        preferred_skill_order_builds.push_back(Build(code, code));
         return nullptr;
+    }
+
+    bool GetCurrentSkillBar(char* out, const size_t out_len)
+    {
+        if (!(out && out_len)) return false;
+        GW::SkillbarMgr::SkillTemplate skill_template;
+        return GetSkillTemplate(GW::Agents::GetControlledCharacterId(), skill_template)
+            && EncodeSkillTemplate(skill_template, out, out_len) && DecodeSkillTemplate(skill_template, out);
     }
 
     void DrawPreferredSkillOrders(IDirect3DDevice9*)
@@ -625,15 +393,15 @@ namespace {
         }
         ImGui::Text("When a set of skills is loaded that matches a set from this list, reorder it to match");
         const float skill_height = ImGui::CalcTextSize(" ").y * 2.f;
-        const auto skill_size = ImVec2(skill_height, skill_height);
         ImGui::Indent();
-        for (auto build : preferred_skill_order_builds) {
-            const GW::Constants::SkillID* skills = build->skills();
+        for (size_t bi = 0; bi < preferred_skill_order_builds.size(); bi++) {
+            auto& build = preferred_skill_order_builds[bi];
+            const GW::Constants::SkillID* skills = build.Skills();
             for (size_t i = 0; skills && i < 8; i++) {
                 if (i) {
                     ImGui::SameLine(0, 0);
                 }
-                ImGui::ImageCropped(*Resources::GetSkillImage(skills[i]), skill_size);
+                ImGui::ImageCropped(*Resources::GetSkillImage(skills[i]), ImVec2(skill_height, skill_height));
                 if (ImGui::IsItemHovered()) {
                     const GW::Skill* s = GW::SkillbarMgr::GetSkillConstantData(skills[i]);
                     if (s) {
@@ -644,9 +412,9 @@ namespace {
             }
             ImGui::SameLine();
             char btn_label[48];
-            snprintf(btn_label, sizeof(btn_label), "%s Remove###remove_preferred_skill_order_%p", reinterpret_cast<const char*>(ICON_FA_TRASH), build);
+            snprintf(btn_label, sizeof(btn_label), "%s Remove###remove_preferred_skill_order_%zu", reinterpret_cast<const char*>(ICON_FA_TRASH), bi);
             if (ImGui::Button(btn_label, ImVec2(0, skill_height))) {
-                delete build;
+                preferred_skill_order_builds.erase(preferred_skill_order_builds.begin() + static_cast<ptrdiff_t>(bi));
                 Log::Flash("Preferred skill order removed");
                 break;
             }
@@ -679,7 +447,7 @@ namespace {
     const char* BuildName(const unsigned int idx)
     {
         if (idx < teambuilds.size()) {
-            return teambuilds[idx]->name.c_str();
+            return teambuilds[idx].name.c_str();
         }
         return nullptr;
     }
@@ -691,7 +459,6 @@ namespace {
 
     void LoadFromFile()
     {
-        // clear builds from toolbox
         ClearAllBuilds();
 
         if (inifile == nullptr) {
@@ -713,11 +480,11 @@ namespace {
             }
             const char* section = entry.pItem;
             const int count = inifile->GetLongValue(section, "count", 12);
-            auto tbuild = new TeamBuild(inifile->GetValue(section, "buildname", ""));
-            tbuild->show_numbers = inifile->GetBoolValue(section, "showNumbers", true);
+            TeamBuild tbuild(inifile->GetValue(section, "buildname", ""));
+            tbuild.has_hero_slots = false;
+            tbuild.show_numbers = inifile->GetBoolValue(section, "showNumbers", true);
             char key[16];
             for (int i = 0; i < count; ++i) {
-
                 snprintf(key, _countof(key), "name%d", i);
                 const char* nameval = inifile->GetValue(section, key, "");
                 snprintf(key, _countof(key), "template%d", i);
@@ -725,37 +492,37 @@ namespace {
                 snprintf(key, _countof(key), "pcons%d", i);
                 std::string pconsval = inifile->GetValue(section, key, "");
 
-                auto build = new Build(*tbuild, nameval, templateval);
+                Build build(nameval, templateval);
 
-                // Parse pcons
                 size_t pos = 0;
                 std::string token;
                 while ((pos = pconsval.find(",")) != std::string::npos) {
                     token = pconsval.substr(0, pos);
-                    build->pcons.emplace(token.c_str());
+                    build.pcons.emplace(token.c_str());
                     pconsval.erase(0, pos + 1);
                 }
                 if (pconsval.length()) {
-                    build->pcons.emplace(pconsval.c_str());
+                    build.pcons.emplace(pconsval.c_str());
                 }
-                tbuild->builds.push_back(build);
+                tbuild.builds.push_back(std::move(build));
             }
-            teambuilds.push_back(tbuild);
+            teambuilds.push_back(std::move(tbuild));
         }
-        // Sort by name
         if (order_by_name) {
-            sort(teambuilds.begin(), teambuilds.end(), [](const TeamBuild* a, const TeamBuild* b) {
-                return _stricmp(a->name.c_str(), b->name.c_str()) < 0;
+            std::ranges::sort(teambuilds, [](const TeamBuild& a, const TeamBuild& b) {
+                return _stricmp(a.name.c_str(), b.name.c_str()) < 0;
             });
         }
         builds_changed = false;
         LoadFromBuildsFolder();
     }
+
     std::filesystem::path GetBuildsFolder() {
         const auto gw_builds_folder = GW::MemoryMgr::GetBuildsDir();
         if (gw_builds_folder.empty()) return L"";
         return gw_builds_folder / L"GWToolbox" / L"Builds";
     }
+
     bool SaveToBuildsFolder()
     {
         const auto tb_builds_folder = GetBuildsFolder();
@@ -764,34 +531,35 @@ namespace {
         std::set<std::filesystem::path> expected_paths;
         expected_paths.emplace(tb_builds_folder);
 
-        for (const auto tbuild : teambuilds) {
-            if (tbuild->name.empty()) continue;
+        for (const auto& tbuild : teambuilds) {
+            if (tbuild.name.empty()) continue;
 
-            const std::filesystem::path tbuild_folder = tb_builds_folder / TextUtils::SanitiseFilename(tbuild->name);
+            const std::filesystem::path tbuild_folder = tb_builds_folder / TextUtils::SanitiseFilename(tbuild.name);
             expected_paths.emplace(tbuild_folder);
 
             const auto tbuild_name_path = tbuild_folder / "tbuild.name";
-            if (!Resources::WriteFile(tbuild_name_path, tbuild->name)) return false;
+            if (!Resources::WriteFile(tbuild_name_path, tbuild.name)) return false;
             expected_paths.emplace(tbuild_name_path);
 
-            for (const auto build : tbuild->builds) {
-                if (build->name.empty() && build->code.empty()) continue;
+            for (size_t j = 0; j < tbuild.builds.size(); j++) {
+                const auto& build = tbuild.builds[j];
+                if (build.name.empty() && build.code.empty()) continue;
 
-                const std::string file_stem = TextUtils::SanitiseFilename(build->name.empty() ? std::format("Build_{}", build->index() + 1) : build->name);
+                const std::string file_stem = TextUtils::SanitiseFilename(build.name.empty() ? std::format("Build_{}", j + 1) : build.name);
 
-                if (!build->name.empty()) {
+                if (!build.name.empty()) {
                     const auto p = tbuild_folder / (file_stem + ".name");
-                    if (!Resources::WriteFile(p, build->name)) return false;
+                    if (!Resources::WriteFile(p, build.name)) return false;
                     expected_paths.emplace(p);
                 }
-                if (!build->code.empty()) {
+                if (!build.code.empty()) {
                     const auto p = tbuild_folder / (file_stem + ".txt");
-                    if (!Resources::WriteFile(p, build->code)) return false;
+                    if (!Resources::WriteFile(p, build.code)) return false;
                     expected_paths.emplace(p);
                 }
-                if (!build->pcons.empty()) {
+                if (!build.pcons.empty()) {
                     const auto p = tbuild_folder / (file_stem + ".pcons");
-                    if (!Resources::WriteFile(p, TextUtils::Join({build->pcons.begin(), build->pcons.end()}, "\n"))) return false;
+                    if (!Resources::WriteFile(p, TextUtils::Join({build.pcons.begin(), build.pcons.end()}, "\n"))) return false;
                     expected_paths.emplace(p);
                 }
             }
@@ -818,20 +586,24 @@ namespace {
         for (const auto& tbuild_entry : std::filesystem::directory_iterator(tb_builds_folder)) {
             if (!tbuild_entry.is_directory()) continue;
 
-            // Prefer the original name from tbuild.name, fall back to the folder name
             std::string tbuild_name;
             const auto tbuild_name_path = tbuild_entry.path() / "tbuild.name";
-            if (!Resources::ReadFile(tbuild_name_path, tbuild_name)) 
+            if (!Resources::ReadFile(tbuild_name_path, tbuild_name))
                 tbuild_name = TextUtils::WStringToString(tbuild_entry.path().filename().wstring());
             tbuild_name = TextUtils::trim(tbuild_name);
 
-            auto it = std::ranges::find_if(teambuilds, [&](const TeamBuild* tb) {
-                return _stricmp(tb->name.c_str(), tbuild_name.c_str()) == 0;
+            auto it = std::ranges::find_if(teambuilds, [&](const TeamBuild& tb) {
+                return _stricmp(tb.name.c_str(), tbuild_name.c_str()) == 0;
             });
-            auto tbuild = it != teambuilds.end() ? *it : nullptr;
-            if (!tbuild) {
-                tbuild = new TeamBuild(tbuild_name);
-                teambuilds.push_back(tbuild);
+            TeamBuild* tbuild_ptr;
+            if (it != teambuilds.end()) {
+                tbuild_ptr = &(*it);
+            }
+            else {
+                TeamBuild new_tb(tbuild_name);
+                new_tb.has_hero_slots = false;
+                teambuilds.push_back(std::move(new_tb));
+                tbuild_ptr = &teambuilds.back();
             }
 
             for (const auto& file_entry : std::filesystem::directory_iterator(tbuild_entry.path())) {
@@ -846,30 +618,28 @@ namespace {
 
                 const auto stem = path.stem().wstring();
 
-                // Prefer the original name from .name file, fall back to the filename stem
                 std::string build_name;
                 const auto name_path = path.parent_path() / (stem + L".name");
                 if (!Resources::ReadFile(name_path, build_name)) build_name = TextUtils::WStringToString(stem);
                 build_name = TextUtils::trim(build_name);
 
-                auto bit = std::ranges::find_if(tbuild->builds, [&](const Build* b) {
-                    return _stricmp(b->name.c_str(), build_name.c_str()) == 0;
+                auto bit = std::ranges::find_if(tbuild_ptr->builds, [&](const Build& b) {
+                    return _stricmp(b.name.c_str(), build_name.c_str()) == 0;
                 });
-                auto build = bit != tbuild->builds.end() ? *bit : nullptr;
-                if (build) {
-                    build->code = code;
-                    build->pcons.clear();
+                if (bit != tbuild_ptr->builds.end()) {
+                    bit->code = code;
+                    bit->pcons.clear();
                 }
                 else {
-                    build = new Build(*tbuild, build_name, code);
-                    tbuild->builds.push_back(build);
+                    tbuild_ptr->builds.push_back(Build(build_name, code));
+                    bit = tbuild_ptr->builds.end() - 1;
                 }
 
                 const auto pcons_path = path.parent_path() / (stem + L".pcons");
                 std::string pcons_content;
                 if (Resources::ReadFile(pcons_path, pcons_content)) {
                     for (const auto& pcon : TextUtils::Split(TextUtils::trim(pcons_content), "\n"))
-                        if (!pcon.empty()) build->pcons.emplace(pcon);
+                        if (!pcon.empty()) bit->pcons.emplace(pcon);
                 }
             }
         }
@@ -877,48 +647,44 @@ namespace {
         builds_changed = false;
         return true;
     }
-    
+
     void SaveToFile()
     {
         if (!(builds_changed || GWToolbox::SettingsFolderChanged()))
-            return; // No change
+            return;
         if (inifile == nullptr) {
             inifile = new ToolboxIni();
         }
 
-        // clear builds from ini
         inifile->Reset();
 
-        for (const auto build : preferred_skill_order_builds) {
-            inifile->SetValue("preferred_skill_orders", build->code.c_str(), build->code.c_str());
+        for (const auto& build : preferred_skill_order_builds) {
+            inifile->SetValue("preferred_skill_orders", build.code.c_str(), build.code.c_str());
         }
 
-        // then save
         for (unsigned int i = 0; i < teambuilds.size(); ++i) {
-            const auto tbuild = teambuilds[i];
+            const auto& tbuild = teambuilds[i];
             char section[16];
             snprintf(section, 16, "builds%03d", i);
-            inifile->SetValue(section, "buildname", tbuild->name.c_str());
-            inifile->SetBoolValue(section, "showNumbers", tbuild->show_numbers);
-            inifile->SetLongValue(section, "count", tbuild->builds.size());
-            for (unsigned int j = 0; j < tbuild->builds.size(); ++j) {
-                const auto build = tbuild->builds[j];
+            inifile->SetValue(section, "buildname", tbuild.name.c_str());
+            inifile->SetBoolValue(section, "showNumbers", tbuild.show_numbers);
+            inifile->SetLongValue(section, "count", tbuild.builds.size());
+            for (unsigned int j = 0; j < tbuild.builds.size(); ++j) {
+                const auto& build = tbuild.builds[j];
                 char namekey[16];
                 char templatekey[16];
                 snprintf(namekey, 16, "name%d", j);
                 snprintf(templatekey, 16, "template%d", j);
-                inifile->SetValue(section, namekey, build->name.c_str());
-                inifile->SetValue(section, templatekey, build->code.c_str());
+                inifile->SetValue(section, namekey, build.name.c_str());
+                inifile->SetValue(section, templatekey, build.code.c_str());
 
-                if (!build->pcons.empty()) {
+                if (!build.pcons.empty()) {
                     char pconskey[16];
                     std::string pconsval;
                     snprintf(pconskey, 16, "pcons%d", j);
                     size_t k = 0;
-                    for (auto& pconstr : build->pcons) {
-                        if (k) {
-                            pconsval += ",";
-                        }
+                    for (auto& pconstr : build.pcons) {
+                        if (k) pconsval += ",";
                         k = 1;
                         pconsval += pconstr;
                     }
@@ -933,7 +699,7 @@ namespace {
     bool MoveOldBuilds(ToolboxIni* ini)
     {
         if (!teambuilds.empty()) {
-            return false; // builds are already loaded, skip
+            return false;
         }
 
         bool found_old_build = false;
@@ -944,8 +710,9 @@ namespace {
             if (strncmp(section, "builds", 6) != 0)
                 continue;
             const int count = ini->GetLongValue(section, "count", 12);
-            auto tbuild = new TeamBuild(ini->GetValue(section, "buildname", ""));
-            tbuild->show_numbers = ini->GetBoolValue(section, "showNumbers", true);
+            TeamBuild tbuild(ini->GetValue(section, "buildname", ""));
+            tbuild.has_hero_slots = false;
+            tbuild.show_numbers = ini->GetBoolValue(section, "showNumbers", true);
             char namekey[16];
             char templatekey[16];
             for (int i = 0; i < count; ++i) {
@@ -953,10 +720,10 @@ namespace {
                 snprintf(templatekey, _countof(templatekey), "template%d", i);
                 const char* nameval = ini->GetValue(section, namekey, "");
                 const char* templateval = ini->GetValue(section, templatekey, "");
-                tbuild->builds.push_back(new Build(*tbuild, nameval, templateval));
+                tbuild.builds.push_back(Build(nameval, templateval));
             }
             found_old_build = true;
-            teambuilds.push_back(tbuild);
+            teambuilds.push_back(std::move(tbuild));
             ini->Delete(section, nullptr);
         }
 
@@ -968,7 +735,7 @@ namespace {
         return false;
     }
 
-    const Build* FindBuildFromChatCmd(int argc, const LPWSTR* argv) {
+    BuildRef FindBuildFromChatCmd(int argc, const LPWSTR* argv) {
         if (argc > 2) {
             const std::string build_name = TextUtils::WStringToString(argv[2]);
             const std::string team_build_name = TextUtils::WStringToString(argv[1]);
@@ -978,7 +745,7 @@ namespace {
             const std::string build_name = TextUtils::WStringToString(argv[1]);
             return Find(nullptr, build_name.c_str());
         }
-        return nullptr;
+        return {};
     }
 
     void CHAT_CMD_FUNC(CmdLoad)
@@ -990,7 +757,7 @@ namespace {
             Log::WarningW(L"Syntax: /%s [teambuild_name] [build_name|build_code]\n/%s [build_name|build_code]", *argv, *argv);
             return;
         }
-        Load(FindBuildFromChatCmd(argc, argv)); 
+        Load(FindBuildFromChatCmd(argc, argv));
     }
     void CHAT_CMD_FUNC(CmdPing)
     {
@@ -998,7 +765,8 @@ namespace {
             Log::WarningW(L"Syntax: /%s [teambuild_name] [build_name|build_code]\n/%s [build_name|build_code]", *argv, *argv);
             return;
         }
-        Send(FindBuildFromChatCmd(argc, argv));
+        const auto ref = FindBuildFromChatCmd(argc, argv);
+        if (ref.valid()) Send(*ref.tb, ref.idx);
     }
 
 }
@@ -1040,11 +808,11 @@ void BuildsWindow::DrawSettingsInternal()
 
 void SetTooltipFromTeambuild(const TeamBuild* tbuild) {
     ImGui::SetTooltip([tbuild]() {
-        for (auto build : tbuild->builds) {
-            if (build->name.empty() && build->code.empty()) continue;
+        for (const auto& build : tbuild->builds) {
+            if (build.name.empty() && build.code.empty()) continue;
             ImGui::Spacing();
-            ImGui::TextUnformatted(build->name.c_str());
-            GuiUtils::DrawSkillbar(build->code.c_str(),false);
+            ImGui::TextUnformatted(build.name.c_str());
+            GuiUtils::DrawSkillbar(build.code.c_str(), false);
             ImGui::Spacing();
         }
     });
@@ -1053,15 +821,13 @@ void SetTooltipFromTeambuild(const TeamBuild* tbuild) {
 void BuildsWindow::Draw(IDirect3DDevice9* pDevice)
 {
     DrawPreferredSkillOrders(pDevice);
-    // @Cleanup: Use the BuildsWindow instance, not a static variable
     static auto last_instance_type = GW::Constants::InstanceType::Loading;
     const GW::Constants::InstanceType instance_type = GW::Map::GetInstanceType();
 
     if (instance_type != last_instance_type) {
-        // Run tasks on map change without an StoC hook
         if (hide_when_entering_explorable && instance_type == GW::Constants::InstanceType::Explorable) {
-            for (auto hb : teambuilds) {
-                hb->edit_open = false;
+            for (auto& hb : teambuilds) {
+                hb.edit_open = false;
             }
             visible = false;
         }
@@ -1072,19 +838,19 @@ void BuildsWindow::Draw(IDirect3DDevice9* pDevice)
         ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
         ImGui::SetNextWindowSize(ImVec2(300, 250), ImGuiCond_FirstUseEver);
         if (ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
-            for (const auto tbuild : teambuilds) {
-                ImGui::PushID(static_cast<int>(tbuild->ui_id));
+            for (auto& tbuild : teambuilds) {
+                ImGui::PushID(tbuild.ui_id.c_str());
                 ImGui::GetStyle().ButtonTextAlign = ImVec2(0.0f, 0.5f);
-                if (ImGui::Button(tbuild->name.c_str(), ImVec2(ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemInnerSpacing.x - 60.0f * ImGui::FontScale(), 0))) {
-                    if (one_teambuild_at_a_time && !tbuild->edit_open) {
+                if (ImGui::Button(tbuild.name.c_str(), ImVec2(ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemInnerSpacing.x - 60.0f * ImGui::FontScale(), 0))) {
+                    if (one_teambuild_at_a_time && !tbuild.edit_open) {
                         for (auto& tb : teambuilds) {
-                            tb->edit_open = false;
+                            tb.edit_open = false;
                         }
                     }
-                    tbuild->edit_open = !tbuild->edit_open;
+                    tbuild.edit_open = !tbuild.edit_open;
                 }
                 if (ImGui::IsItemHovered()) {
-                    SetTooltipFromTeambuild(tbuild);
+                    SetTooltipFromTeambuild(&tbuild);
                 }
                 ImGui::GetStyle().ButtonTextAlign = ImVec2(0.5f, 0.5f);
                 ImGui::SameLine(0, ImGui::GetStyle().ItemInnerSpacing.x);
@@ -1094,92 +860,43 @@ void BuildsWindow::Draw(IDirect3DDevice9* pDevice)
                 ImGui::PopID();
             }
             if (ImGui::Button("Add Teambuild", ImVec2(ImGui::GetContentRegionAvail().x, 0))) {
-                auto tbuild = new TeamBuild(std::format("My New Teambuild, {}",TextUtils::GetFormattedDateTime()));
-                tbuild->edit_open = true;
+                TeamBuild new_tbuild(std::format("My New Teambuild, {}", TextUtils::GetFormattedDateTime()));
+                new_tbuild.has_hero_slots = false;
+                new_tbuild.edit_open = true;
                 const auto party_agent_ids = GW::PartyMgr::GetPartyAgentIds();
+                new_tbuild.builds.reserve(party_agent_ids.size());
                 for (const auto agent_id : party_agent_ids) {
-                    const auto b = new Build(*tbuild, "", "");
-                    if (!PrefillBuildFromAgent(agent_id, b)) break;
-                    tbuild->builds.push_back(b);
+                    new_tbuild.builds.emplace_back();
+                    if (!PrefillBuildFromAgent(agent_id, new_tbuild.builds.back())) {
+                        new_tbuild.builds.pop_back();
+                        break;
+                    }
                 }
-                teambuilds.push_back(tbuild);
+                teambuilds.push_back(std::move(new_tbuild));
                 builds_changed = true;
             }
         }
         ImGui::End();
     }
-    for (size_t i = 0, size = teambuilds.size(); i < size && size == teambuilds.size(); i++)
-    {
-        const auto tbuild = teambuilds[i];
-        if (!tbuild->edit_open) {
-            continue;
-        }
-        ImGui::PushID(tbuild->ui_id);
-        char winname[192];
-        ASSERT(snprintf(winname,_countof(winname), "%s###teambuild%d", tbuild->name.c_str(), tbuild->ui_id) > 0);
-        ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
-        ImGui::SetNextWindowSize(ImVec2(500, 0), ImGuiCond_FirstUseEver);
-        if (ImGui::Begin(winname, &tbuild->edit_open)) {
-            ImGui::PushItemWidth(-120.0f);
-            if (ImGui::InputText("Build Name", tbuild->name)) {
-                builds_changed = true;
-            }
-            ImGui::PopItemWidth();
-            bool tmp_builds_changed = builds_changed;
-            builds_changed = false;
-            for (const auto build : tbuild->builds) {
-                ImGui::PushID(build);
-                DrawBuildSection(build);
-                ImGui::PopID();
-                if (builds_changed) break;
-            }
-            builds_changed |= tmp_builds_changed;
-            ImGui::Spacing();
-            ImGui::Separator();
-            ImGui::Spacing();
-            if (ImGui::Checkbox("Show numbers", &tbuild->show_numbers)) {
-                builds_changed = true;
-            }
-            ImGui::SameLine();
-            const auto btn_width = 140.f;
-            ImGui::SetCursorPosX(ImGui::GetContentRegionAvail().x - btn_width);
-            if (ImGui::Button("Add Build", ImVec2(btn_width, 0))) {
-                const auto b = new Build(*tbuild, "", "");
-                PrefillBuildFromAgent(GW::Agents::GetControlledCharacterId(), b);
-                tbuild->builds.push_back(b);
-                editing_build = b;
-                builds_changed = true;
-            }
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip("Add another player build row");
-            }
-            ImGui::Spacing();
 
-            if (ImGui::Button("Up") && i > 0) {
-                std::swap(teambuilds[i - 1], teambuilds[i]);
-                builds_changed = true;
-            }
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip("Move the teambuild up in the list");
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Down") && i + 1 < teambuilds.size()) {
-                std::swap(teambuilds[i], teambuilds[i + 1]);
-                builds_changed = true;
-            }
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip("Move the teambuild down in the list");
-            }
-            ImGui::SameLine();
-            bool delete_tbuild = false;
-            if (ImGui::ConfirmButton("Delete", &delete_tbuild, "Delete Teambuild?\n\nAre you sure?\nThis operation cannot be undone.\n\n")) {
-                delete tbuild;
-                builds_changed = true;
-                ImGui::CloseCurrentPopup();
-            }
+    // Draw edit windows using the unified DrawEditWindow
+    for (size_t i = 0; i < teambuilds.size(); i++) {
+        if (!teambuilds[i].edit_open) continue;
+        TeamBuild& tbuild = teambuilds[i];
+
+        auto on_load = [](TeamBuild& tb, size_t j) {
+            Load(tb, j);
+        };
+        auto on_send = [](TeamBuild& tb, size_t j) {
+            Send(tb, j);
+        };
+        auto on_view = [](TeamBuild& tb, size_t j) {
+            if (j < tb.builds.size()) View(tb.builds[j]);
+        };
+
+        if (!tbuild.DrawEditWindow(i, teambuilds, builds_changed, on_load, on_send, on_view)) {
+            break; // teambuild deleted; vector modified
         }
-        ImGui::End();
-        ImGui::PopID();
     }
 }
 
@@ -1198,12 +915,11 @@ void BuildsWindow::Update(const float)
         LoadFromFile();
         order_by_changed = false;
     }
-    // if we open the window, load from file. If we close the window, save to file.
     static bool old_visible = false;
     bool cur_visible = false;
     cur_visible |= visible;
-    for (const auto tbuild : teambuilds) {
-        cur_visible |= tbuild->edit_open;
+    for (const auto& tbuild : teambuilds) {
+        cur_visible |= tbuild.edit_open;
     }
 
     if (cur_visible != old_visible) {
@@ -1255,7 +971,6 @@ void BuildsWindow::Initialize()
     GW::Chat::CreateCommand(&ChatCmd_HookEntry, L"loadbuild", CmdLoad);
     GW::Chat::CreateCommand(&ChatCmd_HookEntry, L"pingbuild", CmdPing);
     RegisterUIMessageCallback(&OnUIMessage_HookEntry, GW::UI::UIMessage::kSendLoadSkillTemplate, OnUIMessage);
-    //GW::CtoS::RegisterPacketCallback(&on_load_skills_entry, GAME_CMSG_SKILLBAR_LOAD, OnSkillbarLoad);
 }
 
 void BuildsWindow::DrawHelp()

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -38,13 +38,8 @@ namespace {
     GW::HookEntry OnRecvWhisper_Entry;
     GW::HookEntry OnOpenTemplate_Entry;
 
-
-
-
     clock_t send_timer = 0;
     clock_t kickall_timer = 0;
-
-
 
     struct CodeOnHero {
         enum Stage : uint8_t { Add, Load, Finished } stage = Add;
@@ -123,7 +118,7 @@ namespace {
 
     // Pool of received/detached teambuilds shown as standalone windows (not in the main list).
     // Entries are removed when their window is closed and no other owner holds the shared_ptr.
-    std::vector<std::shared_ptr<TeamHeroBuild>> detached_pool{};
+    std::vector<std::shared_ptr<TeamBuild>> detached_pool{};
 
     char whisper_target[128]{};
 
@@ -181,31 +176,6 @@ namespace {
         HeroID::GhostOfAlthea
     };
 
-    // Returns hero IDs sorted by name; re-sorts each frame until all names are decoded.
-    const std::vector<HeroID>& SortedHeroIDs()
-    {
-        static std::vector<HeroID> sorted;
-        static bool is_sorted = false;
-        if (!is_sorted) {
-            sorted.clear();
-            for (const auto id : HeroIndexToID) {
-                if (id != HeroID::NoHero) sorted.push_back(id);
-            }
-            bool all_decoded = true;
-            for (const auto id : sorted) {
-                if (Resources::GetHeroName(id)->string().empty()) {
-                    all_decoded = false;
-                    break;
-                }
-            }
-            std::ranges::sort(sorted, [](const HeroID a, const HeroID b) {
-                return _stricmp(Resources::GetHeroName(a)->string().c_str(), Resources::GetHeroName(b)->string().c_str()) < 0;
-            });
-            is_sorted = all_decoded;
-        }
-        return sorted;
-    }
-
     const size_t GetPlayerHeroCount()
     {
         size_t ret = 0;
@@ -234,10 +204,11 @@ namespace {
     {
         const auto packet = (GW::UI::UIPacket::kAddCustomChatLink*)wparam;
 
-        if (!(packet && packet->url && *packet->url && TeamBuildEncoder::IsEncodedTeamBuild(packet->url))) 
+        if (!(packet && packet->url && *packet->url && TeamBuildEncoder::IsEncodedTeamBuild(packet->url)))
             return;
 
-        TeamHeroBuild tbuild("", TextUtils::WStringToString(packet->url).c_str());
+        TeamBuild tbuild("", TextUtils::WStringToString(packet->url).c_str());
+        tbuild.has_hero_slots = true;
         if (!TeamBuildEncoder::EncodedToTeamBuild(packet->url, tbuild)) return;
 
         status->blocked = true;
@@ -265,7 +236,8 @@ namespace {
             return;
         }
 
-        auto tbuild = std::make_shared<TeamHeroBuild>(TextUtils::WStringToString(packet->label), ui_id);
+        auto tbuild = std::make_shared<TeamBuild>(TextUtils::WStringToString(packet->label), ui_id);
+        tbuild->has_hero_slots = true;
         if (!TeamBuildEncoder::EncodedToTeamBuild(packet->url, *tbuild)) return;
         status->blocked = true;
         tbuild->edit_open = tbuild->focus_next_frame = true;
@@ -274,14 +246,12 @@ namespace {
 
 } // namespace
 
-unsigned int TeamHeroBuild::cur_ui_id = 0;
-
-std::string HeroBuildsWindow::EncodeTeambuildToDaybreak(const TeamHeroBuild& tbuild)
+std::string HeroBuildsWindow::EncodeTeambuildToDaybreak(const TeamBuild& tbuild)
 {
     return TeamBuildEncoder::TeamBuildToDaybreak(tbuild);
 }
 
-bool HeroBuildsWindow::DecodeTeambuildFromDaybreak(const std::string& code, TeamHeroBuild& out)
+bool HeroBuildsWindow::DecodeTeambuildFromDaybreak(const std::string& code, TeamBuild& out)
 {
     return TeamBuildEncoder::DaybreakToTeamBuild(code, out);
 }
@@ -330,6 +300,7 @@ void HeroBuildsWindow::Initialize()
     ToolboxWindow::Initialize();
     send_timer = TIMER_INIT();
     skill_toggle_sprite = GwDatTextureModule::LoadTextureFromFileId(0x268f6);
+    TeamBuild::SetSkillToggleSprite(skill_toggle_sprite);
     GW::Chat::CreateCommand(&ChatCmd_HookEntry, L"heroteam", &CmdHeroTeamBuild);
     GW::Chat::CreateCommand(&ChatCmd_HookEntry, L"herobuild", &CmdHeroTeamBuild);
     GW::UI::RegisterUIMessageCallback(&OnOpenTemplate_Entry, GW::UI::UIMessage::kChatLinkClicked, OnChatLinkClicked);
@@ -362,14 +333,16 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
             const float& item_spacing = ImGui::GetStyle().ItemInnerSpacing.x;
 
             // Collect filtered builds, preserving order
-            std::vector<TeamHeroBuild*> filtered;
-            for (TeamHeroBuild& tbuild : teambuilds) {
+            std::vector<TeamBuild*> filtered;
+            for (TeamBuild& tbuild : teambuilds) {
                 if (filter_by_profession && player_profession != GW::Constants::Profession::None) {
-                    const auto& player_code = tbuild.builds[0].code;
-                    if (!player_code.empty()) {
-                        GW::SkillbarMgr::SkillTemplate t{};
-                        if (GW::SkillbarMgr::DecodeSkillTemplate(t, player_code.c_str()) && t.primary != player_profession) {
-                            continue;
+                    if (!tbuild.builds.empty()) {
+                        const auto& player_code = tbuild.builds[0].code;
+                        if (!player_code.empty()) {
+                            GW::SkillbarMgr::SkillTemplate t{};
+                            if (GW::SkillbarMgr::DecodeSkillTemplate(t, player_code.c_str()) && t.primary != player_profession) {
+                                continue;
+                            }
                         }
                     }
                 }
@@ -378,8 +351,8 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
 
             // Build ordered group list
             std::vector<std::string> group_order;
-            std::unordered_map<std::string, std::vector<TeamHeroBuild*>> by_group;
-            for (TeamHeroBuild* tbuild : filtered) {
+            std::unordered_map<std::string, std::vector<TeamBuild*>> by_group;
+            for (TeamBuild* tbuild : filtered) {
                 const std::string g(tbuild->group);
                 if (!by_group.contains(g)) {
                     by_group[g] = {};
@@ -388,7 +361,7 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                 by_group[g].push_back(tbuild);
             }
 
-            auto draw_teambuild_row = [&](TeamHeroBuild& tbuild) {
+            auto draw_teambuild_row = [&](TeamBuild& tbuild) {
                 ImGui::PushID(tbuild.ui_id.c_str());
                 ImGui::GetStyle().ButtonTextAlign = ImVec2(0.0f, 0.5f);
                 if (ImGui::Button(tbuild.name.c_str(), ImVec2(ImGui::GetContentRegionAvail().x - item_spacing - btn_width, 0))) {
@@ -403,7 +376,7 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                     ImGui::SetTooltip([&tbuild, this]() {
                         for (size_t ti = 0; ti < tbuild.builds.size(); ti++) {
                             const auto& build = tbuild.builds[ti];
-                            if (build.code[0] == 0 && build.name[0] == 0) continue;
+                            if (build.code.empty() && build.name.empty()) continue;
                             ImGui::Spacing();
                             std::string name;
                             HeroBuildName(tbuild, ti, &name);
@@ -432,7 +405,7 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
             for (const auto& group_name : group_order) {
                 auto& group_builds = by_group[group_name];
                 if (group_name.empty()) {
-                    for (TeamHeroBuild* tbuild : group_builds) {
+                    for (TeamBuild* tbuild : group_builds) {
                         draw_teambuild_row(*tbuild);
                     }
                 }
@@ -441,7 +414,7 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                     const bool open = ImGui::CollapsingHeader(group_name.c_str(), ImGuiTreeNodeFlags_DefaultOpen);
                     if (open) {
                         ImGui::Indent();
-                        for (TeamHeroBuild* tbuild : group_builds) {
+                        for (TeamBuild* tbuild : group_builds) {
                             draw_teambuild_row(*tbuild);
                         }
                         ImGui::Unindent();
@@ -450,25 +423,30 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                 }
             }
             if (ImGui::Button("Add Teambuild", ImVec2(ImGui::GetContentRegionAvail().x, 0))) {
-                auto tb = TeamHeroBuild(std::format("My New Hero Teambuild, {}", TextUtils::GetFormattedDateTime()));
+                TeamBuild tb(std::format("My New Hero Teambuild, {}", TextUtils::GetFormattedDateTime()));
+                tb.has_hero_slots = true;
                 tb.edit_open = true;
                 GW::SkillbarMgr::SkillTemplate skill_template;
                 for (auto i = 0u; i < 8; i++) {
-                    if (!GW::SkillbarMgr::GetSkillTemplate(GW::PartyMgr::GetPartyMemberAgentId(i), skill_template)) continue;
-                    char buf[64]{};
-                    if (!GW::SkillbarMgr::EncodeSkillTemplate(skill_template, buf, _countof(buf))) continue;
-                    const auto party_info = GW::PartyMgr::GetPartyInfo();
-                    const auto cur_hero_id = i > 0 && party_info && party_info->heroes.size() >= i ? party_info->heroes[i - 1].hero_id : HeroID::NoHero;
-                    const GW::HeroFlag* flag = cur_hero_id != HeroID::NoHero ? GetHeroFlagInfo(cur_hero_id) : nullptr;
-                    tb.builds[i] = HeroBuild("", buf, cur_hero_id, 0, static_cast<uint32_t>(flag ? flag->hero_behavior : GW::HeroBehavior::Guard));
+                    Build build;
+                    if (GW::SkillbarMgr::GetSkillTemplate(GW::PartyMgr::GetPartyMemberAgentId(i), skill_template)) {
+                        char buf[64]{};
+                        if (GW::SkillbarMgr::EncodeSkillTemplate(skill_template, buf, _countof(buf))) {
+                            const auto party_info = GW::PartyMgr::GetPartyInfo();
+                            const auto cur_hero_id = i > 0 && party_info && party_info->heroes.size() >= i ? party_info->heroes[i - 1].hero_id : HeroID::NoHero;
+                            const GW::HeroFlag* flag = cur_hero_id != HeroID::NoHero ? GetHeroFlagInfo(cur_hero_id) : nullptr;
+                            build = Build("", buf, cur_hero_id, 0, static_cast<uint32_t>(flag ? flag->hero_behavior : GW::HeroBehavior::Guard));
+                        }
+                    }
+                    tb.builds.push_back(std::move(build));
                 }
 
                 builds_changed = true;
-                teambuilds.push_back(tb);
+                teambuilds.push_back(std::move(tb));
             }
             /* Code for copying a teambuild */
             std::vector<const char*> names(teambuilds.size(), "\0");
-            std::ranges::transform(teambuilds, names.begin(), [](const TeamHeroBuild& tb) {
+            std::ranges::transform(teambuilds, names.begin(), [](const TeamBuild& tb) {
                 return tb.name.c_str();
             });
             if (const auto num_elements = names.size()) {
@@ -479,290 +457,50 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                 ImGui::PopItemWidth();
                 ImGui::SameLine(0, ImGui::GetStyle().ItemInnerSpacing.x);
                 if (ImGui::Button("Copy##1", ImVec2(60.0f, 0))) {
-                    TeamHeroBuild new_tb = teambuilds[selected_teambuild];
+                    TeamBuild new_tb = teambuilds[selected_teambuild];
                     new_tb.name += " (Copy)";
                     builds_changed = true;
-                    teambuilds.push_back(new_tb);
+                    teambuilds.push_back(std::move(new_tb));
                 }
             }
         }
         ImGui::End();
     }
 
+    // Draw edit windows for each open teambuild using unified DrawEditWindow
     for (size_t i = 0; i < teambuilds.size(); i++) {
-        if (!teambuilds[i].edit_open) {
-            continue;
-        }
-        TeamHeroBuild& tbuild = teambuilds[i];
-        const auto winname = std::format("{}###herobuild{}", tbuild.name, tbuild.ui_id);
-        ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
-        ImGui::SetNextWindowSize(ImVec2(500, 0), ImGuiCond_FirstUseEver);
-        if (ImGui::Begin(winname.c_str(), &tbuild.edit_open)) {
-            constexpr size_t name_buffer_size = 128;
-            builds_changed |= ImGui::InputText("Hero Build Name", tbuild.name, name_buffer_size);
-            builds_changed |= ImGui::InputText("Group", tbuild.group, name_buffer_size);
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip("Assign to a group. Builds sharing a group name are shown together under a collapsible header.");
-            }
-            const float btn_width = 50.0f * ImGui::FontScale();
-            const float icon_btn_width = btn_width / 1.75f;
-            const float panel_width = btn_width + 12.0f;
-            const float item_spacing = ImGui::GetStyle().ItemInnerSpacing.x;
-            const float text_item_width = (ImGui::GetContentRegionAvail().x - btn_width - btn_width - btn_width - panel_width - icon_btn_width - item_spacing * 4) / 3;
-            float offset = btn_width;
-            ImGui::SetCursorPosX(offset);
-            ImGui::Text("Name");
-            ImGui::SameLine(offset += text_item_width + item_spacing);
-            ImGui::Text("Template");
-            for (size_t j = 0; j < tbuild.builds.size(); ++j) {
-                offset = btn_width;
-                HeroBuild& build = tbuild.builds[j];
-                ImGui::PushID(static_cast<int>(j));
-                if (j == 0) {
-                    ImGui::Text("P");
-                }
-                else {
-                    ImGui::Text("H#%d", j);
-                }
-                ImGui::SameLine(offset);
-                ImGui::PushItemWidth(text_item_width);
-                builds_changed |= ImGui::InputText("###name", build.name, name_buffer_size);
-                if (ImGui::IsItemHovered() && !build.name.empty()) {
-                    ImGui::SetTooltip("%s", build.name.c_str());
-                }
-                ImGui::SameLine(offset += text_item_width + item_spacing);
-                builds_changed |= ImGui::InputText("###code", build.code, name_buffer_size);
-                if (ImGui::IsItemHovered()) {
-                    ImGui::SetTooltip([&]() {
-                        GuiUtils::DrawSkillbar(build.code.c_str());
-                    });
-                }
-                ImGui::SameLine(offset += text_item_width + item_spacing);
-                if (j == 0) {
-                    ImGui::TextDisabled("Player");
-                    ImGui::SameLine(offset += text_item_width + item_spacing + btn_width + 10.0f + icon_btn_width + item_spacing * 2);
-                    ImGui::PopItemWidth();
-                }
-                else {
-                    {
-                        const auto& sorted_heroes = SortedHeroIDs();
-                        const auto hero_it = std::ranges::find(sorted_heroes, build.hero_id);
-                        int combo_idx = hero_it != sorted_heroes.end() ? static_cast<int>(std::distance(sorted_heroes.begin(), hero_it)) : -1;
-                        if (ImGui::MyCombo(
-                                "###heroid", "Choose Hero", &combo_idx,
-                                [](void*, const int idx, const char** out_text) -> bool {
-                                    const auto& heroes = SortedHeroIDs();
-                                    if (idx < 0 || idx >= static_cast<int>(heroes.size())) return false;
-                                    *out_text = Resources::GetHeroName(heroes[idx])->string().c_str();
-                                    return true;
-                                },
-                                nullptr, static_cast<int>(sorted_heroes.size())
-                            )) {
-                            build.hero_id = combo_idx >= 0 && combo_idx < static_cast<int>(sorted_heroes.size()) ? sorted_heroes[combo_idx] : HeroID::NoHero;
-                            builds_changed = true;
-                        }
-                    }
-                    ImGui::PopItemWidth();
-                    ImGui::SameLine(offset += text_item_width + item_spacing);
-                    const auto* icon = reinterpret_cast<const char*>(build.show_panel ? ICON_FA_EYE : ICON_FA_EYE_SLASH);
-                    if (ImGui::Button(icon, ImVec2(icon_btn_width, 0))) {
-                        build.show_panel = !build.show_panel;
-                        builds_changed = true;
-                    }
-                    if (ImGui::IsItemHovered()) {
-                        ImGui::SetTooltip(build.show_panel ? "Hero panel: Show" : "Hero panel: Hide");
-                    }
-                    ImGui::SameLine(offset += icon_btn_width + item_spacing);
-                    auto hero_stance_icon = ICON_FA_SHIELD_ALT;
-                    auto hero_stance_tooltip = "Hero behaviour: Guard";
-                    switch (build.behavior) {
-                        case 2:
-                            hero_stance_icon = reinterpret_cast<const char*>(ICON_FA_DOVE);
-                            hero_stance_tooltip = "Hero behaviour: Avoid Combat";
-                            break;
-                        case 0:
-                            hero_stance_icon = reinterpret_cast<const char*>(ICON_FA_FIST_RAISED);
-                            hero_stance_tooltip = "Hero behaviour: Fight";
-                            break;
-                    }
-                    if (ImGui::Button(hero_stance_icon, ImVec2(icon_btn_width, 0))) {
-                        build.behavior++;
-                        if (build.behavior > 2) {
-                            build.behavior = 0;
-                        }
-                        builds_changed = true;
-                    }
-                    if (ImGui::IsItemHovered()) {
-                        ImGui::SetTooltip(hero_stance_tooltip);
-                    }
-                    ImGui::SameLine(offset += icon_btn_width + item_spacing);
+        if (!teambuilds[i].edit_open) continue;
+        TeamBuild& tbuild = teambuilds[i];
 
-                    int enabled_count = 8;
-                    for (int k = 0; k < 8; k++) {
-                        if ((build.disabled_skills >> k) & 1) {
-                            enabled_count--;
-                        }
-                    }
-                    char skills_label[8];
-                    snprintf(skills_label, sizeof(skills_label), "%d/8", enabled_count);
-                    if (ImGui::Button(skills_label, ImVec2(icon_btn_width, 0))) {
-                        ImGui::OpenPopup("SkillsPopup");
-                    }
-                    if (ImGui::IsItemHovered()) {
-                        ImGui::SetTooltip("Click to toggle which skills are disabled when loading this build");
-                    }
-                    if (ImGui::BeginPopup("SkillsPopup")) {
-                        GW::SkillbarMgr::SkillTemplate skill_template{};
-                        const bool decoded = !build.code.empty() && GW::SkillbarMgr::DecodeSkillTemplate(skill_template, build.code.c_str());
-
-                        constexpr float skill_btn_px = 48.0f;
-                        const ImVec2 btn_size(skill_btn_px, skill_btn_px);
-
-                        for (int k = 0; k < 8; k++) {
-                            if (k > 0) {
-                                ImGui::SameLine(0, 0);
-                            }
-
-                            const bool is_disabled = (build.disabled_skills >> k) & 1;
-                            const auto skill_id = decoded ? skill_template.skills[k] : GW::Constants::SkillID::No_Skill;
-                            auto* skill_tex = *Resources::GetSkillImage(skill_id);
-
-                            ImGui::PushID(k);
-                            const ImVec2 pos = ImGui::GetCursorScreenPos();
-
-                            if (ImGui::InvisibleButton("##skill_slot", btn_size)) {
-                                if (is_disabled) {
-                                    build.disabled_skills &= static_cast<uint8_t>(~(1u << k));
-                                }
-                                else {
-                                    build.disabled_skills |= static_cast<uint8_t>(1u << k);
-                                }
-                                builds_changed = true;
-                            }
-                            const bool hovered = ImGui::IsItemHovered();
-
-                            const ImVec2 p_max(pos.x + skill_btn_px, pos.y + skill_btn_px);
-                            auto* draw_list = ImGui::GetWindowDrawList();
-
-                            if (skill_id != GW::Constants::SkillID::No_Skill && skill_tex) {
-                                draw_list->AddImage(reinterpret_cast<ImTextureID>(skill_tex), pos, p_max);
-                            }
-                            else {
-                                draw_list->AddRectFilled(pos, p_max, IM_COL32(50, 50, 50, 255));
-                            }
-
-                            // Dark overlay then semi-transparent cross to clearly show disabled state
-                            if (is_disabled) {
-                                draw_list->AddRectFilled(pos, p_max, IM_COL32(0, 0, 0, 140));
-                                if (skill_toggle_sprite && *skill_toggle_sprite) {
-                                    // Bottom-left of 0x268f6 sprite sheet (col 0, row 1): semi-transparent cross
-                                    draw_list->AddImage(reinterpret_cast<ImTextureID>(*skill_toggle_sprite), pos, p_max, ImVec2(0.0f, 0.5f), ImVec2(0.5f, 1.0f));
-                                }
-                            }
-
-                            if (hovered) {
-                                draw_list->AddRect(pos, p_max, IM_COL32(255, 255, 255, 200), 0.0f, 0, 2.0f);
-                            }
-
-                            ImGui::PopID();
-                        }
-                        ImGui::EndPopup();
-                    }
-                    ImGui::SameLine(offset += icon_btn_width + item_spacing);
-                }
-
-                if (ImGui::Button(ImGui::GetIO().KeyCtrl ? "Send" : "View", ImVec2(btn_width, 0))) {
-                    if (ImGui::GetIO().KeyCtrl) {
-                        Send(tbuild, j);
-                    }
-                    else {
-                        View(tbuild, j);
-                    }
-                }
-                if (ImGui::IsItemHovered()) {
-                    ImGui::SetTooltip(ImGui::GetIO().KeyCtrl ? "Click to send to team chat" : "Click to view build. Ctrl + Click to send to chat.");
-                }
-                ImGui::SameLine(offset += btn_width + item_spacing);
-                if (ImGui::Button("Load", ImVec2(btn_width, 0))) {
-                    Load(tbuild, j);
-                }
-                if (j == 0) {
-                    if (ImGui::IsItemHovered()) {
-                        ImGui::SetTooltip("Load Build on Player");
-                    }
-                }
-                else {
-                    if (ImGui::IsItemHovered()) {
-                        ImGui::SetTooltip("Load Build on Hero");
-                    }
-                }
-                ImGui::PopID();
-            }
-            ImGui::Spacing();
-
-            if (ImGui::SmallButton("Up") && i > 0) {
-                std::swap(teambuilds[i - 1], teambuilds[i]);
-                builds_changed = true;
-            }
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip("Move the teambuild up in the list");
-            }
-            ImGui::SameLine();
-            if (ImGui::SmallButton("Down") && i + 1 < static_cast<int>(teambuilds.size())) {
-                std::swap(teambuilds[i], teambuilds[i + 1]);
-                builds_changed = true;
-            }
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip("Move the teambuild down in the list");
-            }
-            ImGui::SameLine();
-            ImGui::SmallConfirmButton(
-                "Delete", "Are you sure?\nThis operation cannot be undone.\n\n",
-                [](bool result, void* wparam) {
-                    if (!result) return;
-                    auto& instance = Instance();
-                    uint32_t idx = (uint32_t)wparam;
-                    if (idx < instance.teambuilds.size()) {
-                        instance.teambuilds.erase(instance.teambuilds.begin() + idx);
-                        instance.builds_changed = true;
-                    }
-                },
-                (void*)i
-            );
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip("Delete the teambuild");
-            }
-            ImGui::SameLine();
-            ImGui::PushItemWidth(110.0f);
-            const static char* modes[] = {"Don't change", "Normal Mode", "Hard Mode"};
-            ImGui::Combo("Mode", &tbuild.mode, modes, 3);
-            ImGui::PopItemWidth();
-            ImGui::SameLine(ImGui::GetContentRegionAvail().x + ImGui::GetCursorPosX() - 40);
-            if (ImGui::Button("Close", ImVec2(ImGui::GetContentRegionAvail().x, 0))) {
-                tbuild.edit_open = false;
-            }
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip("Close this window");
-            }
-
-            ImGui::Spacing();
-            ImGui::Separator();
-            if (ImGui::Button("Send to chat")) {
-                const auto chat_msg = TeamBuildEncoder::ToChatMessage(tbuild);
+        auto on_load = [this](TeamBuild& tb, size_t j) {
+            if (j < tb.builds.size()) Load(tb, j);
+        };
+        auto on_send = [this](TeamBuild& tb, size_t j) {
+            if (j == SIZE_MAX) {
+                const auto chat_msg = TeamBuildEncoder::ToChatMessage(tb);
                 if (!chat_msg.empty()) {
                     GW::GameThread::Enqueue([cpy = chat_msg]() {
                         GW::UI::SendUIMessage(GW::UI::UIMessage::kAppendMessageToChat, (void*)cpy.c_str());
                     });
                 }
             }
+            else {
+                Send(tb, j);
+            }
+        };
+        auto on_view = [](TeamBuild& tb, size_t j) {
+            View(tb, j);
+        };
+
+        if (!tbuild.DrawEditWindow(i, teambuilds, builds_changed, on_load, on_send, on_view)) {
+            break; // teambuild was deleted; teambuilds vector modified
         }
-        ImGui::End();
     }
 
     // Draw detached teambuild windows (received builds not in the main list).
     // Build names are lazily populated with the elite skill from each slot.
     for (auto& tbuild_ptr : detached_pool) {
-        TeamHeroBuild& tbuild = *tbuild_ptr;
+        TeamBuild& tbuild = *tbuild_ptr;
         if (!tbuild.edit_open) continue;
 
         const auto winname = std::format("{}###detached_{}", tbuild.name, tbuild.ui_id);
@@ -776,11 +514,11 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
         if (ImGui::Begin(winname.c_str(), &tbuild.edit_open)) {
             for (size_t j = 0; j < tbuild.builds.size(); j++) {
                 const auto& build = tbuild.builds[j];
-                if (!build.code[0] && build.hero_id == HeroID::NoHero) continue;
+                if (build.code.empty() && build.hero_id == HeroID::NoHero) continue;
                 std::string disp_name;
                 HeroBuildName(tbuild, j, &disp_name);
                 if (!disp_name.empty()) ImGui::TextUnformatted(disp_name.c_str());
-                if (build.code[0]) GuiUtils::DrawSkillbar(build.code.c_str(), false);
+                if (!build.code.empty()) GuiUtils::DrawSkillbar(build.code.c_str(), false);
                 ImGui::Spacing();
             }
             ImGui::Separator();
@@ -790,7 +528,7 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
             if (ImGui::IsItemHovered()) ImGui::SetTooltip("Load all builds onto your heroes");
             ImGui::SameLine();
             if (ImGui::Button("Add to My Builds")) {
-                TeamHeroBuild copy = tbuild;
+                TeamBuild copy = tbuild;
                 copy.edit_open = false;
                 teambuilds.push_back(std::move(copy));
                 builds_changed = true;
@@ -812,7 +550,7 @@ HeroBuildsWindow::~HeroBuildsWindow() {
     delete inifile;
 }
 
-void HeroBuildsWindow::View(const TeamHeroBuild& tbuild, const size_t idx)
+void HeroBuildsWindow::View(const TeamBuild& tbuild, const size_t idx)
 {
     if (idx >= tbuild.builds.size()) {
         return;
@@ -835,15 +573,15 @@ void HeroBuildsWindow::View(const TeamHeroBuild& tbuild, const size_t idx)
     });
 }
 
-void HeroBuildsWindow::Send(const TeamHeroBuild& tbuild)
+void HeroBuildsWindow::Send(const TeamBuild& tbuild)
 {
     if (!std::string(tbuild.name).empty()) {
         send_queue.push(tbuild.name);
     }
     for (size_t i = 0; i < tbuild.builds.size(); i++) {
         if (i == 0) {
-            const HeroBuild& build = tbuild.builds[i];
-            if (build.code[0] == 0 && build.name[0] == 0) {
+            const Build& build = tbuild.builds[i];
+            if (build.code.empty() && build.name.empty()) {
                 continue; // Player build is empty.
             }
         }
@@ -851,12 +589,12 @@ void HeroBuildsWindow::Send(const TeamHeroBuild& tbuild)
     }
 }
 
-void HeroBuildsWindow::Send(const TeamHeroBuild& tbuild, const size_t idx)
+void HeroBuildsWindow::Send(const TeamBuild& tbuild, const size_t idx)
 {
     if (idx >= tbuild.builds.size()) {
         return;
     }
-    const HeroBuild& build = tbuild.builds[idx];
+    const Build& build = tbuild.builds[idx];
     std::string build_name;
     HeroBuildName(tbuild, idx, &build_name);
     if (build_name.empty()) {
@@ -865,17 +603,18 @@ void HeroBuildsWindow::Send(const TeamHeroBuild& tbuild, const size_t idx)
     const auto msg = build.code.empty() ? build_name : std::format("[{};{}]", build_name, build.code);
     if (!msg.empty()) send_queue.push(msg);
 }
-void HeroBuildsWindow::HeroBuildName(const TeamHeroBuild& tbuild, const size_t idx, std::string* out)
+
+void HeroBuildsWindow::HeroBuildName(const TeamBuild& tbuild, const size_t idx, std::string* out)
 {
     if (idx >= tbuild.builds.size()) {
         return;
     }
-    const HeroBuild& build = tbuild.builds[idx];
+    const Build& build = tbuild.builds[idx];
     const auto& code = build.code;
     const auto id = idx > 0 ? build.hero_id : HeroID::NoHero;
     const auto hero_name = idx == 0 ? "Player" : Resources::GetHeroName(id)->string();
-    const auto name = build.name[0] ? build.name : build.GetFallbackBuildName();
-    if (name.empty() && !code[0] && id == HeroID::NoHero) {
+    const auto name = !build.name.empty() ? build.name : build.GetFallbackBuildName();
+    if (name.empty() && code.empty() && id == HeroID::NoHero) {
         return;
     }
     *out = std::format("{} ({})", name, hero_name);
@@ -896,7 +635,7 @@ void HeroBuildsWindow::Load(const size_t idx)
     }
 }
 
-void HeroBuildsWindow::Load(const TeamHeroBuild& tbuild)
+void HeroBuildsWindow::Load(const TeamBuild& tbuild)
 {
     if (GW::Map::GetInstanceType() != GW::Constants::InstanceType::Outpost) {
         return;
@@ -914,7 +653,7 @@ void HeroBuildsWindow::Load(const TeamHeroBuild& tbuild)
     send_timer = TIMER_INIT(); // give GW time to update the hero structs after adding them.
 }
 
-void HeroBuildsWindow::Load(const TeamHeroBuild& tbuild, const size_t idx)
+void HeroBuildsWindow::Load(const TeamBuild& tbuild, const size_t idx)
 {
     if (idx >= tbuild.builds.size()) {
         return;
@@ -922,7 +661,7 @@ void HeroBuildsWindow::Load(const TeamHeroBuild& tbuild, const size_t idx)
     if (GW::Map::GetInstanceType() != GW::Constants::InstanceType::Outpost) {
         return;
     }
-    const HeroBuild& build = tbuild.builds[idx];
+    const Build& build = tbuild.builds[idx];
     const std::string code(build.code);
 
     if (idx == 0) {
@@ -932,7 +671,7 @@ void HeroBuildsWindow::Load(const TeamHeroBuild& tbuild, const size_t idx)
         }
     }
     else if (build.hero_id != HeroID::NoHero) {
-        pending_hero_loads.push_back({code.c_str(), build.hero_id, build.show_panel, build.behavior, build.disabled_skills});
+        pending_hero_loads.push_back({code.c_str(), build.hero_id, build.show_panel ? 1 : 0, build.behavior, build.disabled_skills});
     }
 }
 
@@ -992,7 +731,7 @@ void HeroBuildsWindow::Update(float)
     static bool old_visible = false;
     bool cur_visible = false;
     cur_visible |= visible;
-    for (const TeamHeroBuild& tbuild : teambuilds) {
+    for (const TeamBuild& tbuild : teambuilds) {
         cur_visible |= tbuild.edit_open;
     }
 
@@ -1020,12 +759,12 @@ void CHAT_CMD_FUNC(HeroBuildsWindow::CmdHeroTeamBuild)
         argBuildname.append(argv[i]);
     }
     const std::string argBuildName_s = TextUtils::WStringToString(argBuildname);
-    const TeamHeroBuild* found = Instance().GetTeambuildByName(argBuildName_s);
+    const TeamBuild* found = Instance().GetTeambuildByName(argBuildName_s);
     if (!found) {
         Log::ErrorW(L"No hero build found for %s", argBuildname.c_str());
         return;
     }
-    const TeamHeroBuild& tbuild = *found;
+    const TeamBuild& tbuild = *found;
     Instance().Load(tbuild);
 }
 
@@ -1066,7 +805,8 @@ void HeroBuildsWindow::LoadFromFile()
     for (const ToolboxIni::Entry& entry : entries) {
         const char* section = entry.pItem;
 
-        TeamHeroBuild tb(inifile->GetValue(section, "buildname", ""));
+        TeamBuild tb(inifile->GetValue(section, "buildname", ""));
+        tb.has_hero_slots = true;
         tb.mode = inifile->GetLongValue(section, "mode", false);
         tb.group = inifile->GetValue(section, "group", "");
 
@@ -1103,13 +843,10 @@ void HeroBuildsWindow::LoadFromFile()
             const auto show_panel = inifile->GetLongValue(section, showpanelkey, 0);
             const uint32_t behavior = static_cast<uint32_t>(inifile->GetLongValue(section, behaviorkey, 1));
             const uint8_t disabled_skills = static_cast<uint8_t>(inifile->GetLongValue(section, dskillskey, 0));
-            tb.builds[i] = HeroBuild(nameval, templateval, hero_id, show_panel == 1 ? 1 : 0, behavior, disabled_skills);
+            tb.builds.push_back(Build(nameval, templateval, hero_id, show_panel == 1 ? 1 : 0, behavior, disabled_skills));
         }
 
-        // Check the binary to see if we should instead take the ptr to read everything to avoid the copy
-        // But this might not matter at all, because we would do copy anyway for each element and hence
-        // as much copy.
-        teambuilds.push_back(tb);
+        teambuilds.push_back(std::move(tb));
     }
 
     builds_changed = false;
@@ -1124,15 +861,15 @@ void HeroBuildsWindow::SaveToFile() const
 
         // then save
         for (size_t i = 0; i < teambuilds.size(); i++) {
-            const TeamHeroBuild& tbuild = teambuilds[i];
+            const TeamBuild& tbuild = teambuilds[i];
             char section[buffer_size];
             snprintf(section, buffer_size, "builds%03d", i);
             inifile->SetValue(section, "buildname", tbuild.name.c_str());
             inifile->SetLongValue(section, "mode", tbuild.mode);
-            if (!tbuild.group.empty()) 
+            if (!tbuild.group.empty())
                 inifile->SetValue(section, "group", tbuild.group.c_str());
             for (size_t j = 0; j < tbuild.builds.size(); ++j) {
-                const HeroBuild& build = tbuild.builds[j];
+                const Build& build = tbuild.builds[j];
 
                 char namekey[buffer_size];
                 char templatekey[buffer_size];
@@ -1149,7 +886,7 @@ void HeroBuildsWindow::SaveToFile() const
                 inifile->SetValue(section, namekey, build.name.c_str());
                 inifile->SetValue(section, templatekey, build.code.c_str());
                 inifile->SetLongValue(section, heroidkey, static_cast<long>(build.hero_id));
-                inifile->SetLongValue(section, showpanelkey, build.show_panel);
+                inifile->SetLongValue(section, showpanelkey, build.show_panel ? 1 : 0);
                 inifile->SetLongValue(section, behaviorkey, build.behavior);
                 inifile->SetLongValue(section, dskillskey, build.disabled_skills);
             }
@@ -1159,7 +896,7 @@ void HeroBuildsWindow::SaveToFile() const
     }
 }
 
-TeamHeroBuild* HeroBuildsWindow::GetTeambuildByName(const std::string& build_name_search)
+TeamBuild* HeroBuildsWindow::GetTeambuildByName(const std::string& build_name_search)
 {
     const std::string compare = TextUtils::ToLower(TextUtils::RemovePunctuation(build_name_search));
     for (auto& tb : teambuilds) {

--- a/GWToolboxdll/Windows/HeroBuildsWindow.h
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.h
@@ -16,7 +16,6 @@
 
 class HeroBuildsWindow : public ToolboxWindow {
 
-
     HeroBuildsWindow();
 
     ~HeroBuildsWindow();
@@ -49,9 +48,9 @@ public:
     void LoadFromFile();
     void SaveToFile() const;
 
-    void Load(unsigned int idx);
-    [[nodiscard]] const char* BuildName(unsigned int idx) const;
-    [[nodiscard]] unsigned int BuildCount() const { return teambuilds.size(); }
+    void Load(size_t idx);
+    [[nodiscard]] const char* BuildName(size_t idx) const;
+    [[nodiscard]] unsigned int BuildCount() const { return static_cast<unsigned int>(teambuilds.size()); }
 
     static void CHAT_CMD_FUNC(CmdHeroTeamBuild);
 
@@ -66,23 +65,20 @@ private:
     bool filter_by_profession = false;
 
     // Load a teambuild
-    void Load(const TeamHeroBuild& tbuild);
+    void Load(const TeamBuild& tbuild);
     // Load a specific build from a teambuild
-    void Load(const TeamHeroBuild& tbuild, unsigned int idx);
-    void Send(const TeamHeroBuild& tbuild, size_t idx);
-    void Send(const TeamHeroBuild& tbuild);
-    static void View(const TeamHeroBuild& tbuild, unsigned int idx);
-    static void HeroBuildName(const TeamHeroBuild& tbuild, unsigned int idx, std::string* out);
-    TeamHeroBuild* GetTeambuildByName(const std::string& argBuildname);
+    void Load(const TeamBuild& tbuild, size_t idx);
+    void Send(const TeamBuild& tbuild, size_t idx);
+    void Send(const TeamBuild& tbuild);
+    static void View(const TeamBuild& tbuild, size_t idx);
+    static void HeroBuildName(const TeamBuild& tbuild, size_t idx, std::string* out);
+    TeamBuild* GetTeambuildByName(const std::string& argBuildname);
 
     // Encode a teambuild into a Daybreak party loadout base64 string (header=15, type=1, version=1).
-    static std::string EncodeTeambuildToDaybreak(const TeamHeroBuild& tbuild);
+    static std::string EncodeTeambuildToDaybreak(const TeamBuild& tbuild);
     // Decode a Daybreak party loadout base64 string into a teambuild.
-    static bool DecodeTeambuildFromDaybreak(const std::string& code, TeamHeroBuild& out);
+    static bool DecodeTeambuildFromDaybreak(const std::string& code, TeamBuild& out);
 
     bool builds_changed = false;
-    std::vector<TeamHeroBuild> teambuilds{};
-
-
-
+    std::vector<TeamBuild> teambuilds{};
 };


### PR DESCRIPTION
Introduces unified `Build` and `TeamBuild` structs in `Utils/TeamBuild.h/cpp` that consolidate the separate types used by `BuildsWindow` and `HeroBuildsWindow` into a single shared representation, as requested in #issue2037.

Generates with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/gwdevhub/GWToolboxpp/actions/runs/26017529937