### PR TITLE
fix: clarify copyright footer to avoid implying ArenaNet affiliation

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -73,14 +73,14 @@ import siteConfig from '../../site.config.json';
     class="mx-auto max-w-7xl border-t border-(--color-border-glass-subtle) px-4 py-3 text-[0.7rem] leading-relaxed text-(--color-fg-faint) sm:px-6"
   >
     <p class="font-semibold text-(--color-fg-meta)">
-      This website is in no way affiliated with or endorsed by ArenaNet or NCSoft.
+      GWToolbox++ is an independent fan project and is in no way affiliated with or endorsed by ArenaNet or NCSoft.
     </p>
     <p class="mt-1">
-      © 2005&ndash;{new Date().getFullYear()} ArenaNet, Inc. All rights reserved. NCsoft,
-      the interlocking NC logo, ArenaNet, Arena.net, Guild Wars, Guild Wars Factions,
-      Factions, Guild Wars Nightfall, Nightfall, Guild Wars: Eye of the North, Eye of
-      the North, Guild Wars 2, and all associated logos and designs are trademarks or
-      registered trademarks of NCsoft Corporation. All other trademarks are the
+      © {new Date().getFullYear()} GWToolbox++ contributors. Guild Wars and all associated game content are
+      © 2005&ndash;{new Date().getFullYear()} ArenaNet, Inc. All rights reserved. NCsoft, the interlocking NC logo,
+      ArenaNet, Arena.net, Guild Wars, Guild Wars Factions, Factions, Guild Wars Nightfall, Nightfall,
+      Guild Wars: Eye of the North, Eye of the North, Guild Wars 2, and all associated logos and designs
+      are trademarks or registered trademarks of NCsoft Corporation. All other trademarks are the
       property of their respective owners.
     </p>
   </div>


### PR DESCRIPTION
Restructure the docs site footer to make it unambiguous that GWToolbox++ is an independent fan project:

- Site's own copyright (© GWToolbox++ contributors) comes first
- ArenaNet copyright is explicitly attributed to "Guild Wars and all associated game content", not the site
- Trademark list ends cleanly without an ArenaNet copyright notice immediately following "NCsoft Corporation"

Closes #2134

Generated with [Claude Code](https://claude.ai/code)