### PR TITLE
Fix pointer-based ImGui IDs that pollute ini files

### DIFF
--- a/GWToolboxdll/ImGuiAddons.cpp
+++ b/GWToolboxdll/ImGuiAddons.cpp
@@ -347,7 +347,8 @@ namespace ImGui {
     bool ConfirmButton(const char* label, bool* confirm_bool, const char* confirm_content)
     {
         static char id_buf[128];
-        snprintf(id_buf, sizeof(id_buf), "%s##confirm_popup", label);
+        const ImGuiID h = ImHashStr(confirm_content, 0, ImHashStr(label));
+        snprintf(id_buf, sizeof(id_buf), "%s###confirm_popup_%u", label, h);
         if (Button(label)) {
             OpenPopup(id_buf);
         }

--- a/GWToolboxdll/ImGuiAddons.cpp
+++ b/GWToolboxdll/ImGuiAddons.cpp
@@ -299,8 +299,6 @@ namespace ImGui {
 
     bool SmallConfirmButton(const char* label, const char* confirm_content, ImGui::ImGuiConfirmDialogCallback callback, void* wparam)
     {
-        static char id_buf[128];
-        snprintf(id_buf, sizeof(id_buf), "%s##confirm_popup%p", label, label);
         if (SmallButton(label)) {
             ConfirmDialog(confirm_content, callback, wparam);
             return true;
@@ -349,7 +347,7 @@ namespace ImGui {
     bool ConfirmButton(const char* label, bool* confirm_bool, const char* confirm_content)
     {
         static char id_buf[128];
-        snprintf(id_buf, sizeof(id_buf), "%s##confirm_popup%p", label, confirm_bool);
+        snprintf(id_buf, sizeof(id_buf), "%s##confirm_popup", label);
         if (Button(label)) {
             OpenPopup(id_buf);
         }

--- a/GWToolboxdll/Modules/AudioSettings.cpp
+++ b/GWToolboxdll/Modules/AudioSettings.cpp
@@ -311,9 +311,9 @@ void AudioSettings::DrawSettingsInternal() {
     using PlaySoundInt_pt = bool(__cdecl*)(const wchar_t*, uint32_t, uint32_t, uint32_t);
 
     auto log_sound = [](const std::wstring& filename, PlaySoundInt_pt PlaySound_pt, uint32_t arg1, uint32_t arg2, uint32_t arg3) {
-        ImGui::PushID(&filename);
         std::string buf;
         GuiUtils::ArrayToIni(filename, &buf);
+        ImGui::PushID(buf.c_str());
         ImGui::TextUnformatted(buf.c_str());
         ImGui::SameLine(200.f * ImGui::FontScale());
         if (ImGui::Button("Play")) {

--- a/GWToolboxdll/Windows/GWMarketWindow.cpp
+++ b/GWToolboxdll/Windows/GWMarketWindow.cpp
@@ -940,7 +940,7 @@ namespace {
                 if (name_lower.find(search_lower) == std::string::npos) continue;
             }
 
-            ImGui::PushID(item.name);
+            ImGui::PushID(item.name->c_str());
 
             bool selected = (current_viewing_item == *item.name);
             if (ImGui::Selectable(item.name->c_str(), selected)) {


### PR DESCRIPTION
Fixes #3 instances where runtime pointer values (memory addresses) were being used as ImGui widget/popup IDs. Since ASLR changes addresses each run, this generated new unique entries in interface.ini/Layouts.ini on every session, contributing to the bloat described in #2152.

Changes:
- `AudioSettings.cpp`: reorder buf setup before PushID, use string content
- `ImGuiAddons.cpp` SmallConfirmButton: remove dead id_buf line (never used)
- `ImGuiAddons.cpp` ConfirmButton: replace %p pointer with label-based popup ID
- `GWMarketWindow.cpp`: use item.name->c_str() instead of raw std::string*

Closes #2152

Generated with [Claude Code](https://claude.ai/code)