### PR TITLE
Add World Map checkbox to Quest Module settings

### DIFF
--- a/GWToolboxdll/Modules/QuestModule.cpp
+++ b/GWToolboxdll/Modules/QuestModule.cpp
@@ -675,6 +675,7 @@ void QuestModule::DrawSettingsInternal()
     recalc_quest_paths |= ImGui::Checkbox("Terrain##terrianquestpath", &draw_quest_path_on_terrain);
     recalc_quest_paths |= ImGui::Checkbox("Minimap##minimapquestpath", &draw_quest_path_on_minimap);
     recalc_quest_paths |= ImGui::Checkbox("Mission Map##missionmapquestpath", &draw_quest_path_on_mission_map);
+    ImGui::Checkbox("World Map##worldmapquestpath", &WorldMapWidget::ShowLinesOnWorldMap());
 #ifdef _DEBUG
     recalc_quest_paths |= ImGui::Checkbox("Show paths to all quests##drawallquestpaths", &show_paths_to_all_quests);
 #endif

--- a/GWToolboxdll/Widgets/WorldMapWidget.cpp
+++ b/GWToolboxdll/Widgets/WorldMapWidget.cpp
@@ -968,6 +968,11 @@ void WorldMapWidget::SignalTerminate()
     GW::UI::RemoveUIMessageCallback(&OnUIMessage_HookEntry);
 }
 
+bool& WorldMapWidget::ShowLinesOnWorldMap()
+{
+    return show_lines_on_world_map;
+}
+
 void WorldMapWidget::ShowAllOutposts(const bool show = showing_all_outposts)
 {
     if (view_all_outposts_patch.IsValid()) view_all_outposts_patch.TogglePatch(show);

--- a/GWToolboxdll/Widgets/WorldMapWidget.h
+++ b/GWToolboxdll/Widgets/WorldMapWidget.h
@@ -41,4 +41,5 @@ public:
     static GW::Constants::MapID GetMapIdForLocation(const GW::Vec2f& world_map_pos, GW::Constants::MapID exclude_map_id = (GW::Constants::MapID)0);
     static bool WorldMapToGamePos(const GW::Vec2f& world_map_pos, GW::GamePos& game_map_pos);
     static bool GamePosToWorldMap(const GW::GamePos& game_map_pos, GW::Vec2f& world_map_pos);
+    static bool& ShowLinesOnWorldMap();
 };


### PR DESCRIPTION
Exposes WorldMapWidget's `show_lines_on_world_map` via a public static accessor, and adds a "World Map" checkbox in Quest Module settings that controls it directly — alongside the existing Terrain/Minimap/Mission Map options.

Closes #1472

Generated with [Claude Code](https://claude.ai/code)