### PR TITLE
Add "Send all builds in chat" button with confirmation, rename "Send to chat"

### DIFF
--- a/GWToolboxdll/Utils/TeamBuild.cpp
+++ b/GWToolboxdll/Utils/TeamBuild.cpp
@@ -628,15 +628,26 @@ bool TeamBuild::DrawEditWindow(
             edit_open = false;
         }
         if (ImGui::IsItemHovered()) ImGui::SetTooltip("Close this window");
+    }
 
-        // "Send to chat" is a teambuild-level action that requires encoding.
-        // Call on_send with SIZE_MAX as a sentinel to indicate the whole teambuild.
-        if (on_send) {
-            ImGui::Spacing();
-            ImGui::Separator();
-            if (ImGui::Button("Send to chat")) {
-                on_send(*this, SIZE_MAX);
-            }
+    if (on_send) {
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::Spacing();
+        if (ImGui::Button("Send Teambuild code to chat")) {
+            on_send(*this, SIZE_MAX);
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Send the encoded teambuild link to team chat");
+        }
+        ImGui::SameLine();
+        if (ImGui::ConfirmButton("Send all builds in chat", &send_all_confirming_,
+                "Send All Builds to Chat\n\nThis will send each build as a separate message in team chat.\nAre you sure?")) {
+            on_send(*this, SIZE_MAX - 1);
+            send_all_confirming_ = false;
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Send all builds as individual skill template links in team chat");
         }
     }
 

--- a/GWToolboxdll/Utils/TeamBuild.h
+++ b/GWToolboxdll/Utils/TeamBuild.h
@@ -96,6 +96,7 @@ struct TeamBuild {
 
 private:
     int editing_build_idx_ = -1; // which build row is expanded (player-builds layout)
+    bool send_all_confirming_ = false;
 
     void DrawPlayerBuildsContent(bool& builds_changed,
                                  const BuildAction& on_load,

--- a/GWToolboxdll/Windows/BuildsWindow.cpp
+++ b/GWToolboxdll/Windows/BuildsWindow.cpp
@@ -888,7 +888,8 @@ void BuildsWindow::Draw(IDirect3DDevice9* pDevice)
             Load(tb, j);
         };
         auto on_send = [](TeamBuild& tb, size_t j) {
-            Send(tb, j);
+            if (j >= SIZE_MAX - 1) Send(tb);
+            else Send(tb, j);
         };
         auto on_view = [](TeamBuild& tb, size_t j) {
             if (j < tb.builds.size()) View(tb.builds[j]);

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -484,6 +484,9 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                     });
                 }
             }
+            else if (j == SIZE_MAX - 1) {
+                Send(tb);
+            }
             else {
                 Send(tb, j);
             }


### PR DESCRIPTION
Renames "Send to chat" to "Send Teambuild code to chat" and adds a new "Send all builds in chat" button using `ImGui::ConfirmButton` to prevent accidental chat spam, as requested in #2037.

Both buttons now appear on hero and player versions of the teambuild edit window.

Generated with [Claude Code](https://claude.ai/code)) • [View job run](https://github.com/gwdevhub/GWToolboxpp/actions/runs/26021339769) • [`claude/issue-2037-20260518-0808`](https://github.com/gwdevhub/GWToolboxpp/tree/claude/issue-2037-20260518-0808