### PR TITLE
feat: Hero builds group sequencing (HerobuildGroup with sort_order)

### DIFF
--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -45,6 +45,48 @@ namespace {
 
     ToolboxIni* inifile = nullptr;
 
+    // ----------------------------------------------------------------
+    // Hero build group ordering
+    // ----------------------------------------------------------------
+
+    struct HerobuildGroup {
+        std::string name{};
+        size_t sort_order = SIZE_MAX;
+    };
+
+    std::unordered_map<std::string, HerobuildGroup> hero_build_groups;
+
+    size_t GetGroupSortOrder(const std::string& name)
+    {
+        if (name.empty()) return SIZE_MAX;
+        const auto it = hero_build_groups.find(name);
+        return it != hero_build_groups.end() ? it->second.sort_order : SIZE_MAX;
+    }
+
+    // Creates the group if it doesn't exist, assigning a provisional sort_order
+    // equal to the current group count (so first-seen order is preserved).
+    // Returns the group (existing or newly created).
+    HerobuildGroup& UpsertGroup(const std::string& name)
+    {
+        if (!hero_build_groups.contains(name)) {
+            HerobuildGroup& grp = hero_build_groups[name];
+            grp.name = name;
+            grp.sort_order = hero_build_groups.size() - 1;
+            return grp;
+        }
+        return hero_build_groups[name];
+    }
+
+    void SortTeambuilds(std::vector<TeamBuild>& teambuilds)
+    {
+        std::stable_sort(teambuilds.begin(), teambuilds.end(),
+            [](const TeamBuild& a, const TeamBuild& b) {
+                return GetGroupSortOrder(a.group) < GetGroupSortOrder(b.group);
+            });
+    }
+
+    // ----------------------------------------------------------------
+
     // GW file 0x268f6: 2x2 sprite sheet (tick/cross overlays)
     // Bottom-left sprite (col 0, row 1) = semi-transparent cross = "disabled" overlay
     IDirect3DTexture9** skill_toggle_sprite = nullptr;
@@ -211,6 +253,7 @@ void HeroBuildsWindow::Terminate()
 {
     ToolboxWindow::Terminate();
     teambuilds.clear();
+    hero_build_groups.clear();
     detached_pool.clear();
     GW::Chat::DeleteCommand(&ChatCmd_HookEntry);
     GW::UI::RemoveUIMessageCallback(&OnOpenTemplate_Entry);
@@ -249,16 +292,38 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                 filtered.push_back(&tbuild);
             }
 
-            // Build ordered group list
-            std::vector<std::string> group_order;
+            // Group builds by name
             std::unordered_map<std::string, std::vector<TeamBuild*>> by_group;
             for (TeamBuild* tbuild : filtered) {
-                const std::string g(tbuild->group);
-                if (!by_group.contains(g)) {
-                    by_group[g] = {};
-                    group_order.push_back(g);
+                by_group[std::string(tbuild->group)].push_back(tbuild);
+            }
+
+            // Auto-register groups that were typed into the "Group" field but have
+            // not yet been written to file (and so have no herobuildgroup entry).
+            for (const auto& [gname, _] : by_group) {
+                if (!gname.empty() && !hero_build_groups.contains(gname)) {
+                    UpsertGroup(gname);
                 }
-                by_group[g].push_back(tbuild);
+            }
+
+            // Order named groups by sort_order; ungrouped builds appear last.
+            std::vector<std::string> group_order;
+            {
+                std::vector<const HerobuildGroup*> sorted_grps;
+                for (const auto& [name, grp] : hero_build_groups) {
+                    if (by_group.contains(name)) {
+                        sorted_grps.push_back(&grp);
+                    }
+                }
+                std::ranges::sort(sorted_grps, [](const HerobuildGroup* a, const HerobuildGroup* b) {
+                    return a->sort_order < b->sort_order;
+                });
+                for (const auto* grp : sorted_grps) {
+                    group_order.push_back(grp->name);
+                }
+            }
+            if (by_group.contains("")) {
+                group_order.push_back("");
             }
 
             auto draw_teambuild_row = [&](TeamBuild& tbuild) {
@@ -302,7 +367,8 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                 ImGui::PopID();
             };
 
-            for (const auto& group_name : group_order) {
+            for (size_t gi = 0; gi < group_order.size(); gi++) {
+                const auto& group_name = group_order[gi];
                 auto& group_builds = by_group[group_name];
                 if (group_name.empty()) {
                     for (TeamBuild* tbuild : group_builds) {
@@ -311,7 +377,47 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                 }
                 else {
                     ImGui::PushID(group_name.c_str());
-                    const bool open = ImGui::CollapsingHeader(group_name.c_str(), ImGuiTreeNodeFlags_DefaultOpen);
+
+                    // A named group is "last" when no further named group follows it.
+                    const bool is_first = (gi == 0);
+                    const bool is_last = (gi + 1 >= group_order.size() || group_order[gi + 1].empty());
+
+                    constexpr auto header_flags = ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_AllowOverlap;
+                    const bool open = ImGui::CollapsingHeader(group_name.c_str(), header_flags);
+
+                    // Overlay ↑/↓ buttons on the right side of the header row.
+                    {
+                        const float btn_sz = ImGui::GetFrameHeight();
+                        const float spacing = ImGui::GetStyle().ItemSpacing.x;
+                        ImGui::SameLine();
+                        float btn_x = ImGui::GetContentRegionAvail().x + ImGui::GetCursorPosX();
+                        const float btn_y = ImGui::GetCursorPosY();
+
+                        if (!is_last) {
+                            btn_x -= btn_sz;
+                            ImGui::SetCursorPos({btn_x, btn_y});
+                            if (ImGui::Button(ICON_FA_ARROW_DOWN "##gd", ImVec2(btn_sz, btn_sz))) {
+                                std::swap(hero_build_groups[group_name].sort_order,
+                                          hero_build_groups[group_order[gi + 1]].sort_order);
+                                SortTeambuilds(teambuilds);
+                                builds_changed = true;
+                            }
+                            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Move group down");
+                            btn_x -= spacing;
+                        }
+                        if (!is_first) {
+                            btn_x -= btn_sz;
+                            ImGui::SetCursorPos({btn_x, btn_y});
+                            if (ImGui::Button(ICON_FA_ARROW_UP "##gu", ImVec2(btn_sz, btn_sz))) {
+                                std::swap(hero_build_groups[group_name].sort_order,
+                                          hero_build_groups[group_order[gi - 1]].sort_order);
+                                SortTeambuilds(teambuilds);
+                                builds_changed = true;
+                            }
+                            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Move group up");
+                        }
+                    }
+
                     if (open) {
                         ImGui::Indent();
                         for (TeamBuild* tbuild : group_builds) {
@@ -576,21 +682,39 @@ void HeroBuildsWindow::SaveSettings(ToolboxIni* ini)
 
 void HeroBuildsWindow::LoadFromFile()
 {
-    // clear builds from toolbox
     teambuilds.clear();
+    hero_build_groups.clear();
 
     inifile->LoadFile(Resources::GetSettingFile(INI_FILENAME).c_str());
 
-    // then load
     TNamesDepend entries;
     inifile->GetAllSections(entries);
     for (const auto& entry : entries) {
         const char* section = entry.pItem;
 
+        // herobuildgroup sections carry sort_order metadata for named groups.
+        // They may appear before or after the builds that reference them.
+        if (strncmp(section, "herobuildgroup", 14) == 0) {
+            const char* name = inifile->GetValue(section, "name", "");
+            if (!*name) continue;
+            auto& grp = hero_build_groups[name];
+            grp.name = name;
+            grp.sort_order = static_cast<size_t>(inifile->GetLongValue(section, "sort_order", static_cast<long>(grp.sort_order)));
+            continue;
+        }
+
+        if (strncmp(section, "builds", 6) != 0) continue;
+
         TeamBuild tb(inifile->GetValue(section, "buildname", ""));
         tb.has_hero_slots = true;
         tb.mode = inifile->GetLongValue(section, "mode", false);
         tb.group = inifile->GetValue(section, "group", "");
+
+        // Create the group with a provisional sort_order if it hasn't been seen yet.
+        // An explicit herobuildgroup section (processed above or below) will overwrite it.
+        if (!tb.group.empty()) {
+            UpsertGroup(tb.group);
+        }
 
         for (auto i = 0; i < 8; i++) {
             constexpr size_t buffer_size = 16;
@@ -630,6 +754,10 @@ void HeroBuildsWindow::LoadFromFile()
 
         teambuilds.push_back(std::move(tb));
     }
+
+    // Sort so that builds belonging to the same group are contiguous and groups
+    // appear in ascending sort_order. Relative order within each group is preserved.
+    SortTeambuilds(teambuilds);
 
     builds_changed = false;
 }
@@ -672,6 +800,29 @@ void HeroBuildsWindow::SaveToFile() const
                 inifile->SetLongValue(section, behaviorkey, build.behavior);
                 inifile->SetLongValue(section, dskillskey, build.disabled_skills);
             }
+        }
+
+        // Collect groups that are still referenced by at least one build.
+        std::unordered_set<std::string> used_groups;
+        for (const auto& tb : teambuilds) {
+            if (!tb.group.empty()) used_groups.insert(tb.group);
+        }
+
+        // Build a sorted list of used groups; write with normalized 0-based sort_order.
+        std::vector<std::pair<std::string, size_t>> sorted_groups;
+        for (const auto& [name, grp] : hero_build_groups) {
+            if (used_groups.contains(name)) {
+                sorted_groups.push_back({name, grp.sort_order});
+            }
+        }
+        std::ranges::sort(sorted_groups, [](const auto& a, const auto& b) {
+            return a.second < b.second;
+        });
+        for (size_t gi = 0; gi < sorted_groups.size(); gi++) {
+            char grp_section[32];
+            snprintf(grp_section, sizeof(grp_section), "herobuildgroup%03zu", gi);
+            inifile->SetValue(grp_section, "name", sorted_groups[gi].first.c_str());
+            inifile->SetLongValue(grp_section, "sort_order", static_cast<long>(gi));
         }
 
         ASSERT(inifile->SaveFile(Resources::GetSettingFile(INI_FILENAME).c_str()) == SI_OK);


### PR DESCRIPTION
Fixes #2147

Adds `HerobuildGroup` struct to `HeroBuildsWindow` so named groups of hero builds can be reordered, mirroring the existing `HotkeyGroup` pattern used for hotkeys.

## Changes
- New `HerobuildGroup { name, sort_order }` struct and helpers (`UpsertGroup`, `GetGroupSortOrder`, `SortTeambuilds`) in anonymous namespace
- `LoadFromFile`: parses `herobuildgroup*` ini sections; calls `UpsertGroup` when a build has a group name; provisional sort_order inferred from first-seen order when no explicit entry exists; stable-sorts teambuilds after loading
- `SaveToFile`: writes `herobuildgroup*` sections with normalised 0-based sort_order; unused groups are pruned
- `Draw`: group headers get ↑/↓ buttons via `ImGuiTreeNodeFlags_AllowOverlap`; clicking swaps adjacent group sort_orders and re-sorts the builds vector
- `Terminate`: clears `hero_build_groups`

Generated with [Claude Code](https://claude.ai/code)