### PR TITLE
Add mobile/normal mode layout settings to UI elements

### DIFF
--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -5,6 +5,7 @@
 #include <GWCA/Managers/MapMgr.h>
 #include <GWCA/Managers/AgentMgr.h>
 #include <GWCA/Managers/GameThreadMgr.h>
+#include <GWCA/Managers/UIMgr.h>
 
 #include <Utils/GuiUtils.h>
 #include <GWToolbox.h>
@@ -383,6 +384,16 @@ void ToolboxSettings::Draw(IDirect3DDevice9*)
 {
     ImGui::GetStyle().WindowBorderSize = move_all ? 1.0f : 0.0f;
     is_in_explorable = GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable;
+
+    static bool mobile_mode_initialized = false;
+    const bool new_mobile = GW::UI::IsInMobileMode();
+    if (!mobile_mode_initialized || new_mobile != is_in_mobile_mode) {
+        mobile_mode_initialized = true;
+        is_in_mobile_mode = new_mobile;
+        for (auto* elem : GWToolbox::GetUIElements()) {
+            elem->OnMobileModeChanged(is_in_mobile_mode);
+        }
+    }
 }
 
 void ToolboxSettings::DrawSettingsCogButtons()

--- a/GWToolboxdll/Modules/ToolboxSettings.h
+++ b/GWToolboxdll/Modules/ToolboxSettings.h
@@ -46,6 +46,7 @@ public:
     static inline bool show_close_in_outpost = true;
     static inline bool show_close_in_explorable = true;
     static inline bool is_in_explorable = false;
+    static inline bool is_in_mobile_mode = false;
 private:
     // === location stuff ===
     clock_t location_timer = 0;

--- a/GWToolboxdll/ToolboxUIElement.cpp
+++ b/GWToolboxdll/ToolboxUIElement.cpp
@@ -66,8 +66,9 @@ void ToolboxUIElement::UpdateCachedFrameStates()
 }
 void ToolboxUIElement::UpdateLocationAgainstSnappedFrame()
 {
-    if (snapped_frame_label.empty()) return;
-    const auto snapped_frame_state = GetCachedFrameState(snapped_frame_label.c_str());
+    const std::string& active_snap = ToolboxSettings::is_in_mobile_mode ? mobile_snapped_frame_label : snapped_frame_label;
+    if (active_snap.empty()) return;
+    const auto snapped_frame_state = GetCachedFrameState(active_snap.c_str());
     if (!snapped_frame_state) return;
     const auto& frame_pos = snapped_frame_state->position;
     if (!ImVec2Eq(last_frame_pos, empty_imvec2) && !ImVec2Eq(last_frame_pos,frame_pos)) {
@@ -123,10 +124,36 @@ void ToolboxUIElement::LoadSettings(ToolboxIni* ini)
     LOAD_BOOL(show_breakout_button);
     LOAD_BOOL(lock_breakout_button);
     LOAD_STRING(snapped_frame_label);
+    LOAD_BOOL(mobile_lock_move);
+    LOAD_BOOL(mobile_lock_size);
+    LOAD_BOOL(mobile_auto_size);
+    LOAD_STRING(mobile_snapped_frame_label);
+    has_normal_layout = ini->GetBoolValue(Name(), "has_normal_layout", false);
+    if (has_normal_layout) {
+        LOAD_FLOAT(normal_pos[0]); LOAD_FLOAT(normal_pos[1]);
+        LOAD_FLOAT(normal_size[0]); LOAD_FLOAT(normal_size[1]);
+    }
+    has_mobile_layout = ini->GetBoolValue(Name(), "has_mobile_layout", false);
+    if (has_mobile_layout) {
+        LOAD_FLOAT(mobile_pos[0]); LOAD_FLOAT(mobile_pos[1]);
+        LOAD_FLOAT(mobile_size[0]); LOAD_FLOAT(mobile_size[1]);
+    }
 }
 
 void ToolboxUIElement::SaveSettings(ToolboxIni* ini)
 {
+    // Sync current mode's stored positions from the live window
+    if (const auto window = ImGui::FindWindowByName(Name())) {
+        if (ToolboxSettings::is_in_mobile_mode) {
+            mobile_pos[0] = window->Pos.x; mobile_pos[1] = window->Pos.y;
+            mobile_size[0] = window->SizeFull.x; mobile_size[1] = window->SizeFull.y;
+            has_mobile_layout = true;
+        } else {
+            normal_pos[0] = window->Pos.x; normal_pos[1] = window->Pos.y;
+            normal_size[0] = window->SizeFull.x; normal_size[1] = window->SizeFull.y;
+            has_normal_layout = true;
+        }
+    }
     ToolboxModule::SaveSettings(ini);
     SAVE_BOOL(visible);
     SAVE_BOOL(show_menubutton);
@@ -138,23 +165,44 @@ void ToolboxUIElement::SaveSettings(ToolboxIni* ini)
     SAVE_BOOL(show_breakout_button);
     SAVE_BOOL(lock_breakout_button);
     SAVE_STRING(snapped_frame_label);
+    SAVE_BOOL(mobile_lock_move);
+    SAVE_BOOL(mobile_lock_size);
+    SAVE_BOOL(mobile_auto_size);
+    SAVE_STRING(mobile_snapped_frame_label);
+    ini->SetBoolValue(Name(), "has_normal_layout", has_normal_layout);
+    if (has_normal_layout) {
+        SAVE_FLOAT(normal_pos[0]); SAVE_FLOAT(normal_pos[1]);
+        SAVE_FLOAT(normal_size[0]); SAVE_FLOAT(normal_size[1]);
+    }
+    ini->SetBoolValue(Name(), "has_mobile_layout", has_mobile_layout);
+    if (has_mobile_layout) {
+        SAVE_FLOAT(mobile_pos[0]); SAVE_FLOAT(mobile_pos[1]);
+        SAVE_FLOAT(mobile_size[0]); SAVE_FLOAT(mobile_size[1]);
+    }
+}
+
+bool ToolboxUIElement::IsMoveLocked() const
+{
+    return ToolboxSettings::is_in_mobile_mode ? mobile_lock_move : lock_move;
+}
+
+bool ToolboxUIElement::IsSizeLocked() const
+{
+    return ToolboxSettings::is_in_mobile_mode ? mobile_lock_size : lock_size;
+}
+
+bool ToolboxUIElement::IsAutoSized() const
+{
+    return ToolboxSettings::is_in_mobile_mode ? mobile_auto_size : auto_size;
 }
 
 ImGuiWindowFlags ToolboxUIElement::GetWinFlags(ImGuiWindowFlags flags) const
 {
     if (!ToolboxSettings::move_all) {
-        if (lock_move) {
-            flags |= ImGuiWindowFlags_NoMove;
-        }
-        if (lock_size) {
-            flags |= ImGuiWindowFlags_NoResize;
-        }
-        if (auto_size) {
-            flags |= ImGuiWindowFlags_AlwaysAutoResize;
-        }
-        if (!show_titlebar) {
-            flags |= ImGuiWindowFlags_NoTitleBar;
-        }
+        if (IsMoveLocked()) flags |= ImGuiWindowFlags_NoMove;
+        if (IsSizeLocked()) flags |= ImGuiWindowFlags_NoResize;
+        if (IsAutoSized()) flags |= ImGuiWindowFlags_AlwaysAutoResize;
+        if (!show_titlebar) flags |= ImGuiWindowFlags_NoTitleBar;
     }
     return flags;
 }
@@ -175,48 +223,135 @@ void ToolboxUIElement::RegisterSettingsContent()
         SettingsWeighting());
 }
 
+void ToolboxUIElement::OnMobileModeChanged(const bool is_mobile)
+{
+    const auto window = ImGui::FindWindowByName(Name());
+    if (is_mobile) {
+        // Save current (normal) position before switching
+        if (window) {
+            normal_pos[0] = window->Pos.x; normal_pos[1] = window->Pos.y;
+            normal_size[0] = window->SizeFull.x; normal_size[1] = window->SizeFull.y;
+            has_normal_layout = true;
+        }
+        // Apply stored mobile position if available
+        if (has_mobile_layout && window) {
+            ImGui::SetWindowPos(window, {mobile_pos[0], mobile_pos[1]});
+            ImGui::SetWindowSize(window, {mobile_size[0], mobile_size[1]});
+        }
+    } else {
+        // Save current (mobile) position before switching
+        if (window) {
+            mobile_pos[0] = window->Pos.x; mobile_pos[1] = window->Pos.y;
+            mobile_size[0] = window->SizeFull.x; mobile_size[1] = window->SizeFull.y;
+            has_mobile_layout = true;
+        }
+        // Restore stored normal position if available
+        if (has_normal_layout && window) {
+            ImGui::SetWindowPos(window, {normal_pos[0], normal_pos[1]});
+            ImGui::SetWindowSize(window, {normal_size[0], normal_size[1]});
+        }
+    }
+    // Reset settings tab to reflect new mode
+    settings_active_tab = is_mobile ? 1 : 0;
+}
+
 void ToolboxUIElement::DrawSizeAndPositionSettings()
 {
-    ImVec2 pos(0, 0);
-    ImVec2 size(100.0f, 100.0f);
-    const auto window = ImGui::FindWindowByName(Name());
-    if (window) {
-        pos = window->Pos;
-        size = window->SizeFull;
+    const bool is_mobile = ToolboxSettings::is_in_mobile_mode;
+
+    // Auto-select tab based on current mode on first open
+    if (settings_active_tab < 0) {
+        settings_active_tab = is_mobile ? 1 : 0;
     }
-    if (is_movable || is_resizable) {
-        char buf[128];
-        sprintf(buf, "You need to show the %s for this control to work", TypeName());
-        if (is_movable && !lock_move) {
-            // Build a list of narrow-string options from available_frame_labels
+
+    const auto window = ImGui::FindWindowByName(Name());
+
+    // Sync the current mode's stored positions from the live window
+    if (window) {
+        if (is_mobile) {
+            mobile_pos[0] = window->Pos.x; mobile_pos[1] = window->Pos.y;
+            mobile_size[0] = window->SizeFull.x; mobile_size[1] = window->SizeFull.y;
+            has_mobile_layout = true;
+        } else {
+            normal_pos[0] = window->Pos.x; normal_pos[1] = window->Pos.y;
+            normal_size[0] = window->SizeFull.x; normal_size[1] = window->SizeFull.y;
+            has_normal_layout = true;
+        }
+    }
+
+    // --- Vertical tab layout (two-column table) ---
+    const float tab_h = ImGui::GetTextLineHeightWithSpacing() + ImGui::GetStyle().FramePadding.y * 2.f;
+    const float tab_w = std::max(ImGui::CalcTextSize("Normal").x, ImGui::CalcTextSize("Mobile").x)
+                        + ImGui::GetStyle().FramePadding.x * 4.f;
+
+    const bool tab_is_mobile = (settings_active_tab == 1);
+    const bool tab_is_current_mode = (tab_is_mobile == is_mobile);
+
+    bool& lm          = tab_is_mobile ? mobile_lock_move          : lock_move;
+    bool& ls          = tab_is_mobile ? mobile_lock_size           : lock_size;
+    bool& as_         = tab_is_mobile ? mobile_auto_size            : auto_size;
+    std::string& snap = tab_is_mobile ? mobile_snapped_frame_label : snapped_frame_label;
+    float* cur_pos    = tab_is_mobile ? mobile_pos                 : normal_pos;
+    float* cur_size   = tab_is_mobile ? mobile_size                : normal_size;
+
+    char need_show_buf[128];
+    snprintf(need_show_buf, sizeof(need_show_buf), "You need to show the %s for this control to work", TypeName());
+
+    if (ImGui::BeginTable("##layout_table", 2, ImGuiTableFlags_None)) {
+        ImGui::TableSetupColumn("tabs", ImGuiTableColumnFlags_WidthFixed, tab_w);
+        ImGui::TableSetupColumn("content", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableNextRow();
+
+        // Left column: Normal / Mobile tab buttons
+        ImGui::TableSetColumnIndex(0);
+        for (int i = 0; i < 2; i++) {
+            const char* label = i == 0 ? "Normal" : "Mobile";
+            const bool selected = settings_active_tab == i;
+            if (selected) {
+                ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyle().Colors[ImGuiCol_ButtonActive]);
+            }
+            if (ImGui::Button(label, {tab_w, tab_h})) {
+                settings_active_tab = i;
+            }
+            if (selected) {
+                ImGui::PopStyleColor();
+            }
+        }
+
+        // Right column: per-mode settings
+        ImGui::TableSetColumnIndex(1);
+
+        if (!tab_is_current_mode) {
+            ImGui::TextDisabled("(Changes apply when %s mode is active)", tab_is_mobile ? "mobile" : "normal");
+        }
+
+        // Snap to Frame
+        {
             static const char* frame_label_options[_countof(available_frame_labels) + 1];
             for (size_t i = 0; i < _countof(available_frame_labels); i++) {
                 frame_label_options[i] = available_frame_labels[i].label;
             }
             frame_label_options[_countof(available_frame_labels)] = nullptr;
 
-            // Find current selection index (-1 = none / "None")
             int current_idx = -1;
             for (size_t i = 0; i < _countof(available_frame_labels); i++) {
-                if (available_frame_labels[i].label == snapped_frame_label)
-                {
+                if (available_frame_labels[i].label == snap) {
                     current_idx = static_cast<int>(i);
                     break;
                 }
             }
-
-            // Build preview string
             const char* preview = current_idx >= 0 ? frame_label_options[current_idx] : "None";
-            if (ImGui::BeginCombo("Snap to Frame", preview)) {
-                // "None" option — convert relative offset back to absolute
-                if (ImGui::Selectable("None", current_idx < 0)) {
-                    snapped_frame_label.clear();
-                }
 
+            const bool snap_disabled = !is_movable || lm;
+            ImGui::BeginDisabled(snap_disabled);
+            if (ImGui::BeginCombo("Snap to Frame", preview)) {
+                if (ImGui::Selectable("None", current_idx < 0)) {
+                    snap.clear();
+                }
                 for (size_t i = 0; i < _countof(available_frame_labels); i++) {
                     const bool selected = (static_cast<int>(i) == current_idx);
                     if (ImGui::Selectable(frame_label_options[i], selected)) {
-                        snapped_frame_label = available_frame_labels[i].label;
+                        snap = available_frame_labels[i].label;
                     }
                     if (selected) {
                         ImGui::SetItemDefaultFocus();
@@ -224,47 +359,125 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
                 }
                 ImGui::EndCombo();
             }
-            ImGui::ShowHelp(buf);
+            ImGui::EndDisabled();
+            if (snap_disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                if (!is_movable) {
+                    ImGui::SetTooltip("This %s cannot be moved", TypeName());
+                } else {
+                    ImGui::SetTooltip("Uncheck 'Lock Position' to enable snap-to-frame");
+                }
+            } else {
+                ImGui::ShowHelp(need_show_buf);
+            }
+        }
 
-            if (ImGui::DragFloat2("Position", reinterpret_cast<float*>(&pos), 1.0f, 0.0f, 0.0f, "%.0f")) {
-                ImGui::SetWindowPos(Name(), pos);
+        // Position
+        {
+            const bool pos_disabled = !is_movable || lm;
+            ImGui::BeginDisabled(pos_disabled);
+            if (ImGui::DragFloat2("Position", cur_pos, 1.0f, 0.0f, 0.0f, "%.0f")) {
+                if (tab_is_current_mode && window) {
+                    ImGui::SetWindowPos(window, {cur_pos[0], cur_pos[1]});
+                }
             }
-            ImGui::ShowHelp(buf);
-        }
-        if (is_resizable && !lock_size && !auto_size) {
-            if (ImGui::DragFloat2("Size", reinterpret_cast<float*>(&size), 1.0f, 0.0f, 0.0f, "%.0f")) {
-                ImGui::SetWindowSize(Name(), size);
+            ImGui::EndDisabled();
+            if (pos_disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                if (!is_movable) {
+                    ImGui::SetTooltip("This %s cannot be moved", TypeName());
+                } else {
+                    ImGui::SetTooltip("Uncheck 'Lock Position' to adjust position");
+                }
+            } else {
+                ImGui::ShowHelp(need_show_buf);
             }
-            ImGui::ShowHelp(buf);
         }
+
+        // Size
+        {
+            const bool size_disabled = !is_resizable || ls || as_;
+            ImGui::BeginDisabled(size_disabled);
+            if (ImGui::DragFloat2("Size", cur_size, 1.0f, 0.0f, 0.0f, "%.0f")) {
+                if (tab_is_current_mode && window) {
+                    ImGui::SetWindowSize(window, {cur_size[0], cur_size[1]});
+                }
+            }
+            ImGui::EndDisabled();
+            if (size_disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                if (!is_resizable) {
+                    ImGui::SetTooltip("This %s cannot be resized", TypeName());
+                } else if (as_) {
+                    ImGui::SetTooltip("Uncheck 'Auto Size' to adjust size");
+                } else {
+                    ImGui::SetTooltip("Uncheck 'Lock Size' to adjust size");
+                }
+            } else {
+                ImGui::ShowHelp(need_show_buf);
+            }
+        }
+
+        // Lock / auto checkboxes
+        ImGui::StartSpacedElements(180.f);
+
+        ImGui::NextSpacedElement();
+        ImGui::BeginDisabled(!is_movable);
+        ImGui::Checkbox("Lock Position", &lm);
+        ImGui::EndDisabled();
+        if (!is_movable && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+            ImGui::SetTooltip("This %s cannot be moved", TypeName());
+        }
+
+        ImGui::NextSpacedElement();
+        ImGui::BeginDisabled(!is_resizable);
+        ImGui::Checkbox("Lock Size", &ls);
+        ImGui::EndDisabled();
+        if (!is_resizable && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+            ImGui::SetTooltip("This %s cannot be resized", TypeName());
+        }
+
+        ImGui::NextSpacedElement();
+        ImGui::BeginDisabled(!is_resizable);
+        ImGui::Checkbox("Auto Size", &as_);
+        ImGui::EndDisabled();
+        if (!is_resizable && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+            ImGui::SetTooltip("This %s cannot be resized", TypeName());
+        }
+
+        ImGui::EndTable();
     }
+
+    // Shared settings (not per-mode) drawn below the two-column layout
     ImGui::StartSpacedElements(180.f);
-    if (is_movable) {
-        ImGui::NextSpacedElement();
-        ImGui::Checkbox("Lock Position", &lock_move);
+
+    ImGui::NextSpacedElement();
+    ImGui::BeginDisabled(!has_titlebar);
+    ImGui::Checkbox("Show titlebar", &show_titlebar);
+    ImGui::EndDisabled();
+    if (!has_titlebar && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        ImGui::SetTooltip("This %s has no titlebar", TypeName());
     }
-    if (is_resizable) {
-        ImGui::NextSpacedElement();
-        ImGui::Checkbox("Lock Size", &lock_size);
-        ImGui::NextSpacedElement();
-        ImGui::Checkbox("Auto Size", &auto_size);
+
+    ImGui::NextSpacedElement();
+    ImGui::BeginDisabled(!has_closebutton);
+    ImGui::Checkbox("Show close button", &show_closebutton);
+    ImGui::EndDisabled();
+    if (!has_closebutton && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        ImGui::SetTooltip("This %s has no close button", TypeName());
     }
-    ImGui::StartSpacedElements(180.f);
-    if (has_titlebar) {
-        ImGui::NextSpacedElement();
-        ImGui::Checkbox("Show titlebar", &show_titlebar);
-    }
-    if (has_closebutton) {
-        ImGui::NextSpacedElement();
-        ImGui::Checkbox("Show close button", &show_closebutton);
-    }
-    if (can_show_in_main_window) {
-        ImGui::NextSpacedElement();
-        if (ImGui::Checkbox("Show in main window", &show_menubutton)) {
+
+    ImGui::NextSpacedElement();
+    ImGui::BeginDisabled(!can_show_in_main_window);
+    if (ImGui::Checkbox("Show in main window", &show_menubutton)) {
+        if (can_show_in_main_window) {
             MainWindow::Instance().pending_refresh_buttons = true;
         }
     }
-    ImGui::CheckboxWithHelp("Show breakout button", &show_breakout_button, "Shows a small floating button on screen that toggles this window.\nRight-click the button to remove it.");
+    ImGui::EndDisabled();
+    if (!can_show_in_main_window && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        ImGui::SetTooltip("This %s cannot be shown in the main window", TypeName());
+    }
+
+    ImGui::CheckboxWithHelp("Show breakout button", &show_breakout_button,
+        "Shows a small floating button on screen that toggles this window.\nRight-click the button to remove it.");
     if (show_breakout_button) {
         ImGui::Indent();
         ImGui::Checkbox("Lock breakout button position", &lock_breakout_button);

--- a/GWToolboxdll/ToolboxUIElement.h
+++ b/GWToolboxdll/ToolboxUIElement.h
@@ -24,6 +24,9 @@ public:
 
     void SaveSettings(ToolboxIni* ini) override;
 
+    // Called when the game switches between mobile and normal mode
+    void OnMobileModeChanged(bool is_mobile);
+
     [[nodiscard]] virtual ImGuiWindowFlags GetWinFlags(ImGuiWindowFlags flags = 0) const;
 
     // returns true if clicked
@@ -50,11 +53,24 @@ public:
     bool show_breakout_button = false;
     bool lock_breakout_button = false;
 
+    // Mobile-mode layout settings (separate from normal-mode settings above)
+    bool mobile_lock_move = false;
+    bool mobile_lock_size = false;
+    bool mobile_auto_size = false;
+
+    // Returns lock_move/lock_size/auto_size for the current game mode
+    [[nodiscard]] bool IsMoveLocked() const;
+    [[nodiscard]] bool IsSizeLocked() const;
+    [[nodiscard]] bool IsAutoSized() const;
+
     bool* GetVisiblePtr();
 
     bool has_titlebar = false;
     bool show_titlebar = true;
     bool show_closebutton = true;
+
+    // Settings panel tab: 0 = Normal, 1 = Mobile, -1 = auto (tracks current mode)
+    int settings_active_tab = -1;
 
 protected:
     bool can_show_in_main_window = true;
@@ -63,6 +79,15 @@ protected:
     bool is_movable = true;
 
     std::string snapped_frame_label;
+    std::string mobile_snapped_frame_label;
+
+    // Stored positions for each mode (used when switching modes)
+    bool has_normal_layout = false;
+    float normal_pos[2] = {};
+    float normal_size[2] = {};
+    bool has_mobile_layout = false;
+    float mobile_pos[2] = {};
+    float mobile_size[2] = {};
 
     float min_size[2] = { 250.f,90.f };
     float max_size[2] = { FLT_MAX, FLT_MAX };

--- a/GWToolboxdll/ToolboxWidget.cpp
+++ b/GWToolboxdll/ToolboxWidget.cpp
@@ -13,7 +13,7 @@ ImGuiWindowFlags ToolboxWidget::GetWinFlags(ImGuiWindowFlags flags, const bool n
     flags = ToolboxUIElement::GetWinFlags(flags);
     flags |= ImGuiWindowFlags_NoTitleBar;
     flags |= ImGuiWindowFlags_NoScrollbar;
-    if (noinput_if_frozen && lock_move && lock_size && !ToolboxSettings::move_all) {
+    if (noinput_if_frozen && IsMoveLocked() && IsSizeLocked() && !ToolboxSettings::move_all) {
         flags |= ImGuiWindowFlags_NoInputs;
     }
     return flags;

--- a/GWToolboxdll/ToolboxWidget.h
+++ b/GWToolboxdll/ToolboxWidget.h
@@ -4,7 +4,7 @@
 
 class ToolboxWidget : public ToolboxUIElement {
 public:
-    ToolboxWidget() { lock_move = lock_size = true; }
+    ToolboxWidget() { lock_move = lock_size = mobile_lock_move = mobile_lock_size = true; }
     ~ToolboxWidget() override = default;
 
     [[nodiscard]] bool IsWidget() const override { return true; }


### PR DESCRIPTION
Implements #3 2069: separate size/position settings for mobile and non-mobile game views.

- Tracks `GW::UI::IsInMobileMode()` each frame via `ToolboxSettings::is_in_mobile_mode`
- Adds mobile-specific layout fields (lock_move, lock_size, auto_size, snapped_frame_label, pos, size)
- `DrawSizeAndPositionSettings` now shows Normal/Mobile vertical tabs on the left with per-mode settings on the right
- All settings elements are always drawn; inapplicable ones use BeginDisabled() + tooltip instead of being hidden
- On mode change, window positions/sizes are automatically saved and restored

Generated with [Claude Code](https://claude.ai/code)