### PR TITLE
Add BeginVerticalTabBar/EndVerticalTabBar to ImGuiAddons

### DIFF
--- a/GWToolboxdll/ImGuiAddons.cpp
+++ b/GWToolboxdll/ImGuiAddons.cpp
@@ -6,6 +6,24 @@
 #include <Keys.h>
 
 namespace {
+    // Renders text rotated 90° CCW around `center` (gives top-to-bottom reading on a left-side tab strip).
+    void RenderTextRotated90CCW(ImDrawList* dl, ImVec2 center, ImU32 col, const char* text)
+    {
+        if (!text || !*text)
+            return;
+        const ImVec2 sz = ImGui::CalcTextSize(text);
+        const int vtx0 = dl->VtxBuffer.Size;
+        dl->AddText({center.x - sz.x * 0.5f, center.y - sz.y * 0.5f}, col, text);
+        // CCW rotation: (dx, dy) -> (-dy, dx)
+        for (int i = vtx0; i < dl->VtxBuffer.Size; i++) {
+            ImDrawVert& v = dl->VtxBuffer[i];
+            const float dx = v.pos.x - center.x;
+            const float dy = v.pos.y - center.y;
+            v.pos.x = center.x - dy;
+            v.pos.y = center.y + dx;
+        }
+    }
+
     ImGui::ImGuiContextMenuCallback imguiaddons_context_menu_callback = nullptr;
     void* imguiaddons_context_menu_wparam = nullptr;
     const char* imguiaddons_context_menu_id = "###imguiaddons_context_menu";
@@ -790,6 +808,70 @@ namespace ImGui {
         DrawTextWithOutline(GetWindowDrawList(), text, GetCursorScreenPos(), textColor, outlineColor, thickness);
         ImVec2 textSize = CalcTextSize(text);
         SetCursorPosY(GetCursorPosY() + textSize.y);
+    }
+
+    bool BeginVerticalTabBar(const char* str_id, const char* const* labels, const int labels_count,
+                              int* active_tab, const int highlighted_tab, const float tab_width_hint)
+    {
+        const ImGuiStyle& style = GetStyle();
+        const float font_sz = GetFontSize();
+        const float tab_w   = tab_width_hint > 0.f ? tab_width_hint : font_sz + style.FramePadding.x * 4.f;
+
+        if (!BeginTable(str_id, 2, ImGuiTableFlags_BordersInnerV))
+            return false;
+
+        TableSetupColumn("##vtabs",    ImGuiTableColumnFlags_WidthFixed,   tab_w);
+        TableSetupColumn("##vcontent", ImGuiTableColumnFlags_WidthStretch);
+        TableNextRow();
+        TableSetColumnIndex(0);
+
+        ImDrawList* const dl = GetWindowDrawList();
+        PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.f, 0.f));
+
+        for (int i = 0; i < labels_count; i++) {
+            const char* label    = labels[i];
+            const bool  selected = (*active_tab == i);
+            const float text_w   = CalcTextSize(label).x;
+            const float btn_h    = text_w + style.FramePadding.y * 4.f;
+
+            PushID(i);
+            PushStyleColor(ImGuiCol_Button,
+                selected ? style.Colors[ImGuiCol_ButtonActive] : ImVec4(0.f, 0.f, 0.f, 0.f));
+            PushStyleColor(ImGuiCol_ButtonHovered,
+                selected ? style.Colors[ImGuiCol_ButtonActive] : style.Colors[ImGuiCol_ButtonHovered]);
+
+            const ImVec2 tl = GetCursorScreenPos();
+            if (ButtonEx("##vtab", {tab_w, btn_h}, ImGuiButtonFlags_None))
+                *active_tab = i;
+
+            PopStyleColor(2);
+
+            RenderTextRotated90CCW(dl, {tl.x + tab_w * 0.5f, tl.y + btn_h * 0.5f},
+                GetColorU32(selected ? ImGuiCol_Text : ImGuiCol_TextDisabled), label);
+
+            // Small dot on the right edge marks the currently-active mode tab
+            if (i == highlighted_tab) {
+                constexpr float r = 3.f;
+                dl->AddCircleFilled(
+                    {tl.x + tab_w - style.FramePadding.x - r, tl.y + btn_h * 0.5f},
+                    r, GetColorU32(ImGuiCol_CheckMark));
+            }
+
+            if (IsItemHovered())
+                SetTooltip("%s", label);
+
+            PopID();
+        }
+
+        PopStyleVar(); // ItemSpacing
+
+        TableSetColumnIndex(1);
+        return true;
+    }
+
+    void EndVerticalTabBar()
+    {
+        EndTable();
     }
 
 }

--- a/GWToolboxdll/ImGuiAddons.h
+++ b/GWToolboxdll/ImGuiAddons.h
@@ -107,4 +107,14 @@ namespace ImGui {
                                        ImU32 textColor = IM_COL32(255, 255, 255, 255),
                                        ImU32 outlineColor = IM_COL32(0, 0, 0, 255),
                                        float thickness = 1.0f);
+
+    // Vertical tab bar: tabs on the left with rotated labels, content on the right.
+    // labels/labels_count: tab label strings.
+    // active_tab: in/out 0-indexed selection.
+    // highlighted_tab: index shown with a small dot indicator (-1 = none); use to mark the currently-active mode.
+    // tab_width: override tab strip width (0 = auto-sized from font height).
+    // Returns true when rendered; always call EndVerticalTabBar() iff this returns true.
+    IMGUI_API bool BeginVerticalTabBar(const char* str_id, const char* const* labels, int labels_count,
+                                       int* active_tab, int highlighted_tab = -1, float tab_width = 0.f);
+    IMGUI_API void EndVerticalTabBar();
 }

--- a/GWToolboxdll/ToolboxUIElement.cpp
+++ b/GWToolboxdll/ToolboxUIElement.cpp
@@ -279,10 +279,8 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
         }
     }
 
-    // --- Vertical tab layout (two-column table) ---
-    const float tab_h = ImGui::GetTextLineHeightWithSpacing() + ImGui::GetStyle().FramePadding.y * 2.f;
-    const float tab_w = std::max(ImGui::CalcTextSize("Normal").x, ImGui::CalcTextSize("Mobile").x)
-                        + ImGui::GetStyle().FramePadding.x * 4.f;
+    static const char* layout_tabs[] = {"Normal", "Mobile"};
+    const int highlighted_tab = is_mobile ? 1 : 0;
 
     const bool tab_is_mobile = (settings_active_tab == 1);
     const bool tab_is_current_mode = (tab_is_mobile == is_mobile);
@@ -297,29 +295,8 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
     char need_show_buf[128];
     snprintf(need_show_buf, sizeof(need_show_buf), "You need to show the %s for this control to work", TypeName());
 
-    if (ImGui::BeginTable("##layout_table", 2, ImGuiTableFlags_None)) {
-        ImGui::TableSetupColumn("tabs", ImGuiTableColumnFlags_WidthFixed, tab_w);
-        ImGui::TableSetupColumn("content", ImGuiTableColumnFlags_WidthStretch);
-        ImGui::TableNextRow();
-
-        // Left column: Normal / Mobile tab buttons
-        ImGui::TableSetColumnIndex(0);
-        for (int i = 0; i < 2; i++) {
-            const char* label = i == 0 ? "Normal" : "Mobile";
-            const bool selected = settings_active_tab == i;
-            if (selected) {
-                ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyle().Colors[ImGuiCol_ButtonActive]);
-            }
-            if (ImGui::Button(label, {tab_w, tab_h})) {
-                settings_active_tab = i;
-            }
-            if (selected) {
-                ImGui::PopStyleColor();
-            }
-        }
-
+    if (ImGui::BeginVerticalTabBar("##layout_tabs", layout_tabs, 2, &settings_active_tab, highlighted_tab)) {
         // Right column: per-mode settings
-        ImGui::TableSetColumnIndex(1);
 
         if (!tab_is_current_mode) {
             ImGui::TextDisabled("(Changes apply when %s mode is active)", tab_is_mobile ? "mobile" : "normal");
@@ -442,7 +419,7 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
             ImGui::SetTooltip("This %s cannot be resized", TypeName());
         }
 
-        ImGui::EndTable();
+        ImGui::EndVerticalTabBar();
     }
 
     // Shared settings (not per-mode) drawn below the two-column layout


### PR DESCRIPTION
Adds a reusable vertical tab bar helper to ImGuiAddons with rotated tab labels and a current-mode indicator dot.

Related to #2070.

Generated with [Claude Code](https://claude.ai/code)