### PR TITLE
Null-check compass frame context before deref in EnsureCompassIsLoaded

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -294,6 +294,7 @@ namespace {
         const auto compass = GetCompassFrame();
         if (!compass) return false;
         const auto context = static_cast<CompassContext*>(GW::UI::GetFrameContext(compass));
+        if (!context) return false;
         if (!context->compass_canvas) {
             SetWindowVisibleTmp(GW::UI::WindowID_Compass, true);
             pending_compass_hide = true;


### PR DESCRIPTION
Crash stacktrace:

```
>	GWToolboxdll.dll!`anonymous namespace'::EnsureCompassIsLoaded() Line 297	C++
 	GWToolboxdll.dll!Minimap::OnUIMessage(GW::HookStatus * status, GW::UI::UIMessage msgid, void * wParam, void * lParam) Line 875	C++
 	[Inline Frame] GWToolboxdll.dll!std::invoke(void(*)(GW::HookStatus *, GW::UI::UIMessage, void *, void *) &) Line 1680	
 	GWToolboxdll.dll!std::_Func_impl_no_alloc<void (__cdecl*)(GW::HookStatus *,enum GW::UI::UIMessage,void *,void *),void,GW::HookStatus *,enum GW::UI::UIMessage,void *,void *>::_Do_call(GW::HookStatus * && <_Args_0>, GW::UI::UIMessage && <_Args_1>, void * && <_Args_2>, void * && <_Args_3>) Line 880	
 	gwca.dll!6f613cc2()	
```

`context` was null.