### PR TITLE
feat: add "Sort by Map" buttons to custom markers, lines, and polygons

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/CustomRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/CustomRenderer.cpp
@@ -395,6 +395,16 @@ void CustomRenderer::DrawLineSettings()
         });
         markers_changed = true;
     }
+    ImGui::SameLine();
+    bool sort_lines_by_map = false;
+    if (ImGui::ConfirmButton("Sort by Map##lines", &sort_lines_by_map, "Sort all lines by map ID?\nThis cannot be undone.")) {
+        std::sort(lines.begin(), lines.end(), [](const CustomLine* a, const CustomLine* b) {
+            if (a->map != b->map)
+                return static_cast<uint32_t>(a->map) < static_cast<uint32_t>(b->map);
+            return strcmp(a->name, b->name) < 0;
+        });
+        markers_changed = true;
+    }
 }
 
 void CustomRenderer::DrawMarkerSettings()
@@ -530,6 +540,19 @@ void CustomRenderer::DrawMarkerSettings()
     bool sort_markers = false;
     if (ImGui::ConfirmButton("Sort A-Z##markers", &sort_markers, "Sort all markers alphabetically by name?\nThis cannot be undone.")) {
         std::sort(markers.begin(), markers.end(), [](const CustomMarker& a, const CustomMarker& b) {
+            return strcmp(a.name, b.name) < 0;
+        });
+        for (auto& mark : markers) {
+            mark.Invalidate();
+        }
+        markers_changed = true;
+    }
+    ImGui::SameLine();
+    bool sort_markers_by_map = false;
+    if (ImGui::ConfirmButton("Sort by Map##markers", &sort_markers_by_map, "Sort all markers by map ID?\nThis cannot be undone.")) {
+        std::sort(markers.begin(), markers.end(), [](const CustomMarker& a, const CustomMarker& b) {
+            if (a.map != b.map)
+                return static_cast<uint32_t>(a.map) < static_cast<uint32_t>(b.map);
             return strcmp(a.name, b.name) < 0;
         });
         for (auto& mark : markers) {
@@ -709,6 +732,19 @@ void CustomRenderer::DrawPolygonSettings()
     bool sort_polygons = false;
     if (ImGui::ConfirmButton("Sort A-Z##polygons", &sort_polygons, "Sort all polygons alphabetically by name?\nThis cannot be undone.")) {
         std::sort(polygons.begin(), polygons.end(), [](const CustomPolygon& a, const CustomPolygon& b) {
+            return strcmp(a.name, b.name) < 0;
+        });
+        for (auto& poly : polygons) {
+            poly.Invalidate();
+        }
+        markers_changed = true;
+    }
+    ImGui::SameLine();
+    bool sort_polygons_by_map = false;
+    if (ImGui::ConfirmButton("Sort by Map##polygons", &sort_polygons_by_map, "Sort all polygons by map ID?\nThis cannot be undone.")) {
+        std::sort(polygons.begin(), polygons.end(), [](const CustomPolygon& a, const CustomPolygon& b) {
+            if (a.map != b.map)
+                return static_cast<uint32_t>(a.map) < static_cast<uint32_t>(b.map);
             return strcmp(a.name, b.name) < 0;
         });
         for (auto& poly : polygons) {


### PR DESCRIPTION
Adds "Sort by Map" buttons alongside the existing "Sort A-Z" buttons in the Custom Circles, Custom Lines, and Custom Polygons settings panels. Sorting uses map ID as primary key and name A-Z as secondary key for ties.

Fixes #2150.

Generated with [Claude Code](https://claude.ai/code)