### PR TITLE
Add Nicholas crafting ingredient tooltip for Skale Fins and Drake Flesh

### DIFF
--- a/GWToolboxdll/Constants/EncStrings.h
+++ b/GWToolboxdll/Constants/EncStrings.h
@@ -165,6 +165,7 @@ namespace GW {
         static const wchar_t* CelestialEssences = L"\x570A\x9453\x84A6\x64D4";
         static const wchar_t* PhantomResidue = L"\x2937";
         static const wchar_t* DrakeKabob = L"\x8101\x42D1\xFB15\xD39E\x5A26";
+        static const wchar_t* ChunkOfDrakeFlesh = L"\x108\x107" L"Chunk of Drake Flesh\x1"; // TODO: find the real enc name in-game
         static const wchar_t* AmberChunks = L"\x55D0\xF8B7\xB108\x6018";
         static const wchar_t* GlowingHearts = L"\x2914";
         static const wchar_t* SaurianBones = L"\x8102\x26D8\xB5B9\x9AF6\x42D6";

--- a/GWToolboxdll/Modules/ItemTooltipModule.cpp
+++ b/GWToolboxdll/Modules/ItemTooltipModule.cpp
@@ -195,13 +195,21 @@ namespace {
         }
         else {
             const auto nicholas_info = DailyQuests::GetNicholasItemInfo(item->name_enc);
-            if (!nicholas_info) return;
-            const auto collection_time = DailyQuests::GetTimestampFromNicholasTheTraveller(nicholas_info);
-            if (collection_time <= current_time) {
-                text = std::format(L"Nicholas The Traveler collects {} of these right now!", nicholas_info->quantity);
+            const auto ingredient_info = nicholas_info ? nullptr : DailyQuests::GetNicholasIngredientInfo(item->name_enc);
+            if (!nicholas_info && !ingredient_info) return;
+            const auto active_info = nicholas_info ? nicholas_info : ingredient_info;
+            const auto collection_time = DailyQuests::GetTimestampFromNicholasTheTraveller(active_info);
+            if (nicholas_info) {
+                if (collection_time <= current_time)
+                    text = std::format(L"Nicholas The Traveler collects {} of these right now!", nicholas_info->quantity);
+                else
+                    text = std::format(L"Nicholas The Traveler collects {} of these {}!", nicholas_info->quantity, TextUtils::RelativeTimeW(collection_time));
             }
             else {
-                text = std::format(L"Nicholas The Traveler collects {} of these {}!", nicholas_info->quantity, TextUtils::RelativeTimeW(collection_time));
+                if (collection_time <= current_time)
+                    text = L"Used to craft an item Nicholas The Traveler collects right now!";
+                else
+                    text = std::format(L"Used to craft an item Nicholas The Traveler collects {}!", TextUtils::RelativeTimeW(collection_time));
             }
         }
 

--- a/GWToolboxdll/Windows/DailyQuestsWindow.cpp
+++ b/GWToolboxdll/Windows/DailyQuestsWindow.cpp
@@ -2086,6 +2086,22 @@ DailyQuests::QuestData* DailyQuests::GetNicholasSandfordItemInfo(const wchar_t* 
     return nullptr;
 }
 
+DailyQuests::NicholasCycleData* DailyQuests::GetNicholasIngredientInfo(const wchar_t* ingredient_enc)
+{
+    // Crafting ingredients whose end product Nicholas The Traveller collects.
+    // If an item's enc name isn't known yet, it will be a placeholder that won't match - find it in-game and update EncStrings.h.
+    static const struct { const wchar_t* ingredient; const wchar_t* nicholas_item; } ingredients[] = {
+        {GW::EncStrings::SkaleFins, GW::EncStrings::BowlofSkalefinSoup},
+        {GW::EncStrings::ChunkOfDrakeFlesh, GW::EncStrings::DrakeKabob}, // TODO: update ChunkOfDrakeFlesh enc name in EncStrings.h
+    };
+    if (!ingredient_enc) return nullptr;
+    for (const auto& entry : ingredients) {
+        if (wcscmp(ingredient_enc, entry.ingredient) == 0)
+            return GetNicholasItemInfo(entry.nicholas_item);
+    }
+    return nullptr;
+}
+
 time_t DailyQuests::GetTimestampFromNicholasSandford(QuestData* data)
 {
     constexpr time_t NICHOLAS_PRE_START_DATE = 1239260400;

--- a/GWToolboxdll/Windows/DailyQuestsWindow.h
+++ b/GWToolboxdll/Windows/DailyQuestsWindow.h
@@ -82,6 +82,8 @@ public:
     static NicholasCycleData* GetNicholasItemInfo(const wchar_t* item_name_encoded);
     // Returns info about the Nicholas Sandford (pre-searing) item if the given item name matches
     static QuestData* GetNicholasSandfordItemInfo(const wchar_t* item_name_encoded);
+    // Returns info about the Nicholas item crafted from the given ingredient enc name, if a match is found
+    static NicholasCycleData* GetNicholasIngredientInfo(const wchar_t* ingredient_enc);
 
     struct ZaishenCoinReward {
         uint32_t nm;


### PR DESCRIPTION
Hovering over Skale Fins or Chunk of Drake Flesh now shows a tooltip indicating those items are used to craft something Nicholas The Traveler collects (Bowl of Skalefin Soup and Drake Kabob respectively).

Note: `ChunkOfDrakeFlesh` in `EncStrings.h` is a placeholder — the real enc name needs to be found in-game and updated there.

Closes #2045

Generated with [Claude Code](https://claude.ai/code)