### PR TITLE
fix: FastIniSection::GetAllKeys returns key names instead of values

### DIFF
--- a/GWToolboxdll/Utils/FastIni.cpp
+++ b/GWToolboxdll/Utils/FastIni.cpp
@@ -167,7 +167,7 @@ bool FastIniSection::Delete(std::string_view key) {
 void FastIniSection::GetAllKeys(TNamesDepend& out) const {
     for (auto& [k, vec] : keys)
         if (!vec.empty())
-            out.push_back(SI_Entry(vec[0].raw.c_str()));
+            out.push_back(SI_Entry(k.c_str()));
 }
 
 // ===========================================================================


### PR DESCRIPTION
Fixes #1326

`GetAllKeys` was pushing `vec[0].raw.c_str()` (the value string) into `SI_Entry::pItem` instead of `k.c_str()` (the key name). All callers that use `pItem` as a key name for subsequent `GetValue`/`GetLongValue` lookups were silently failing — every entry read from disk was discarded, causing settings to always reset to defaults on reload.

Fixes transmo NPC list not persisting across sessions, and also fixes the same issue in PartyDamage's HP log loading.

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/gwdevhub/GWToolboxpp/tree/claude/issue-1326-20260524-1031