### PR TITLE
Handle player-only teambuilds received via chat link

### DIFF
--- a/GWToolboxdll/Utils/TeamBuild.cpp
+++ b/GWToolboxdll/Utils/TeamBuild.cpp
@@ -454,8 +454,10 @@ void TeamBuild::Load() const
     if (GW::Map::GetInstanceType() != GW::Constants::InstanceType::Outpost) {
         return;
     }
-    GW::PartyMgr::KickAllHeroes();
-    kickall_timer = TIMER_INIT();
+    if (has_hero_slots) {
+        GW::PartyMgr::KickAllHeroes();
+        kickall_timer = TIMER_INIT();
+    }
     if (mode > 0) {
         GW::PartyMgr::SetHardMode(mode == 2);
     }

--- a/GWToolboxdll/Windows/BuildsWindow.cpp
+++ b/GWToolboxdll/Windows/BuildsWindow.cpp
@@ -727,6 +727,13 @@ namespace {
 }
 
 
+void BuildsWindow::AddTeambuild(TeamBuild tbuild)
+{
+    tbuild.edit_open = false;
+    teambuilds.push_back(std::move(tbuild));
+    builds_changed = true;
+}
+
 void BuildsWindow::Terminate()
 {
     ToolboxWindow::Terminate();

--- a/GWToolboxdll/Windows/BuildsWindow.h
+++ b/GWToolboxdll/Windows/BuildsWindow.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ToolboxWindow.h>
+#include <Utils/TeamBuild.h>
 
 namespace GW::UI {
     enum class UIMessage : uint32_t;
@@ -31,6 +32,9 @@ public:
     void LoadSettings(ToolboxIni* ini) override;
     void SaveSettings(ToolboxIni* ini) override;
     void DrawSettingsInternal() override;
+
+    // Add a player-layout teambuild to this window's list (e.g. from a received chat link).
+    void AddTeambuild(TeamBuild tbuild);
 
 private:
     /*

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -30,6 +30,7 @@
 #include <Utils/TeamBuildEncoder.h>
 #include <Utils/TextUtils.h>
 #include <Utils/ToolboxUtils.h>
+#include <Windows/BuildsWindow.h>
 
 constexpr const wchar_t* INI_FILENAME = L"herobuilds.ini";
 
@@ -104,8 +105,10 @@ namespace {
             return;
 
         TeamBuild tbuild("", TextUtils::WStringToString(packet->url).c_str());
-        tbuild.has_hero_slots = true;
         if (!TeamBuildEncoder::EncodedToTeamBuild(packet->url, tbuild)) return;
+        tbuild.has_hero_slots = std::ranges::any_of(tbuild.builds, [](const Build& b) {
+            return b.hero_id != GW::Constants::HeroID::NoHero;
+        });
 
         status->blocked = true;
 
@@ -133,8 +136,10 @@ namespace {
         }
 
         auto tbuild = std::make_shared<TeamBuild>(TextUtils::WStringToString(packet->label), ui_id);
-        tbuild->has_hero_slots = true;
         if (!TeamBuildEncoder::EncodedToTeamBuild(packet->url, *tbuild)) return;
+        tbuild->has_hero_slots = std::ranges::any_of(tbuild->builds, [](const Build& b) {
+            return b.hero_id != GW::Constants::HeroID::NoHero;
+        });
         status->blocked = true;
         tbuild->edit_open = tbuild->focus_next_frame = true;
         detached_pool.push_back(std::move(tbuild));
@@ -389,24 +394,39 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                 const auto& build = tbuild.builds[j];
                 if (build.code.empty() && build.hero_id == HeroID::NoHero) continue;
                 std::string disp_name;
-                HeroBuildName(tbuild, j, &disp_name);
+                if (tbuild.has_hero_slots) {
+                    HeroBuildName(tbuild, j, &disp_name);
+                } else {
+                    const auto& bname = !build.name.empty() ? build.name : build.GetFallbackBuildName();
+                    disp_name = std::format("#{} {}", j + 1, bname);
+                }
                 if (!disp_name.empty()) ImGui::TextUnformatted(disp_name.c_str());
                 if (!build.code.empty()) GuiUtils::DrawSkillbar(build.code.c_str(), false);
                 ImGui::Spacing();
             }
             ImGui::Separator();
-            if (ImGui::Button("Load All")) {
-                tbuild.Load();
+            if (tbuild.has_hero_slots) {
+                if (ImGui::Button("Load All")) {
+                    tbuild.Load();
+                }
+                if (ImGui::IsItemHovered()) ImGui::SetTooltip("Load all builds onto your heroes");
+                ImGui::SameLine();
             }
-            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Load all builds onto your heroes");
-            ImGui::SameLine();
             if (ImGui::Button("Add to My Builds")) {
                 TeamBuild copy = tbuild;
                 copy.edit_open = false;
-                teambuilds.push_back(std::move(copy));
-                builds_changed = true;
+                if (copy.has_hero_slots) {
+                    teambuilds.push_back(std::move(copy));
+                    builds_changed = true;
+                } else {
+                    BuildsWindow::Instance().AddTeambuild(std::move(copy));
+                }
             }
-            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Save this teambuild to your Hero Builds list");
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip(tbuild.has_hero_slots
+                    ? "Save this teambuild to your Hero Builds list"
+                    : "Save this teambuild to your Builds list");
+            }
             ImGui::SameLine();
             if (ImGui::Button("Close")) tbuild.edit_open = false;
         }


### PR DESCRIPTION
Gracefully handle teambuilds designed for multiple players (no heroes) when received via chat link.

- Detect player vs hero teambuild after decoding: sets has_hero_slots based on whether any decoded build has a non-NoHero hero_id
- TeamBuild::Load() no longer kicks heroes for player teambuilds
- Detached window shows player builds with numbered labels instead of hero slot labels
- Hide "Load All" button for player teambuilds (only shown for hero loadouts)
- "Add to My Builds" routes player teambuilds to BuildsWindow, hero teambuilds to HeroBuildsWindow
- Add BuildsWindow::AddTeambuild() public method

Related to PR #2051.

Generated with [Claude Code](https://claude.ai/code)