### PR TITLE
fix: generate fresh ui_id when copying a TeamBuild

### DIFF
--- a/GWToolboxdll/Utils/TeamBuild.cpp
+++ b/GWToolboxdll/Utils/TeamBuild.cpp
@@ -423,6 +423,35 @@ TeamBuild::TeamBuild(std::string_view n, std::string_view id)
 {
 }
 
+TeamBuild::TeamBuild(const TeamBuild& other)
+    : edit_open(other.edit_open)
+    , focus_next_frame(other.focus_next_frame)
+    , mode(other.mode)
+    , show_numbers(other.show_numbers)
+    , has_hero_slots(other.has_hero_slots)
+    , name(other.name)
+    , group(other.group)
+    , ui_id(std::to_string(++s_cur_ui_id))
+    , builds(other.builds)
+{
+}
+
+TeamBuild& TeamBuild::operator=(const TeamBuild& other)
+{
+    if (this != &other) {
+        edit_open = other.edit_open;
+        focus_next_frame = other.focus_next_frame;
+        mode = other.mode;
+        show_numbers = other.show_numbers;
+        has_hero_slots = other.has_hero_slots;
+        name = other.name;
+        group = other.group;
+        ui_id = std::to_string(++s_cur_ui_id);
+        builds = other.builds;
+    }
+    return *this;
+}
+
 void TeamBuild::SetSkillToggleSprite(IDirect3DTexture9** sprite)
 {
     skill_toggle_sprite = sprite;

--- a/GWToolboxdll/Utils/TeamBuild.h
+++ b/GWToolboxdll/Utils/TeamBuild.h
@@ -69,6 +69,8 @@ struct TeamBuild {
 
     TeamBuild() = default;
     explicit TeamBuild(std::string_view name, std::string_view ui_id = {});
+    TeamBuild(const TeamBuild& other);
+    TeamBuild& operator=(const TeamBuild& other);
 
     bool edit_open = false;
     bool focus_next_frame = false;


### PR DESCRIPTION
Add explicit copy constructor and copy assignment operator to TeamBuild so that every copy gets a new ui_id. Previously the compiler-generated copy duplicated the ui_id, causing ImGui to see two windows with identical IDs when a teambuild was copied and both windows were opened simultaneously (conflicting ID errors, red outlines, controls only working for the first-opened window).

Fixes #2068

Generated with [Claude Code](https://claude.ai/code)