### PR TITLE
fix: add required max_length to ImGui::InputText(std::string) wrapper

### DIFF
--- a/GWToolboxdll/ImGuiAddons.cpp
+++ b/GWToolboxdll/ImGuiAddons.cpp
@@ -70,13 +70,14 @@ namespace ImGui {
         if (push_texture) draw_list->PopTexture();
     }
 
-    bool InputText(const char* label, std::string& buf, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data)
+    bool InputText(const char* label, std::string& buf, size_t max_length, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data)
     {
-        if (InputText(label, buf.data(), (int)buf.capacity(), flags, callback, user_data)) {
-            buf.resize(strlen(buf.data()));
-            return true;
-        }
-        return false;
+        // Resize to max_length so ImGui can write up to max_length chars into a fully-initialised
+        // buffer. This avoids UB from writing past buf.size() and ensures capacity >= max_length+1.
+        buf.resize(max_length, '\0');
+        const bool changed = InputText(label, buf.data(), max_length + 1, flags, callback, user_data);
+        buf.resize(strnlen(buf.data(), max_length));
+        return changed;
     }
 
     void SetTooltip(std::function<void()> tooltip_callback)

--- a/GWToolboxdll/ImGuiAddons.h
+++ b/GWToolboxdll/ImGuiAddons.h
@@ -30,8 +30,8 @@ namespace ImGui {
     // ImDrawList::AddImage, but allows you to scale the added image down to fit.
     IMGUI_API void AddImageScaled(ImDrawList* draw_list, ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& size, float max_width, float max_height, const ImVec2& uv_min = ImVec2(0, 0), const ImVec2& uv_max = ImVec2(1, 1), ImU32 col = IM_COL32_WHITE);
 
-    // InputText using a std::string - make sure you set the capacity for the string first, otherwise it won't be able to be filled.
-    IMGUI_API bool InputText(const char* label, std::string& buf, ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL);
+    // InputText using a std::string. max_length is the maximum number of characters the user can type.
+    IMGUI_API bool InputText(const char* label, std::string& buf, size_t max_length, ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL);
 
     IMGUI_API void SetTooltip(std::function<void()> tooltip_callback);
 

--- a/GWToolboxdll/Utils/TeamBuild.cpp
+++ b/GWToolboxdll/Utils/TeamBuild.cpp
@@ -545,7 +545,7 @@ void TeamBuild::DrawPlayerBuildsContent(
         ImGui::Text("#%zu", j + 1);
         ImGui::PushItemWidth(btn_offset - btn_width - spacing * 2);
         ImGui::SameLine(btn_width, 0);
-        if (ImGui::InputText("###name", build.name)) {
+        if (ImGui::InputText("###name", build.name, 128)) {
             builds_changed = true;
         }
         if (ImGui::IsItemHovered() && !build.name.empty()) {
@@ -625,7 +625,7 @@ void TeamBuild::DrawPlayerBuildsContent(
 
             ImGui::TextUnformatted("Build Code:");
             ImGui::SameLine();
-            if (ImGui::InputText("###code", build.code)) {
+            if (ImGui::InputText("###code", build.code, 128)) {
                 build.ResetDecodeCache();
                 ResetEncodedCache();
                 builds_changed = true;
@@ -732,7 +732,7 @@ void TeamBuild::DrawHeroBuildsContent(
 
         ImGui::SameLine(offset);
         ImGui::PushItemWidth(text_item_width);
-        if (ImGui::InputText("###name", build.name)) {
+        if (ImGui::InputText("###name", build.name, 128)) {
             builds_changed = true;
         }
         if (ImGui::IsItemHovered() && !build.name.empty()) {
@@ -740,7 +740,7 @@ void TeamBuild::DrawHeroBuildsContent(
         }
 
         ImGui::SameLine(offset += text_item_width + item_spacing);
-        if (ImGui::InputText("###code", build.code)) {
+        if (ImGui::InputText("###code", build.code, 128)) {
             build.ResetDecodeCache();
             ResetEncodedCache();
             builds_changed = true;
@@ -934,8 +934,8 @@ bool TeamBuild::DrawEditWindow(
     }
 
     if (has_hero_slots) {
-        builds_changed |= ImGui::InputText("Hero Build Name", name);
-        builds_changed |= ImGui::InputText("Group", group);
+        builds_changed |= ImGui::InputText("Hero Build Name", name, 128);
+        builds_changed |= ImGui::InputText("Group", group, 128);
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Assign to a group. Builds sharing a group name are shown together under a collapsible header.");
         }
@@ -943,7 +943,7 @@ bool TeamBuild::DrawEditWindow(
     }
     else {
         ImGui::PushItemWidth(-120.f);
-        builds_changed |= ImGui::InputText("Build Name", name);
+        builds_changed |= ImGui::InputText("Build Name", name, 128);
         ImGui::PopItemWidth();
         DrawPlayerBuildsContent(builds_changed);
     }


### PR DESCRIPTION
Fixes a bug in the `ImGui::InputText` `std::string` overload: off-by-one on buf_size, no guaranteed pre-allocation, UB writes past `buf.size()`, and unbounded `strlen`. Adds a required `max_length` parameter and updates all 7 call sites in TeamBuild.cpp to pass 128.

Related to #2091

Generated with [Claude Code](https://claude.ai/code)