### PR TITLE
Fix IsHeroUnlocked check for mercenary heroes

### DIFF
--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -1082,7 +1082,7 @@ namespace ToolboxUtils {
                 case GW::Constants::HeroID::Merc6:
                 case GW::Constants::HeroID::Merc7:
                 case GW::Constants::HeroID::Merc8:
-                    if (!(a.name && !a.name)) return false; // Unlocked, but not assigned.
+                    if (!a.name[0]) return false; // Unlocked, but not assigned.
             }
             return true;
         }


### PR DESCRIPTION
The previous condition (a.name && !a.name) was a tautological contradiction that always evaluated to false, causing IsHeroUnlocked to always return false for mercenary heroes and blocking them from being added when loading a team build. HeroInfo::name is a fixed wchar_t[20] array, so check the first character to detect an unassigned merc slot.