### PR TITLE
Fix Layout.ini bloat from window position accumulation

### DIFF
--- a/GWToolboxdll/Modules/ToolboxTheme.cpp
+++ b/GWToolboxdll/Modules/ToolboxTheme.cpp
@@ -14,6 +14,19 @@ constexpr auto WindowPositionsFilename = L"Layout.ini";
 constexpr auto IniSection = "Theme";
 
 namespace {
+    // Returns the stable save identifier for a window name.
+    // For "Display Name###ID" returns "ID" (the part after ###).
+    // For "Label##ID" returns "ID" (the part after ##).
+    // For plain names returns the full name.
+    const char* GetWindowSaveId(const char* name)
+    {
+        const char* triple = strstr(name, "###");
+        if (triple) return triple + 3;
+        const char* dbl = strstr(name, "##");
+        if (dbl) return dbl + 2;
+        return name;
+    }
+
     ToolboxIni* LoadIni(ToolboxIni** out, const wchar_t* filename, bool reload_from_disk = false)
     {
         if (!*out) {
@@ -128,26 +141,37 @@ void ToolboxTheme::SaveUILayout()
     }
     const auto ini = GetLayoutIni(false);
     const auto window_ini_section = "Windows";
+
+    // Clear the section before writing so deleted/renamed windows don't accumulate.
+    ini->Delete(window_ini_section, nullptr);
+
+    // Flags that mark windows not worth persisting (child widgets, popups, tooltips, etc.)
+    constexpr ImGuiWindowFlags skip_flags =
+        ImGuiWindowFlags_ChildWindow | ImGuiWindowFlags_Popup |
+        ImGuiWindowFlags_Modal | ImGuiWindowFlags_Tooltip |
+        ImGuiWindowFlags_NoSavedSettings;
+
     ImVector<ImGuiWindow*>& windows = ImGui::GetCurrentContext()->Windows;
     for (const ImGuiWindow* window : windows) {
-        if (!window) 
+        if (!window)
             continue;
-        char key[128];
-        auto pos = &window->OuterRectClipped.Min;
-        if (pos->x == 0.f && pos->y == 0.f) {
-            // If SaveUILayout was called outside of the ImGui draw loop, Pos may be zeroed out.
-            pos = &window->OuterRectClipped.Min;
-        }
+        if (window->Flags & skip_flags)
+            continue;
 
-        snprintf(key, _countof(key), "_%s_X", window->Name);
-        ini->SetDoubleValue(window_ini_section, key, pos->x);
-        snprintf(key, _countof(key), "_%s_Y", window->Name);
-        ini->SetDoubleValue(window_ini_section, key, pos->y);
-        snprintf(key, _countof(key), "_%s_W", window->Name);
+        // Use only the stable ID (part after ### or ##) so renaming a window doesn't
+        // orphan old entries. E.g. "My Build###teambuild_1" → key prefix "teambuild_1".
+        const char* save_id = GetWindowSaveId(window->Name);
+
+        char key[128];
+        snprintf(key, _countof(key), "_%s_X", save_id);
+        ini->SetDoubleValue(window_ini_section, key, window->Pos.x);
+        snprintf(key, _countof(key), "_%s_Y", save_id);
+        ini->SetDoubleValue(window_ini_section, key, window->Pos.y);
+        snprintf(key, _countof(key), "_%s_W", save_id);
         ini->SetDoubleValue(window_ini_section, key, window->SizeFull.x);
-        snprintf(key, _countof(key), "_%s_H", window->Name);
+        snprintf(key, _countof(key), "_%s_H", save_id);
         ini->SetDoubleValue(window_ini_section, key, window->SizeFull.y);
-        snprintf(key, _countof(key), "_%s_Collapsed", window->Name);
+        snprintf(key, _countof(key), "_%s_Collapsed", save_id);
         ini->SetBoolValue(window_ini_section, key, window->Collapsed);
     }
     ASSERT(Resources::SaveIniToFile(Resources::GetSettingFile(WindowPositionsFilename), ini) == 0);
@@ -185,64 +209,57 @@ void ToolboxTheme::LoadUILayout()
         ApplyWindowSettings(ini, window_ini_section, window);
     }
 
-    // Second, pre-populate settings for windows that don't exist yet
-    // This uses ImGui's internal settings system
+    // Second, pre-populate ImGui's internal settings for windows not yet open.
+    // Keys are stored as _<save_id>_X/_Y/_W/_H/_Collapsed where save_id is the
+    // stable identifier (part after ### or ## in the window name, or the full name).
     TNamesDepend keys;
     ini->GetAllKeys(window_ini_section, keys);
 
     for (const auto& key : keys) {
-        if (key.pItem[0] != '_') continue; // Skip non-window keys
+        const char* k = key.pItem;
+        if (k[0] != '_') continue;
 
-        // Extract window name from key (format: _WindowName_X, _WindowName_Y, etc.)
-        std::string key_str(key.pItem);
-        size_t first_underscore = key_str.find('_', 1);
-        if (first_underscore == std::string::npos) continue;
+        // Only process _X keys to avoid visiting each window 5 times.
+        const size_t klen = strlen(k);
+        if (klen < 3 || k[klen - 2] != '_' || k[klen - 1] != 'X') continue;
 
-        std::string window_name = key_str.substr(1, first_underscore - 1);
+        // Extract save_id: strip leading _ and trailing _X
+        const std::string save_id(k + 1, klen - 3);
+        if (save_id.empty()) continue;
 
-        // Check if this window already exists
+        // Check if a window with this stable ID already exists (handled above).
         bool exists = false;
         for (ImGuiWindow* window : windows) {
-            if (window && strcmp(window->Name, window_name.c_str()) == 0) {
+            if (window && strcmp(GetWindowSaveId(window->Name), save_id.c_str()) == 0) {
                 exists = true;
                 break;
             }
         }
 
         if (!exists) {
-            // Create settings entry for windows that don't exist yet
-            const ImGuiID window_id = ImHashStr(window_name.c_str());
+            const ImGuiID window_id = ImHashStr(save_id.c_str());
             ImGuiWindowSettings* settings = ImGui::FindWindowSettingsByID(window_id);
-
             if (!settings) {
-                settings = ImGui::CreateNewWindowSettings(window_name.c_str());
+                settings = ImGui::CreateNewWindowSettings(save_id.c_str());
             }
-
             if (settings) {
                 char key_buf[128];
+                snprintf(key_buf, sizeof(key_buf), "_%s_X", save_id.c_str());
+                const float x = static_cast<float>(ini->GetDoubleValue(window_ini_section, key_buf, 0.0f));
+                snprintf(key_buf, sizeof(key_buf), "_%s_Y", save_id.c_str());
+                const float y = static_cast<float>(ini->GetDoubleValue(window_ini_section, key_buf, 0.0f));
+                snprintf(key_buf, sizeof(key_buf), "_%s_W", save_id.c_str());
+                const float w = static_cast<float>(ini->GetDoubleValue(window_ini_section, key_buf, 0.0f));
+                snprintf(key_buf, sizeof(key_buf), "_%s_H", save_id.c_str());
+                const float h = static_cast<float>(ini->GetDoubleValue(window_ini_section, key_buf, 0.0f));
+                snprintf(key_buf, sizeof(key_buf), "_%s_Collapsed", save_id.c_str());
+                const bool collapsed = ini->GetBoolValue(window_ini_section, key_buf, false);
 
-                // Read positions from INI (these are stored as floats in your INI)
-                snprintf(key_buf, sizeof(key_buf), "_%s_X", window_name.c_str());
-                float x = static_cast<float>(ini->GetDoubleValue(window_ini_section, key_buf, 0.0f));
-                snprintf(key_buf, sizeof(key_buf), "_%s_Y", window_name.c_str());
-                float y = static_cast<float>(ini->GetDoubleValue(window_ini_section, key_buf, 0.0f));
-                snprintf(key_buf, sizeof(key_buf), "_%s_W", window_name.c_str());
-                float w = static_cast<float>(ini->GetDoubleValue(window_ini_section, key_buf, 0.0f));
-                snprintf(key_buf, sizeof(key_buf), "_%s_H", window_name.c_str());
-                float h = static_cast<float>(ini->GetDoubleValue(window_ini_section, key_buf, 0.0f));
-
-                // Convert to ImVec2ih (short integers)
-                // Note: Pos should be relative to viewport, but if you're storing absolute positions,
-                // you might need to adjust this. For single-viewport setups, they're often the same.
-                settings->Pos.x = (short)x;
-                settings->Pos.y = (short)y;
-                settings->Size.x = (short)w;
-                settings->Size.y = (short)h;
-
-                snprintf(key_buf, sizeof(key_buf), "_%s_Collapsed", window_name.c_str());
-                settings->Collapsed = ini->GetBoolValue(window_ini_section, key_buf, false);
-
-                // Important: Tell ImGui to apply these settings when the window is created
+                settings->Pos.x = static_cast<short>(x);
+                settings->Pos.y = static_cast<short>(y);
+                settings->Size.x = static_cast<short>(w);
+                settings->Size.y = static_cast<short>(h);
+                settings->Collapsed = collapsed;
                 settings->WantApply = true;
             }
         }
@@ -254,19 +271,20 @@ void ToolboxTheme::LoadUILayout()
 
 void ToolboxTheme::ApplyWindowSettings(ToolboxIni* ini, const char* section, ImGuiWindow* window)
 {
+    const char* save_id = GetWindowSaveId(window->Name);
     ImVec2 pos = window->Pos;
     ImVec2 size = window->Size;
     char key[128];
 
-    snprintf(key, sizeof(key), "_%s_X", window->Name);
+    snprintf(key, sizeof(key), "_%s_X", save_id);
     pos.x = static_cast<float>(ini->GetDoubleValue(section, key, pos.x));
-    snprintf(key, sizeof(key), "_%s_Y", window->Name);
+    snprintf(key, sizeof(key), "_%s_Y", save_id);
     pos.y = static_cast<float>(ini->GetDoubleValue(section, key, pos.y));
-    snprintf(key, sizeof(key), "_%s_W", window->Name);
+    snprintf(key, sizeof(key), "_%s_W", save_id);
     size.x = static_cast<float>(ini->GetDoubleValue(section, key, size.x));
-    snprintf(key, sizeof(key), "_%s_H", window->Name);
+    snprintf(key, sizeof(key), "_%s_H", save_id);
     size.y = static_cast<float>(ini->GetDoubleValue(section, key, size.y));
-    snprintf(key, sizeof(key), "_%s_Collapsed", window->Name);
+    snprintf(key, sizeof(key), "_%s_Collapsed", save_id);
     const bool collapsed = ini->GetBoolValue(section, key, false);
 
     ImGui::SetWindowPos(window, pos);

--- a/GWToolboxdll/Windows/BuildsWindow.cpp
+++ b/GWToolboxdll/Windows/BuildsWindow.cpp
@@ -435,7 +435,8 @@ namespace {
             }
             const char* section = entry.pItem;
             const int count = inifile->GetLongValue(section, "count", 12);
-            TeamBuild tbuild(inifile->GetValue(section, "buildname", ""));
+            const char* saved_ui_id = inifile->GetValue(section, "uiid", "");
+            TeamBuild tbuild(inifile->GetValue(section, "buildname", ""), saved_ui_id);
             tbuild.has_hero_slots = false;
             tbuild.show_numbers = inifile->GetBoolValue(section, "showNumbers", true);
             char key[16];
@@ -467,6 +468,12 @@ namespace {
             std::ranges::sort(teambuilds, [](const TeamBuild& a, const TeamBuild& b) {
                 return _stricmp(a.name.c_str(), b.name.c_str()) < 0;
             });
+        }
+        // Advance the shared counter past all restored IDs so new builds don't collide.
+        for (const auto& tb : teambuilds) {
+            uint32_t numeric_id = 0;
+            if (std::from_chars(tb.ui_id.data(), tb.ui_id.data() + tb.ui_id.size(), numeric_id).ec == std::errc{})
+                TeamBuild::s_cur_ui_id = std::max(TeamBuild::s_cur_ui_id, numeric_id);
         }
         builds_changed = false;
         LoadFromBuildsFolder();
@@ -625,6 +632,7 @@ namespace {
             char section[16];
             snprintf(section, 16, "builds%03d", i);
             inifile->SetValue(section, "buildname", tbuild.name.c_str());
+            inifile->SetValue(section, "uiid", tbuild.ui_id.c_str());
             inifile->SetBoolValue(section, "showNumbers", tbuild.show_numbers);
             inifile->SetLongValue(section, "count", tbuild.builds.size());
             for (unsigned int j = 0; j < tbuild.builds.size(); ++j) {

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -703,7 +703,8 @@ void HeroBuildsWindow::LoadFromFile()
 
         if (strncmp(section, "builds", 6) != 0) continue;
 
-        TeamBuild tb(inifile->GetValue(section, "buildname", ""));
+        const char* saved_ui_id = inifile->GetValue(section, "uiid", "");
+        TeamBuild tb(inifile->GetValue(section, "buildname", ""), saved_ui_id);
         tb.has_hero_slots = true;
         tb.mode = inifile->GetLongValue(section, "mode", false);
         tb.group = inifile->GetValue(section, "group", "");
@@ -757,6 +758,14 @@ void HeroBuildsWindow::LoadFromFile()
     // appear in ascending sort_order. Relative order within each group is preserved.
     SortTeambuilds(teambuilds);
 
+    // Advance the shared counter past all restored IDs so newly created builds
+    // don't collide with the persisted ones.
+    for (const auto& tb : teambuilds) {
+        uint32_t numeric_id = 0;
+        if (std::from_chars(tb.ui_id.data(), tb.ui_id.data() + tb.ui_id.size(), numeric_id).ec == std::errc{})
+            TeamBuild::s_cur_ui_id = std::max(TeamBuild::s_cur_ui_id, numeric_id);
+    }
+
     builds_changed = false;
 }
 
@@ -773,6 +782,7 @@ void HeroBuildsWindow::SaveToFile() const
             char section[buffer_size];
             snprintf(section, buffer_size, "builds%03d", i);
             inifile->SetValue(section, "buildname", tbuild.name.c_str());
+            inifile->SetValue(section, "uiid", tbuild.ui_id.c_str());
             inifile->SetLongValue(section, "mode", tbuild.mode);
             if (!tbuild.group.empty())
                 inifile->SetValue(section, "group", tbuild.group.c_str());


### PR DESCRIPTION
Fixes five root causes of Layout.ini growing unboundedly on every session (issue #2152):

1. `SaveUILayout()` now skips child windows, popups, tooltips, and other ephemeral ImGui widgets
2. Window keys now use only the stable ID after `###`/`##`, so renaming a teambuild no longer orphans old entries
3. The `[Windows]` section is cleared before each save, so deleted windows don't accumulate
4. `LoadUILayout()` pre-populate now correctly extracts window IDs from keys (fixed underscore parsing)
5. `TeamBuild::ui_id` is now persisted in herobuilds.ini and builds.ini so window positions survive reordering

Closes #2152

Generated with [Claude Code](https://claude.ai/code)