### PR TITLE
Disable send-to-chat button when encoded teambuild exceeds 120 chars

### DIFF
--- a/GWToolboxdll/Utils/TeamBuild.cpp
+++ b/GWToolboxdll/Utils/TeamBuild.cpp
@@ -428,6 +428,18 @@ void TeamBuild::SetSkillToggleSprite(IDirect3DTexture9** sprite)
     skill_toggle_sprite = sprite;
 }
 
+const std::wstring& TeamBuild::GetEncoded() const
+{
+    if (!encoded_cache_.has_value())
+        encoded_cache_ = TeamBuildEncoder::TeamBuildToEncoded(*this);
+    return *encoded_cache_;
+}
+
+void TeamBuild::ResetEncodedCache() const
+{
+    encoded_cache_.reset();
+}
+
 void TeamBuild::Send(bool one_by_one) const
 {
     if (!name.empty())
@@ -437,7 +449,7 @@ void TeamBuild::Send(bool one_by_one) const
             build.Send();
     }
     else {
-        const auto encoded = TeamBuildEncoder::TeamBuildToEncoded(*this);
+        const auto& encoded = GetEncoded();
         if (!encoded.empty())
             send_queue.push(std::format(L"[TB;{}]", encoded));
     }
@@ -445,7 +457,7 @@ void TeamBuild::Send(bool one_by_one) const
 
 void TeamBuild::Copy() const
 {
-    const auto encoded = TeamBuildEncoder::TeamBuildToEncoded(*this);
+    const auto& encoded = GetEncoded();
     if (encoded.empty()) return;
     const auto msg = TextUtils::WStringToString(std::format(L"[TB;{}]", encoded));
     ImGui::SetClipboardText(msg.c_str());
@@ -454,7 +466,7 @@ void TeamBuild::Copy() const
 
 bool TeamBuild::ChatCodeTooLong() const
 {
-    const auto encoded = TeamBuildEncoder::TeamBuildToEncoded(*this);
+    const auto& encoded = GetEncoded();
     // [TB;<encoded>] = 4 + encoded.size() + 1 = encoded.size() + 5; must be < 120
     return !encoded.empty() && encoded.size() + 5 >= 120;
 }
@@ -566,6 +578,7 @@ void TeamBuild::DrawPlayerBuildsContent(
             if (editing_build_idx_ == static_cast<int>(j))       editing_build_idx_ = -1;
             else if (editing_build_idx_ > static_cast<int>(j))   editing_build_idx_--;
             builds.erase(builds.begin() + static_cast<ptrdiff_t>(j));
+            ResetEncodedCache();
             builds_changed = true;
             ImGui::PopID();
             break;
@@ -582,6 +595,7 @@ void TeamBuild::DrawPlayerBuildsContent(
             ImGui::SameLine();
             if (ImGui::InputText("###code", build.code)) {
                 build.ResetDecodeCache();
+                ResetEncodedCache();
                 builds_changed = true;
             }
             if (ImGui::IsItemHovered()) {
@@ -636,6 +650,7 @@ void TeamBuild::DrawPlayerBuildsContent(
     ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x - add_btn_width);
     if (ImGui::Button("Add Build", ImVec2(add_btn_width, 0))) {
         builds.emplace_back("", "");
+        ResetEncodedCache();
         editing_build_idx_ = static_cast<int>(builds.size()) - 1;
         builds_changed = true;
     }
@@ -694,6 +709,7 @@ void TeamBuild::DrawHeroBuildsContent(
         ImGui::SameLine(offset += text_item_width + item_spacing);
         if (ImGui::InputText("###code", build.code)) {
             build.ResetDecodeCache();
+            ResetEncodedCache();
             builds_changed = true;
         }
         if (ImGui::IsItemHovered()) {
@@ -728,6 +744,7 @@ void TeamBuild::DrawHeroBuildsContent(
                         nullptr, static_cast<int>(sorted_heroes.size()))) {
                     build.hero_id = (combo_idx >= 0 && combo_idx < static_cast<int>(sorted_heroes.size()))
                         ? sorted_heroes[combo_idx] : HeroID::NoHero;
+                    ResetEncodedCache();
                     builds_changed = true;
                 }
             }

--- a/GWToolboxdll/Utils/TeamBuild.cpp
+++ b/GWToolboxdll/Utils/TeamBuild.cpp
@@ -452,6 +452,13 @@ void TeamBuild::Copy() const
     Log::Flash("Teambuild code copied to clipboard");
 }
 
+bool TeamBuild::ChatCodeTooLong() const
+{
+    const auto encoded = TeamBuildEncoder::TeamBuildToEncoded(*this);
+    // [TB;<encoded>] = 4 + encoded.size() + 1 = encoded.size() + 5; must be < 120
+    return !encoded.empty() && encoded.size() + 5 >= 120;
+}
+
 void TeamBuild::Load() const
 {
     if (GW::Map::GetInstanceType() != GW::Constants::InstanceType::Outpost) {
@@ -937,11 +944,19 @@ bool TeamBuild::DrawEditWindow(
     ImGui::Spacing();
     ImGui::Separator();
     ImGui::Spacing();
+    const bool chat_code_too_long = ChatCodeTooLong();
+    if (chat_code_too_long) ImGui::BeginDisabled();
     if (ImGui::Button("Send Teambuild code in chat")) {
         this->Send();
     }
-    if (ImGui::IsItemHovered()) {
-        ImGui::SetTooltip("Send the encoded teambuild link to team chat.\nOther toolbox users can click the chat link without getting spammed.");
+    if (chat_code_too_long) ImGui::EndDisabled();
+    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        if (chat_code_too_long) {
+            ImGui::SetTooltip("Teambuild code is too long to send in chat.\n[TB;<code>] would exceed 120 characters.");
+        }
+        else {
+            ImGui::SetTooltip("Send the encoded teambuild link to team chat.\nOther toolbox users can click the chat link without getting spammed.");
+        }
     }
     ImGui::SameLine();
     if (ImGui::Button("Copy Teambuild code")) {

--- a/GWToolboxdll/Utils/TeamBuild.h
+++ b/GWToolboxdll/Utils/TeamBuild.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -108,9 +109,16 @@ struct TeamBuild {
     // Returns true if [TB;<encoded>] would be >= 120 chars (GW chat limit).
     bool ChatCodeTooLong() const;
 
+    // Invalidate the encoded teambuild cache (call when build codes or hero IDs change).
+    void ResetEncodedCache() const;
+
 private:
     int editing_build_idx_ = -1; // which build row is expanded (player-builds layout)
     bool send_all_confirming_ = false;
+    mutable std::optional<std::wstring> encoded_cache_{};
+
+    // Returns the encoded wstring, computing and caching it on first call.
+    const std::wstring& GetEncoded() const;
 
     void DrawPlayerBuildsContent(bool& builds_changed);
 

--- a/GWToolboxdll/Utils/TeamBuild.h
+++ b/GWToolboxdll/Utils/TeamBuild.h
@@ -105,6 +105,9 @@ struct TeamBuild {
     void Load() const;
     void Copy() const;
 
+    // Returns true if [TB;<encoded>] would be >= 120 chars (GW chat limit).
+    bool ChatCodeTooLong() const;
+
 private:
     int editing_build_idx_ = -1; // which build row is expanded (player-builds layout)
     bool send_all_confirming_ = false;

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -288,16 +288,25 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                 }
                 ImGui::GetStyle().ButtonTextAlign = ImVec2(0.5f, 0.5f);
                 ImGui::SameLine(0, item_spacing);
-                if (ImGui::Button(ImGui::GetIO().KeyCtrl ? "Send" : "Load", ImVec2(btn_width, 0))) {
-                    if (ImGui::GetIO().KeyCtrl) {
+                const bool ctrl_held = ImGui::GetIO().KeyCtrl;
+                const bool send_disabled = ctrl_held && tbuild.ChatCodeTooLong();
+                if (send_disabled) ImGui::BeginDisabled();
+                if (ImGui::Button(ctrl_held ? "Send" : "Load", ImVec2(btn_width, 0))) {
+                    if (ctrl_held) {
                         tbuild.Send();
                     }
                     else {
                         tbuild.Load();
                     }
                 }
-                if (ImGui::IsItemHovered()) {
-                    ImGui::SetTooltip(ImGui::GetIO().KeyCtrl ? "Click to send to team chat" : "Click to load builds to heroes and player. Ctrl + Click to send to chat.");
+                if (send_disabled) ImGui::EndDisabled();
+                if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                    if (send_disabled) {
+                        ImGui::SetTooltip("Teambuild code is too long to send in chat.\n[TB;<code>] would exceed 120 characters.");
+                    }
+                    else {
+                        ImGui::SetTooltip(ctrl_held ? "Click to send to team chat" : "Click to load builds to heroes and player. Ctrl + Click to send to chat.");
+                    }
                 }
                 ImGui::PopID();
             };


### PR DESCRIPTION
Closes #2054

Adds `TeamBuild::ChatCodeTooLong()` which encodes the teambuild and checks whether `[TB;<encoded>]` would reach the 120-wchar GW chat limit.

Two send buttons are guarded:
- "Send Teambuild code in chat" in `DrawEditWindow` (TeamBuild.cpp)
- Ctrl+click "Send" in `HeroBuildsWindow::draw_teambuild_row`

Both use `ImGui::BeginDisabled/EndDisabled` for visual feedback and show an explanatory tooltip via `ImGuiHoveredFlags_AllowWhenDisabled`.

Generated with [Claude Code](https://claude.ai/code)