### PR TITLE
Add "No Build Defined" placeholder in TeamBuild hover tooltip

### DIFF
--- a/GWToolboxdll/Utils/TeamBuild.cpp
+++ b/GWToolboxdll/Utils/TeamBuild.cpp
@@ -470,6 +470,7 @@ const std::wstring& TeamBuild::GetEncoded() const
 void TeamBuild::ResetEncodedCache() const
 {
     encoded_cache_.reset();
+    tooltip_cache_.reset();
 }
 
 void TeamBuild::Send(bool one_by_one) const
@@ -498,37 +499,44 @@ void TeamBuild::Copy() const
 
 void TeamBuild::DrawTooltip() const
 {
-    for (const auto& build : builds) {
-        const bool has_hero = build.hero_id != GW::Constants::HeroID::NoHero;
-        const bool has_name = !build.name.empty();
-        const bool has_code = !build.code.empty();
+    if (!tooltip_cache_.has_value()) {
+        auto& entries = tooltip_cache_.emplace();
+        for (const auto& build : builds) {
+            const bool has_hero = build.hero_id != GW::Constants::HeroID::NoHero;
+            const bool has_name = !build.name.empty();
+            const bool has_code = !build.code.empty();
 
-        if (has_hero_slots) {
-            if (!has_hero && !has_name && !has_code) continue;
-        } else {
-            if (!has_name && !has_code) continue;
+            if (has_hero_slots) {
+                if (!has_hero && !has_name && !has_code) continue;
+            } else {
+                if (!has_name && !has_code) continue;
+            }
+
+            TooltipEntry& entry = entries.emplace_back();
+            if (has_hero_slots) {
+                const auto& hero_name = has_hero
+                    ? Resources::GetHeroName(build.hero_id)->string()
+                    : std::string("Player");
+                const auto& display_name = has_name ? build.name : build.GetFallbackBuildName();
+                entry.label = std::format("{} ({})", display_name, hero_name);
+            } else {
+                entry.label = build.name;
+            }
+
+            GW::SkillbarMgr::SkillTemplate st{};
+            if (has_code && GW::SkillbarMgr::DecodeSkillTemplate(st, build.code.c_str()))
+                entry.code = build.code;
         }
+    }
 
+    for (const auto& entry : *tooltip_cache_) {
         ImGui::Spacing();
-
-        if (has_hero_slots) {
-            const auto hero_name = has_hero
-                ? Resources::GetHeroName(build.hero_id)->string()
-                : std::string("Player");
-            const auto display_name = has_name ? build.name : build.GetFallbackBuildName();
-            const auto full_name = std::format("{} ({})", display_name, hero_name);
-            ImGui::TextUnformatted(full_name.c_str());
-        } else {
-            ImGui::TextUnformatted(build.name.c_str());
-        }
-
-        GW::SkillbarMgr::SkillTemplate st{};
-        if (has_code && GW::SkillbarMgr::DecodeSkillTemplate(st, build.code.c_str())) {
-            GuiUtils::DrawSkillbar(build.code.c_str(), false);
+        ImGui::TextUnformatted(entry.label.c_str());
+        if (!entry.code.empty()) {
+            GuiUtils::DrawSkillbar(entry.code.c_str(), false);
         } else {
             ImGui::TextColored({1.f, 0.3f, 0.3f, 1.f}, "No Build Defined");
         }
-
         ImGui::Spacing();
     }
 }
@@ -586,6 +594,7 @@ void TeamBuild::DrawPlayerBuildsContent(
         ImGui::PushItemWidth(btn_offset - btn_width - spacing * 2);
         ImGui::SameLine(btn_width, 0);
         if (ImGui::InputText("###name", build.name, 128)) {
+            tooltip_cache_.reset();
             builds_changed = true;
         }
         if (ImGui::IsItemHovered() && !build.name.empty()) {
@@ -773,6 +782,7 @@ void TeamBuild::DrawHeroBuildsContent(
         ImGui::SameLine(offset);
         ImGui::PushItemWidth(text_item_width);
         if (ImGui::InputText("###name", build.name, 128)) {
+            tooltip_cache_.reset();
             builds_changed = true;
         }
         if (ImGui::IsItemHovered() && !build.name.empty()) {

--- a/GWToolboxdll/Utils/TeamBuild.cpp
+++ b/GWToolboxdll/Utils/TeamBuild.cpp
@@ -496,6 +496,43 @@ void TeamBuild::Copy() const
     Log::Flash("Teambuild code copied to clipboard");
 }
 
+void TeamBuild::DrawTooltip() const
+{
+    for (const auto& build : builds) {
+        const bool has_hero = build.hero_id != GW::Constants::HeroID::NoHero;
+        const bool has_name = !build.name.empty();
+        const bool has_code = !build.code.empty();
+
+        if (has_hero_slots) {
+            if (!has_hero && !has_name && !has_code) continue;
+        } else {
+            if (!has_name && !has_code) continue;
+        }
+
+        ImGui::Spacing();
+
+        if (has_hero_slots) {
+            const auto hero_name = has_hero
+                ? Resources::GetHeroName(build.hero_id)->string()
+                : std::string("Player");
+            const auto display_name = has_name ? build.name : build.GetFallbackBuildName();
+            const auto full_name = std::format("{} ({})", display_name, hero_name);
+            ImGui::TextUnformatted(full_name.c_str());
+        } else {
+            ImGui::TextUnformatted(build.name.c_str());
+        }
+
+        GW::SkillbarMgr::SkillTemplate st{};
+        if (has_code && GW::SkillbarMgr::DecodeSkillTemplate(st, build.code.c_str())) {
+            GuiUtils::DrawSkillbar(build.code.c_str(), false);
+        } else {
+            ImGui::TextColored({1.f, 0.3f, 0.3f, 1.f}, "No Build Defined");
+        }
+
+        ImGui::Spacing();
+    }
+}
+
 bool TeamBuild::ChatCodeTooLong() const
 {
     const auto& encoded = GetEncoded();

--- a/GWToolboxdll/Utils/TeamBuild.h
+++ b/GWToolboxdll/Utils/TeamBuild.h
@@ -108,6 +108,10 @@ struct TeamBuild {
     void Load() const;
     void Copy() const;
 
+    // Draw tooltip content showing each build's skill bar, or a red "No Build Defined"
+    // placeholder when the build code is absent or invalid.
+    void DrawTooltip() const;
+
     // Returns true if [TB;<encoded>] would be >= 120 chars (GW chat limit).
     bool ChatCodeTooLong() const;
 

--- a/GWToolboxdll/Utils/TeamBuild.h
+++ b/GWToolboxdll/Utils/TeamBuild.h
@@ -119,9 +119,15 @@ struct TeamBuild {
     void ResetEncodedCache() const;
 
 private:
+    struct TooltipEntry {
+        std::string label;
+        std::string code; // empty when code is absent or fails to decode
+    };
+
     int editing_build_idx_ = -1; // which build row is expanded (player-builds layout)
     bool send_all_confirming_ = false;
     mutable std::optional<std::wstring> encoded_cache_{};
+    mutable std::optional<std::vector<TooltipEntry>> tooltip_cache_{};
 
     // Returns the encoded wstring, computing and caching it on first call.
     const std::wstring& GetEncoded() const;

--- a/GWToolboxdll/Windows/BuildsWindow.cpp
+++ b/GWToolboxdll/Windows/BuildsWindow.cpp
@@ -773,13 +773,7 @@ void BuildsWindow::DrawSettingsInternal()
 
 void SetTooltipFromTeambuild(const TeamBuild* tbuild) {
     ImGui::SetTooltip([tbuild]() {
-        for (const auto& build : tbuild->builds) {
-            if (build.name.empty() && build.code.empty()) continue;
-            ImGui::Spacing();
-            ImGui::TextUnformatted(build.name.c_str());
-            GuiUtils::DrawSkillbar(build.code.c_str(), false);
-            ImGui::Spacing();
-        }
+        tbuild->DrawTooltip();
     });
 }
 

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -273,17 +273,8 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                     tbuild.edit_open = !tbuild.edit_open;
                 }
                 if (ImGui::IsItemHovered()) {
-                    ImGui::SetTooltip([&tbuild, this]() {
-                        for (size_t ti = 0; ti < tbuild.builds.size(); ti++) {
-                            const auto& build = tbuild.builds[ti];
-                            if (build.code.empty() && build.name.empty()) continue;
-                            ImGui::Spacing();
-                            std::string name;
-                            HeroBuildName(build, &name);
-                            ImGui::TextUnformatted(name.empty() ? build.name.c_str() : name.c_str());
-                            GuiUtils::DrawSkillbar(build.code.c_str(), false);
-                            ImGui::Spacing();
-                        }
+                    ImGui::SetTooltip([&tbuild]() {
+                        tbuild.DrawTooltip();
                     });
                 }
                 ImGui::GetStyle().ButtonTextAlign = ImVec2(0.5f, 0.5f);


### PR DESCRIPTION
Closes #2110

Adds `TeamBuild::DrawTooltip()` which consolidates the hover-tooltip logic from both HeroBuildsWindow and BuildsWindow into the TeamBuild class.

Heroes with no build code (or an invalid code) now show a red "No Build Defined" placeholder in the tooltip instead of being silently omitted.

Generated with [Claude Code](https://claude.ai/code)