### PR TITLE
Show Enemy Health Without Needing Player Damage

### DIFF
--- a/GWToolboxdll/Widgets/HealthLogCache.cpp
+++ b/GWToolboxdll/Widgets/HealthLogCache.cpp
@@ -1,0 +1,99 @@
+#include "stdafx.h"
+
+#include <ToolboxIni.h>
+#include <Modules/Resources.h>
+#include <Utils/TextUtils.h>
+#include <Widgets/HealthLogCache.h>
+
+namespace {
+    constexpr const wchar_t* HEALTHLOG_INI_FILENAME = L"healthlog.ini";
+    constexpr const char* HEALTHLOG_INI_SECTION = "health";
+
+    ToolboxIni* healthlog_ini = nullptr;
+    std::unordered_map<uint32_t, uint32_t> healthlog_max_hp;
+    bool healthlog_loaded = false;
+    std::filesystem::path healthlog_path;
+
+    std::vector<std::filesystem::path> GetHealthLogCandidates()
+    {
+        const auto primary_path = Resources::GetSettingFile(HEALTHLOG_INI_FILENAME);
+        const auto fallback_path = Resources::GetPath(HEALTHLOG_INI_FILENAME);
+        const auto cwd_path = std::filesystem::current_path() / HEALTHLOG_INI_FILENAME;
+        const auto exe_path = Resources::GetExePath().parent_path() / HEALTHLOG_INI_FILENAME;
+        return {primary_path, fallback_path, cwd_path, exe_path};
+    }
+}
+
+namespace HealthLogCache {
+    void Load()
+    {
+        if (healthlog_loaded) {
+            return;
+        }
+        healthlog_loaded = true;
+
+        if (healthlog_ini == nullptr) {
+            healthlog_ini = new ToolboxIni(false, false, false);
+        }
+
+        const auto candidates = GetHealthLogCandidates();
+        const auto fallback_path = Resources::GetPath(HEALTHLOG_INI_FILENAME);
+        std::filesystem::path path;
+        for (const auto& candidate : candidates) {
+            if (std::filesystem::exists(candidate)) {
+                path = candidate;
+                break;
+            }
+        }
+        healthlog_path = path;
+        if (path.empty()) {
+            return;
+        }
+
+        healthlog_max_hp.clear();
+        if (healthlog_ini->LoadFile(path) != SI_OK) {
+            return;
+        }
+
+        TNamesDepend keys;
+        healthlog_ini->GetAllKeys(HEALTHLOG_INI_SECTION, keys);
+        if (keys.empty() && path != fallback_path && std::filesystem::exists(fallback_path)) {
+            healthlog_ini->LoadFile(fallback_path);
+            healthlog_ini->GetAllKeys(HEALTHLOG_INI_SECTION, keys);
+            healthlog_path = fallback_path;
+        }
+
+        for (const auto& key : keys) {
+            int id = 0;
+            if (!TextUtils::ParseInt(key.pItem, &id) || id <= 0) {
+                continue;
+            }
+            const long hp = healthlog_ini->GetLongValue(HEALTHLOG_INI_SECTION, key.pItem, 0);
+            if (hp > 0) {
+                healthlog_max_hp[static_cast<uint32_t>(id)] = static_cast<uint32_t>(hp);
+            }
+        }
+    }
+
+    const std::unordered_map<uint32_t, uint32_t>& GetMap()
+    {
+        Load();
+        return healthlog_max_hp;
+    }
+
+    bool TryGetMaxHp(uint32_t player_number, uint32_t& max_hp_out)
+    {
+        Load();
+        const auto it = healthlog_max_hp.find(player_number);
+        if (it == healthlog_max_hp.end()) {
+            return false;
+        }
+        max_hp_out = it->second;
+        return true;
+    }
+
+    const std::filesystem::path& GetPath()
+    {
+        return healthlog_path;
+    }
+}

--- a/GWToolboxdll/Widgets/HealthLogCache.h
+++ b/GWToolboxdll/Widgets/HealthLogCache.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <unordered_map>
+
+namespace HealthLogCache {
+    void Load();
+    const std::unordered_map<uint32_t, uint32_t>& GetMap();
+    bool TryGetMaxHp(uint32_t player_number, uint32_t& max_hp_out);
+    const std::filesystem::path& GetPath();
+}

--- a/GWToolboxdll/Widgets/HealthWidget.cpp
+++ b/GWToolboxdll/Widgets/HealthWidget.cpp
@@ -15,6 +15,7 @@
 #include <Defines.h>
 #include <Utils/GuiUtils.h>
 #include <Modules/Resources.h>
+#include <Widgets/HealthLogCache.h>
 #include <Widgets/HealthWidget.h>
 #include <Utils/FontLoader.h>
 #include <Utils/TextUtils.h>
@@ -245,7 +246,12 @@ void HealthWidget::Draw(IDirect3DDevice9*)
                 ImGui::PushFont(FontLoader::GetFont(), font_size_abs_value);
                 cur = ImGui::GetCursorPos();
                 ImGui::SetCursorPos(ImVec2(cur.x + 2, cur.y + 2));
-                const auto health_abs = target->max_hp > 0 ? std::format("{:.0f} / {}", target->hp * target->max_hp, target->max_hp) : "-";
+                uint32_t saved_max_hp = 0;
+                if (!HealthLogCache::TryGetMaxHp(target->player_number, saved_max_hp)) {
+                    saved_max_hp = 0;
+                }
+                const uint32_t display_max_hp = target->max_hp > 0 ? target->max_hp : saved_max_hp;
+                const auto health_abs = display_max_hp > 0 ? std::format("{:.0f} / {}", target->hp * display_max_hp, display_max_hp) : "-";
                 ImGui::TextColored(background, health_abs.c_str());
                 ImGui::SetCursorPos(cur);
                 ImGui::Text(health_abs.c_str());
@@ -255,11 +261,14 @@ void HealthWidget::Draw(IDirect3DDevice9*)
             if (click_to_print_health) {
                 if (ctrl_pressed && ImGui::IsMouseReleased(0) && ImGui::IsWindowHovered()) {
                     if (target) {
+                        uint32_t saved_max_hp = 0;
+                        HealthLogCache::TryGetMaxHp(target->player_number, saved_max_hp);
+                        const uint32_t display_max_hp = target->max_hp > 0 ? target->max_hp : saved_max_hp;
                         GW::Agents::AsyncGetAgentName(target, agent_name_ping);
-                        if (!agent_name_ping.empty()) {
+                        if (!agent_name_ping.empty() && display_max_hp > 0) {
                             const std::string agent_name_str = TextUtils::WStringToString(agent_name_ping);
-                            const auto current_hp = static_cast<int>(target->hp * target->max_hp);
-                            const auto message = std::format("{}'s health is {} of {} ({:.0f}%).", agent_name_str.c_str(), current_hp, target->max_hp, target->hp * 100.f);
+                            const auto current_hp = static_cast<int>(target->hp * display_max_hp);
+                            const auto message = std::format("{}'s health is {} of {} ({:.0f}%).", agent_name_str.c_str(), current_hp, display_max_hp, target->hp * 100.f);
                             GW::Chat::SendChat('#', message.c_str());
                         }
                     }

--- a/GWToolboxdll/Widgets/PartyDamage.cpp
+++ b/GWToolboxdll/Widgets/PartyDamage.cpp
@@ -14,6 +14,7 @@
 
 #include <Modules/Resources.h>
 #include <Modules/ToolboxSettings.h>
+#include <Widgets/HealthLogCache.h>
 #include <Widgets/PartyDamage.h>
 #include <Utils/TextUtils.h>
 #include <Utils/ToolboxUtils.h>
@@ -782,24 +783,10 @@ void PartyDamage::LoadSettings(ToolboxIni* ini)
     LOAD_BOOL(show_healing);
 
 
-    if (inifile == nullptr) {
-        inifile = new ToolboxIni(false, false, false);
-    }
-    inifile->LoadFile(Resources::GetSettingFile(INI_FILENAME).c_str());
-    TNamesDepend keys;
-    inifile->GetAllKeys(IniSection, keys);
-    for (const auto& key : keys) {
-        int lkey;
-        if (TextUtils::ParseInt(key.pItem, &lkey)) {
-            if (lkey <= 0) {
-                continue;
-            }
-            const long lval = inifile->GetLongValue(IniSection, key.pItem, 0);
-            if (lval <= 0) {
-                continue;
-            }
-            hp_map[static_cast<size_t>(lkey)] = static_cast<uint32_t>(lval);
-        }
+    HealthLogCache::Load();
+    const auto& cache = HealthLogCache::GetMap();
+    for (const auto& [player_number, hp] : cache) {
+        hp_map[static_cast<size_t>(player_number)] = hp;
     }
 }
 


### PR DESCRIPTION
- Introduced `HealthLogCache` as the single shared loader for `healthlog.ini`
- `HealthLogCache` uses previously fixed `FastIni::GetAllKeys` so it returns key names correctly
- Updated `HealthWidget` and `PartyDamage` to use `HealthLogCache`
- Allow `HealthWidget` to display enemy HP/Max HP without needing player damage first, by loading Max HP value from `HealthLogCache`