### PR TITLE
Refactor: cache tooltip aggregates with static variables

### DIFF
--- a/GWToolboxdll/Windows/AccountInventoryWindow.cpp
+++ b/GWToolboxdll/Windows/AccountInventoryWindow.cpp
@@ -569,24 +569,29 @@ struct MergeStack;
 
     void OnItemTooltip(const MergeStack* ms)
     {
-        // Pre-aggregate quantities per (character, account) and per (character, account, location).
-        // Items in ms->i are sorted by account, character, location, so the keys group consecutive entries.
         auto char_key = [](const AccountInventoryItem* i, const std::string& arc) {
             return arc + "\x1f" + i->character;
         };
         auto loc_key = [](const AccountInventoryItem* i, const std::string& arc) {
             return arc + "\x1f" + i->character + "\x1f" + i->location;
         };
-        std::unordered_map<std::string, uint32_t> char_totals;
-        std::unordered_map<std::string, uint32_t> loc_totals;
-        for (auto it = ms->i.begin(); it != ms->i.end(); it++) {
-            std::string arc;
-            CharacterFreeSlots free_slot{(*it)->account, (*it)->character};
-            if (auto fs_it = free_slots.find(&free_slot); fs_it != free_slots.end()) {
-                arc = (*fs_it)->account_representing_character;
+        // Only one tooltip is visible at a time; cache aggregates and recompute only when the hovered item changes.
+        static const MergeStack* last_ms = nullptr;
+        static std::unordered_map<std::string, uint32_t> char_totals;
+        static std::unordered_map<std::string, uint32_t> loc_totals;
+        if (ms != last_ms) {
+            last_ms = ms;
+            char_totals.clear();
+            loc_totals.clear();
+            for (auto it = ms->i.begin(); it != ms->i.end(); it++) {
+                std::string arc;
+                CharacterFreeSlots free_slot{(*it)->account, (*it)->character};
+                if (auto fs_it = free_slots.find(&free_slot); fs_it != free_slots.end()) {
+                    arc = (*fs_it)->account_representing_character;
+                }
+                char_totals[char_key(*it, arc)] += (*it)->quantity;
+                loc_totals[loc_key(*it, arc)] += (*it)->quantity;
             }
-            char_totals[char_key(*it, arc)] += (*it)->quantity;
-            loc_totals[loc_key(*it, arc)] += (*it)->quantity;
         }
 
         std::string prev_character{};


### PR DESCRIPTION
Use static char_totals/loc_totals inside OnItemTooltip and recompute only when the hovered item pointer changes, instead of rebuilding maps on every frame. No changes to MergeStack or SortAndFilterInventory.

Related to #2057.

Generated with [Claude Code](https://claude.ai/code)