### PR TITLE
Add Nicholas crafting ingredient tooltips for Skale Fins, Drake Flesh, and Iboga Petals

### DIFF
--- a/GWToolboxdll/Constants/EncStrings.h
+++ b/GWToolboxdll/Constants/EncStrings.h
@@ -166,6 +166,7 @@ namespace GW {
         static const wchar_t* PhantomResidue = L"\x2937";
         static const wchar_t* DrakeKabob = L"\x8101\x42D1\xFB15\xD39E\x5A26";
         static const wchar_t* ChunkOfDrakeFlesh = L"\x8101\x583B\xDE0B\xE373\x1070";
+        static const wchar_t* IbogaPetals = L"\x108\x107Iboga Petals\x1"; // TODO: find real enc name in-game
         static const wchar_t* AmberChunks = L"\x55D0\xF8B7\xB108\x6018";
         static const wchar_t* GlowingHearts = L"\x2914";
         static const wchar_t* SaurianBones = L"\x8102\x26D8\xB5B9\x9AF6\x42D6";

--- a/GWToolboxdll/Windows/DailyQuestsWindow.cpp
+++ b/GWToolboxdll/Windows/DailyQuestsWindow.cpp
@@ -2093,6 +2093,7 @@ DailyQuests::NicholasCycleData* DailyQuests::GetNicholasIngredientInfo(const wch
     static const struct { const wchar_t* ingredient; const wchar_t* nicholas_item; } ingredients[] = {
         {GW::EncStrings::SkaleFins, GW::EncStrings::BowlofSkalefinSoup},
         {GW::EncStrings::ChunkOfDrakeFlesh, GW::EncStrings::DrakeKabob}, // TODO: update ChunkOfDrakeFlesh enc name in EncStrings.h
+        {GW::EncStrings::IbogaPetals, GW::EncStrings::PahnaiSalad},     // TODO: update IbogaPetals enc name in EncStrings.h
     };
     if (!ingredient_enc) return nullptr;
     for (const auto& entry : ingredients) {


### PR DESCRIPTION
Hovering over Skale Fins, Chunk of Drake Flesh, or Iboga Petals now shows a tooltip indicating those items are used to craft something Nicholas The Traveler collects.

**Notes:**
- `ChunkOfDrakeFlesh` and `IbogaPetals` in `EncStrings.h` are placeholders — the real enc names need to be found in-game and updated there before those tooltips will fire.
- `SkaleFins` is already defined and will work immediately.

Closes #2045

Generated with [Claude Code](https://claude.ai/code)