### PR TITLE
feat: hotkey group combo dropdown + New Group button

### DIFF
--- a/GWToolboxdll/Windows/Hotkeys/TBHotkey.cpp
+++ b/GWToolboxdll/Windows/Hotkeys/TBHotkey.cpp
@@ -452,9 +452,55 @@ bool TBHotkey::Draw(Op* op, bool first, bool last)
         // === Hotkey section ===
         const float indent_offset = ImGui::GetCurrentWindow()->DC.Indent.x;
         const float offset_sameline = indent_offset + ImGui::GetContentRegionAvail().x / 2;
-        hotkey_changed |= ImGui::InputTextEx("Hotkey Group##hotkey_group", "No Hotkey Group", group, sizeof(group), ImVec2(0, 0), ImGuiInputTextFlags_EnterReturnsTrue, nullptr, nullptr);
-        if (ImGui::IsItemDeactivatedAfterEdit()) {
-            hotkey_changed = true;
+        {
+            std::vector<HotkeyGroup*> groups;
+            HotkeysWindow::GetGroups(groups);
+            const HotkeyGroup* current_parent = HotkeysWindow::FindParentGroup(this);
+
+            int current_idx = 0; // 0 = no group
+            for (int i = 0; i < static_cast<int>(groups.size()); i++) {
+                if (groups[i] == current_parent) {
+                    current_idx = i + 1;
+                    break;
+                }
+            }
+
+            const char* preview = current_idx == 0
+                ? "(No Group)"
+                : (*groups[current_idx - 1]->label ? groups[current_idx - 1]->label : "(unnamed)");
+
+            const float start_x = ImGui::GetCursorPosX();
+            const float item_w = ImGui::CalcItemWidth();
+            const float spacing = ImGui::GetStyle().ItemSpacing.x;
+            const float btn_w = 90.f * scale;
+
+            ImGui::SetNextItemWidth(std::max(1.f, item_w - btn_w - spacing));
+            if (ImGui::BeginCombo("##hotkey_group_combo", preview)) {
+                if (ImGui::Selectable("(No Group)", current_idx == 0) && current_idx != 0) {
+                    HotkeysWindow::RequestMoveToGroup(this, nullptr);
+                    hotkey_changed = true;
+                }
+                for (int i = 0; i < static_cast<int>(groups.size()); i++) {
+                    ImGui::PushID(i);
+                    const char* gname = *groups[i]->label ? groups[i]->label : "(unnamed)";
+                    const bool is_selected = current_idx == i + 1;
+                    if (ImGui::Selectable(gname, is_selected) && !is_selected) {
+                        HotkeysWindow::RequestMoveToGroup(this, groups[i]);
+                        hotkey_changed = true;
+                    }
+                    ImGui::PopID();
+                }
+                ImGui::EndCombo();
+            }
+            ImGui::SameLine(0, spacing);
+            if (ImGui::Button("New Group##grp_create", ImVec2(btn_w, 0))) {
+                HotkeysWindow::RequestNewGroup(this);
+                hotkey_changed = true;
+            }
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Create a new hotkey group containing this hotkey");
+            ImGui::SameLine(start_x + item_w + spacing);
+            ImGui::AlignTextToFramePadding();
+            ImGui::TextUnformatted("Hotkey Group");
         }
         hotkey_changed |= ImGui::InputTextEx("Label##hotkey_label", "Use description as label", label, sizeof(label), ImVec2(0, 0), ImGuiInputTextFlags_EnterReturnsTrue, nullptr, nullptr);
         if (ImGui::IsItemDeactivatedAfterEdit()) {

--- a/GWToolboxdll/Windows/HotkeysWindow.cpp
+++ b/GWToolboxdll/Windows/HotkeysWindow.cpp
@@ -218,6 +218,55 @@ namespace {
         }
     }
 
+    TBHotkey* pending_group_move_hotkey = nullptr;
+    HotkeyGroup* pending_group_move_target = nullptr;
+    bool pending_group_move_create_new = false;
+
+    // Remove `hotkey` from wherever it currently lives (top-level or inside a group).
+    // Returns true if found and removed.
+    bool RemoveHotkeyFromCurrentLocation(TBHotkey* hotkey) {
+        const auto erased_top = std::erase(hotkeys, hotkey);
+        if (erased_top) return true;
+        for (auto* hk : hotkeys) {
+            if (auto* grp = dynamic_cast<HotkeyGroup*>(hk)) {
+                if (std::erase(grp->hotkeys, hotkey)) return true;
+            }
+        }
+        return false;
+    }
+
+    void DoMoveToGroup(TBHotkey* hotkey, HotkeyGroup* target) {
+        RemoveHotkeyFromCurrentLocation(hotkey);
+        if (target)
+            target->hotkeys.push_back(hotkey);
+        else
+            hotkeys.push_back(hotkey);
+        TBHotkey::hotkeys_changed = true;
+        CheckSetValidHotkeys();
+    }
+
+    void DoCreateGroupForHotkey(TBHotkey* hotkey) {
+        auto* new_grp = new HotkeyGroup(nullptr, nullptr);
+
+        // If the hotkey is at the top level, replace it in-place with the new group.
+        for (size_t i = 0; i < hotkeys.size(); i++) {
+            if (hotkeys[i] == hotkey) {
+                hotkeys[i] = new_grp;
+                new_grp->hotkeys.push_back(hotkey);
+                TBHotkey::hotkeys_changed = true;
+                CheckSetValidHotkeys();
+                return;
+            }
+        }
+
+        // If inside a group, remove from that group and append the new group at top level.
+        RemoveHotkeyFromCurrentLocation(hotkey);
+        new_grp->hotkeys.push_back(hotkey);
+        hotkeys.push_back(new_grp);
+        TBHotkey::hotkeys_changed = true;
+        CheckSetValidHotkeys();
+    }
+
     TBHotkey* pending_being_assigned = nullptr;
     TBHotkey* keys_being_assigned = nullptr;
     KeysHeldBitset keys_selected;
@@ -315,9 +364,56 @@ void HotkeysWindow::ChooseKeyCombo(TBHotkey* hotkey)
     pending_being_assigned = hotkey;
 }
 
+void HotkeysWindow::GetGroups(std::vector<HotkeyGroup*>& out)
+{
+    out.clear();
+    for (auto* hk : hotkeys) {
+        if (auto* grp = dynamic_cast<HotkeyGroup*>(hk))
+            out.push_back(grp);
+    }
+}
+
+HotkeyGroup* HotkeysWindow::FindParentGroup(const TBHotkey* hotkey)
+{
+    for (auto* hk : hotkeys) {
+        if (auto* grp = dynamic_cast<HotkeyGroup*>(hk)) {
+            for (auto* child : grp->hotkeys) {
+                if (child == hotkey) return grp;
+            }
+        }
+    }
+    return nullptr;
+}
+
+void HotkeysWindow::RequestMoveToGroup(TBHotkey* hotkey, HotkeyGroup* target)
+{
+    pending_group_move_hotkey = hotkey;
+    pending_group_move_target = target;
+    pending_group_move_create_new = false;
+}
+
+void HotkeysWindow::RequestNewGroup(TBHotkey* hotkey)
+{
+    pending_group_move_hotkey = hotkey;
+    pending_group_move_create_new = true;
+}
+
 void HotkeysWindow::Draw(IDirect3DDevice9*)
 {
     DrawSelectHotkeyPopup();
+
+    // Process deferred group-move requests (queued during last frame's draw to avoid
+    // mutating the hotkeys list while iterating over it).
+    if (pending_group_move_hotkey) {
+        if (pending_group_move_create_new)
+            DoCreateGroupForHotkey(pending_group_move_hotkey);
+        else
+            DoMoveToGroup(pending_group_move_hotkey, pending_group_move_target);
+        pending_group_move_hotkey = nullptr;
+        pending_group_move_target = nullptr;
+        pending_group_move_create_new = false;
+    }
+
     if (!visible) {
         return;
     }

--- a/GWToolboxdll/Windows/HotkeysWindow.h
+++ b/GWToolboxdll/Windows/HotkeysWindow.h
@@ -27,6 +27,18 @@ public:
 
     static void ChooseKeyCombo(TBHotkey* hotkey);
 
+    // Returns all top-level HotkeyGroup objects in display order.
+    static void GetGroups(std::vector<HotkeyGroup*>& out);
+
+    // Returns the HotkeyGroup that owns `hotkey`, or nullptr if top-level.
+    static HotkeyGroup* FindParentGroup(const TBHotkey* hotkey);
+
+    // Deferred: move `hotkey` into `target` (nullptr = top level). Safe to call during Draw.
+    static void RequestMoveToGroup(TBHotkey* hotkey, HotkeyGroup* target);
+
+    // Deferred: create a new group, insert it where `hotkey` currently is, and move `hotkey` into it.
+    static void RequestNewGroup(TBHotkey* hotkey);
+
     static const TBHotkey* CurrentHotkey();
 
     // Update. Will always be called every frame.


### PR DESCRIPTION
Replace the free-text "Hotkey Group" field on each hotkey with a dropdown listing available `HotkeyGroup` objects, plus a "New Group" button that creates a group in-place.

Relates to #2066.

Generated with [Claude Code](https://claude.ai/code)