### PR TITLE
Add per-build Load buttons and attributes to detached teambuild view

### DIFF
--- a/GWToolboxdll/Utils/TeamBuild.cpp
+++ b/GWToolboxdll/Utils/TeamBuild.cpp
@@ -53,6 +53,7 @@ namespace {
 
     std::vector<PendingBuildLoad> pending_build_loads;
     std::queue<std::wstring>      send_queue;
+    std::string                   pending_reroll_build_code;
     clock_t send_timer   = 0;
     clock_t kickall_timer = 0;
 
@@ -377,6 +378,12 @@ void Build::Load() const
 void Build::Update()
 {
     const auto instance_type = GW::Map::GetInstanceType();
+
+    if (!pending_reroll_build_code.empty() && !RerollWindow::IsRerolling()) {
+        const Build pending("", pending_reroll_build_code);
+        pending_reroll_build_code.clear();
+        pending.Load();
+    }
 
     if (instance_type == GW::Constants::InstanceType::Loading) {
         pending_build_loads.clear();

--- a/GWToolboxdll/Utils/TeamBuild.cpp
+++ b/GWToolboxdll/Utils/TeamBuild.cpp
@@ -23,7 +23,9 @@
 #include <Timer.h>
 #include <Utils/GuiUtils.h>
 #include <Utils/TextUtils.h>
+#include <Windows/BuildsWindow.h>
 #include <Windows/PconsWindow.h>
+#include <Windows/RerollWindow.h>
 #include "TeamBuildEncoder.h"
 #include <GWCA/Managers/PartyMgr.h>
 #include "ToolboxUtils.h"
@@ -1128,4 +1130,129 @@ bool TeamBuild::DrawEditWindow(
 
     ImGui::End();
     return true;
+}
+
+// ------------------------------------------------------------
+// DrawDetachedWindow
+// ------------------------------------------------------------
+
+void TeamBuild::DrawDetachedWindow(std::vector<TeamBuild>& hero_builds, bool& builds_changed)
+{
+    if (!edit_open) return;
+    const auto winname = std::format("{}###detached_{}", name, ui_id);
+    ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(420, 0), ImGuiCond_FirstUseEver);
+    if (focus_next_frame) {
+        ImGui::SetNextWindowCollapsed(false);
+        ImGui::SetNextWindowFocus();
+        focus_next_frame = false;
+    }
+    if (!ImGui::Begin(winname.c_str(), &edit_open)) {
+        ImGui::End();
+        return;
+    }
+
+    const auto* me = GW::Agents::GetControlledCharacter();
+    const auto player_profession = me ? static_cast<GW::Constants::Profession>(me->primary) : GW::Constants::Profession::None;
+
+    for (size_t j = 0; j < builds.size(); j++) {
+        const auto& build = builds[j];
+        if (build.code.empty() && build.hero_id == HeroID::NoHero) continue;
+
+        std::string disp_name;
+        if (has_hero_slots) {
+            const auto hero_name = build.hero_id == HeroID::NoHero
+                ? "Player"
+                : Resources::GetHeroName(build.hero_id)->string();
+            const auto& bname = !build.name.empty() ? build.name : build.GetFallbackBuildName();
+            if (!bname.empty() || !build.code.empty() || build.hero_id != HeroID::NoHero) {
+                disp_name = std::format("{} ({})", bname, hero_name);
+            }
+        }
+        else {
+            const auto& bname = !build.name.empty() ? build.name : build.GetFallbackBuildName();
+            disp_name = std::format("#{} {}", j + 1, bname);
+        }
+        if (!disp_name.empty()) ImGui::TextUnformatted(disp_name.c_str());
+        if (!build.code.empty()) GuiUtils::DrawSkillbar(build.code.c_str(), true);
+
+        if (!build.code.empty()) {
+            ImGui::PushID(static_cast<int>(j));
+            bool can_load = false;
+            bool can_reroll = false;
+            const char* load_tooltip = nullptr;
+            GW::Constants::Profession build_profession = GW::Constants::Profession::None;
+
+            if (build.IsPlayerBuild()) {
+                GW::SkillbarMgr::SkillTemplate st{};
+                if (GW::SkillbarMgr::DecodeSkillTemplate(st, build.code.c_str())) {
+                    build_profession = st.primary;
+                    can_load = player_profession != GW::Constants::Profession::None && st.primary == player_profession;
+                    if (!can_load && build_profession != GW::Constants::Profession::None) {
+                        can_reroll = RerollWindow::FindAvailableCharForProfession(build_profession) != nullptr;
+                    }
+                    if (can_load) {
+                        load_tooltip = "Load this build on your player";
+                    }
+                    else if (can_reroll) {
+                        load_tooltip = "Reroll to a matching character and load this build";
+                    }
+                    else {
+                        load_tooltip = "Your profession doesn't match this build and no available character has the right profession";
+                    }
+                }
+            }
+            else {
+                can_load = ToolboxUtils::IsHeroUnlocked(build.hero_id);
+                load_tooltip = can_load ? "Load this build on the hero" : "Hero not unlocked";
+            }
+
+            if (can_reroll && !can_load) {
+                if (ImGui::Button("Reroll")) {
+                    if (RerollWindow::RerollToProfession(build_profession, true, true)) {
+                        pending_reroll_build_code = build.code;
+                    }
+                }
+            }
+            else {
+                if (!can_load) ImGui::BeginDisabled();
+                if (ImGui::Button("Load")) {
+                    build.Load();
+                }
+                if (!can_load) ImGui::EndDisabled();
+            }
+            if (load_tooltip && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                ImGui::SetTooltip(load_tooltip);
+            }
+            ImGui::PopID();
+        }
+
+        ImGui::Spacing();
+    }
+    ImGui::Separator();
+    if (has_hero_slots) {
+        if (ImGui::Button("Load All")) {
+            Load();
+        }
+        if (ImGui::IsItemHovered()) ImGui::SetTooltip("Load all builds onto your heroes");
+        ImGui::SameLine();
+    }
+    if (ImGui::Button("Add to My Builds")) {
+        TeamBuild copy = *this;
+        copy.edit_open = false;
+        if (copy.has_hero_slots) {
+            hero_builds.push_back(std::move(copy));
+            builds_changed = true;
+        }
+        else {
+            BuildsWindow::Instance().AddTeambuild(std::move(copy));
+        }
+    }
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip(has_hero_slots ? "Save this teambuild to your Hero Builds list" : "Save this teambuild to your Builds list");
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Close")) edit_open = false;
+
+    ImGui::End();
 }

--- a/GWToolboxdll/Utils/TeamBuild.h
+++ b/GWToolboxdll/Utils/TeamBuild.h
@@ -80,7 +80,6 @@ struct TeamBuild {
     std::string name{};
     std::string group{};
     std::string ui_id{};
-    std::string pending_reroll_build_code{}; // set while waiting for a reroll to complete before loading
     std::vector<Build> builds{};
 
     // Callback signature: (teambuild, build_index)

--- a/GWToolboxdll/Utils/TeamBuild.h
+++ b/GWToolboxdll/Utils/TeamBuild.h
@@ -80,6 +80,7 @@ struct TeamBuild {
     std::string name{};
     std::string group{};
     std::string ui_id{};
+    std::string pending_reroll_build_code{}; // set while waiting for a reroll to complete before loading
     std::vector<Build> builds{};
 
     // Callback signature: (teambuild, build_index)
@@ -90,8 +91,6 @@ struct TeamBuild {
     //   index        – position of this TeamBuild in all_builds.
     //   all_builds   – the owning vector; may be modified (reorder / delete).
     //   builds_changed – set true when any data is modified.
-    //   on_load / on_send / on_view – module-supplied callbacks invoked when
-    //     the corresponding button is pressed; receive (teambuild, build_index).
     //
     // Returns false when this teambuild was deleted (erased from all_builds).
     bool DrawEditWindow(
@@ -99,6 +98,11 @@ struct TeamBuild {
         std::vector<TeamBuild>& all_builds,
         bool& builds_changed
     );
+
+    // Draw a read-only detached window for a teambuild received via chat link.
+    // hero_builds / builds_changed are the HeroBuildsWindow-owned list used by
+    // the "Add to My Builds" button.
+    void DrawDetachedWindow(std::vector<TeamBuild>& hero_builds, bool& builds_changed);
 
     // Provide the 2×2 sprite sheet used to render the disabled-skill overlay.
     // Call once from HeroBuildsWindow::Initialize().

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -546,7 +546,7 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                     if (can_reroll && !can_load) {
                         // Show "Reroll" button instead of a disabled "Load".
                         if (ImGui::Button("Reroll")) {
-                            if (RerollWindow::Instance().RerollToProfession(build_profession, /*same_map=*/true, /*same_party=*/true)) {
+                            if (RerollWindow::RerollToProfession(build_profession, /*same_map=*/true, /*same_party=*/true)) {
                                 pending_reroll_build_code = build.code;
                             }
                         }
@@ -642,7 +642,7 @@ void HeroBuildsWindow::Update(float)
     }
 
     // Once a reroll-triggered load is pending and the reroll has finished, load the build.
-    if (!pending_reroll_build_code.empty() && !RerollWindow::Instance().IsRerolling()) {
+    if (!pending_reroll_build_code.empty() && !RerollWindow::IsRerolling()) {
         const Build pending_build("", pending_reroll_build_code);
         pending_reroll_build_code.clear();
         pending_build.Load();

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -214,6 +214,119 @@ namespace {
         return tb;
     }
 
+    void DrawDetachedTeambuild(Teambuild* tbuild_pt) {
+        
+        if (!(tbuild_pt && tbuild_pt->edit_open)) return;
+        TeamBuild& tbuild = *tbuild_ptr;
+        const auto winname = std::format("{}###detached_{}", tbuild.name, tbuild.ui_id);
+        ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
+        ImGui::SetNextWindowSize(ImVec2(420, 0), ImGuiCond_FirstUseEver);
+        if (tbuild.focus_next_frame) {
+            ImGui::SetNextWindowCollapsed(false);
+            ImGui::SetNextWindowFocus();
+            tbuild.focus_next_frame = false;
+        }
+        if (ImGui::Begin(winname.c_str(), &tbuild.edit_open)) {
+            const auto* me = GW::Agents::GetControlledCharacter();
+            const auto player_profession = me ? static_cast<GW::Constants::Profession>(me->primary) : GW::Constants::Profession::None;
+
+            for (size_t j = 0; j < tbuild.builds.size(); j++) {
+                const auto& build = tbuild.builds[j];
+                if (build.code.empty() && build.hero_id == HeroID::NoHero) continue;
+                std::string disp_name;
+                if (tbuild.has_hero_slots) {
+                    HeroBuildName(build, &disp_name);
+                }
+                else {
+                    const auto& bname = !build.name.empty() ? build.name : build.GetFallbackBuildName();
+                    disp_name = std::format("#{} {}", j + 1, bname);
+                }
+                if (!disp_name.empty()) ImGui::TextUnformatted(disp_name.c_str());
+                if (!build.code.empty()) GuiUtils::DrawSkillbar(build.code.c_str(), true);
+
+                if (!build.code.empty()) {
+                    ImGui::PushID(static_cast<int>(j));
+                    bool can_load = false;
+                    bool can_reroll = false;
+                    const char* load_tooltip = nullptr;
+                    GW::Constants::Profession build_profession = GW::Constants::Profession::None;
+
+                    if (build.IsPlayerBuild()) {
+                        GW::SkillbarMgr::SkillTemplate st{};
+                        if (GW::SkillbarMgr::DecodeSkillTemplate(st, build.code.c_str())) {
+                            build_profession = st.primary;
+                            can_load = player_profession != GW::Constants::Profession::None && st.primary == player_profession;
+                            if (!can_load && build_profession != GW::Constants::Profession::None) {
+                                // Check if there's an available character we could reroll to.
+                                can_reroll = RerollWindow::FindAvailableCharForProfession(build_profession) != nullptr;
+                            }
+                            if (can_load) {
+                                load_tooltip = "Load this build on your player";
+                            }
+                            else if (can_reroll) {
+                                load_tooltip = "Reroll to a matching character and load this build";
+                            }
+                            else {
+                                load_tooltip = "Your profession doesn't match this build and no available character has the right profession";
+                            }
+                        }
+                    }
+                    else {
+                        can_load = ToolboxUtils::IsHeroUnlocked(build.hero_id);
+                        load_tooltip = can_load ? "Load this build on the hero" : "Hero not unlocked";
+                    }
+
+                    if (can_reroll && !can_load) {
+                        // Show "Reroll" button instead of a disabled "Load".
+                        if (ImGui::Button("Reroll")) {
+                            if (RerollWindow::RerollToProfession(build_profession, /*same_map=*/true, /*same_party=*/true)) {
+                                pending_reroll_build_code = build.code;
+                            }
+                        }
+                    }
+                    else {
+                        if (!can_load) ImGui::BeginDisabled();
+                        if (ImGui::Button("Load")) {
+                            build.Load();
+                        }
+                        if (!can_load) ImGui::EndDisabled();
+                    }
+                    if (load_tooltip && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                        ImGui::SetTooltip(load_tooltip);
+                    }
+                    ImGui::PopID();
+                }
+
+                ImGui::Spacing();
+            }
+            ImGui::Separator();
+            if (tbuild.has_hero_slots) {
+                if (ImGui::Button("Load All")) {
+                    tbuild.Load();
+                }
+                if (ImGui::IsItemHovered()) ImGui::SetTooltip("Load all builds onto your heroes");
+                ImGui::SameLine();
+            }
+            if (ImGui::Button("Add to My Builds")) {
+                TeamBuild copy = tbuild;
+                copy.edit_open = false;
+                if (copy.has_hero_slots) {
+                    teambuilds.push_back(std::move(copy));
+                    builds_changed = true;
+                }
+                else {
+                    BuildsWindow::Instance().AddTeambuild(std::move(copy));
+                }
+            }
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip(tbuild.has_hero_slots ? "Save this teambuild to your Hero Builds list" : "Save this teambuild to your Builds list");
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Close")) tbuild.edit_open = false;
+        }
+        ImGui::End();
+    }
+
 } // namespace
 
 std::string HeroBuildsWindow::EncodeTeambuildToDaybreak(const TeamBuild& tbuild)
@@ -486,112 +599,7 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
     // Draw detached teambuild windows (received builds not in the main list).
     // Build names are lazily populated with the elite skill from each slot.
     for (auto& tbuild_ptr : detached_pool) {
-        TeamBuild& tbuild = *tbuild_ptr;
-        if (!tbuild.edit_open) continue;
-
-        const auto winname = std::format("{}###detached_{}", tbuild.name, tbuild.ui_id);
-        ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
-        ImGui::SetNextWindowSize(ImVec2(420, 0), ImGuiCond_FirstUseEver);
-        if (tbuild.focus_next_frame) {
-            ImGui::SetNextWindowCollapsed(false);
-            ImGui::SetNextWindowFocus();
-            tbuild.focus_next_frame = false;
-        }
-        if (ImGui::Begin(winname.c_str(), &tbuild.edit_open)) {
-            const auto* me = GW::Agents::GetControlledCharacter();
-            const auto player_profession = me ? static_cast<GW::Constants::Profession>(me->primary) : GW::Constants::Profession::None;
-
-            for (size_t j = 0; j < tbuild.builds.size(); j++) {
-                const auto& build = tbuild.builds[j];
-                if (build.code.empty() && build.hero_id == HeroID::NoHero) continue;
-                std::string disp_name;
-                if (tbuild.has_hero_slots) {
-                    HeroBuildName(build, &disp_name);
-                } else {
-                    const auto& bname = !build.name.empty() ? build.name : build.GetFallbackBuildName();
-                    disp_name = std::format("#{} {}", j + 1, bname);
-                }
-                if (!disp_name.empty()) ImGui::TextUnformatted(disp_name.c_str());
-                if (!build.code.empty()) GuiUtils::DrawSkillbar(build.code.c_str(), true);
-
-                if (!build.code.empty()) {
-                    ImGui::PushID(static_cast<int>(j));
-                    bool can_load = false;
-                    bool can_reroll = false;
-                    const char* load_tooltip = nullptr;
-                    GW::Constants::Profession build_profession = GW::Constants::Profession::None;
-
-                    if (build.IsPlayerBuild()) {
-                        GW::SkillbarMgr::SkillTemplate st{};
-                        if (GW::SkillbarMgr::DecodeSkillTemplate(st, build.code.c_str())) {
-                            build_profession = st.primary;
-                            can_load = player_profession != GW::Constants::Profession::None && st.primary == player_profession;
-                            if (!can_load && build_profession != GW::Constants::Profession::None) {
-                                // Check if there's an available character we could reroll to.
-                                can_reroll = RerollWindow::FindAvailableCharForProfession(build_profession) != nullptr;
-                            }
-                            if (can_load) {
-                                load_tooltip = "Load this build on your player";
-                            } else if (can_reroll) {
-                                load_tooltip = "Reroll to a matching character and load this build";
-                            } else {
-                                load_tooltip = "Your profession doesn't match this build and no available character has the right profession";
-                            }
-                        }
-                    } else {
-                        can_load = ToolboxUtils::IsHeroUnlocked(build.hero_id);
-                        load_tooltip = can_load ? "Load this build on the hero" : "Hero not unlocked";
-                    }
-
-                    if (can_reroll && !can_load) {
-                        // Show "Reroll" button instead of a disabled "Load".
-                        if (ImGui::Button("Reroll")) {
-                            if (RerollWindow::RerollToProfession(build_profession, /*same_map=*/true, /*same_party=*/true)) {
-                                pending_reroll_build_code = build.code;
-                            }
-                        }
-                    } else {
-                        if (!can_load) ImGui::BeginDisabled();
-                        if (ImGui::Button("Load")) {
-                            build.Load();
-                        }
-                        if (!can_load) ImGui::EndDisabled();
-                    }
-                    if (load_tooltip && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-                        ImGui::SetTooltip(load_tooltip);
-                    }
-                    ImGui::PopID();
-                }
-
-                ImGui::Spacing();
-            }
-            ImGui::Separator();
-            if (tbuild.has_hero_slots) {
-                if (ImGui::Button("Load All")) {
-                    tbuild.Load();
-                }
-                if (ImGui::IsItemHovered()) ImGui::SetTooltip("Load all builds onto your heroes");
-                ImGui::SameLine();
-            }
-            if (ImGui::Button("Add to My Builds")) {
-                TeamBuild copy = tbuild;
-                copy.edit_open = false;
-                if (copy.has_hero_slots) {
-                    teambuilds.push_back(std::move(copy));
-                    builds_changed = true;
-                } else {
-                    BuildsWindow::Instance().AddTeambuild(std::move(copy));
-                }
-            }
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip(tbuild.has_hero_slots
-                    ? "Save this teambuild to your Hero Builds list"
-                    : "Save this teambuild to your Builds list");
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Close")) tbuild.edit_open = false;
-        }
-        ImGui::End();
+        DrawDetachedTeambuild(tbuild_ptr);
     }
 }
 

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -31,6 +31,7 @@
 #include <Utils/TextUtils.h>
 #include <Utils/ToolboxUtils.h>
 #include <Windows/BuildsWindow.h>
+#include <Windows/RerollWindow.h>
 
 constexpr const wchar_t* INI_FILENAME = L"herobuilds.ini";
 
@@ -42,6 +43,9 @@ namespace {
     // Pool of received/detached teambuilds shown as standalone windows (not in the main list).
     // Entries are removed when their window is closed and no other owner holds the shared_ptr.
     std::vector<std::shared_ptr<TeamBuild>> detached_pool{};
+
+    // Build code queued to be loaded once an in-progress reroll completes.
+    std::string pending_reroll_build_code{};
 
     ToolboxIni* inifile = nullptr;
 
@@ -513,22 +517,46 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                 if (!build.code.empty()) {
                     ImGui::PushID(static_cast<int>(j));
                     bool can_load = false;
+                    bool can_reroll = false;
                     const char* load_tooltip = nullptr;
+                    GW::Constants::Profession build_profession = GW::Constants::Profession::None;
+
                     if (build.IsPlayerBuild()) {
                         GW::SkillbarMgr::SkillTemplate st{};
                         if (GW::SkillbarMgr::DecodeSkillTemplate(st, build.code.c_str())) {
+                            build_profession = st.primary;
                             can_load = player_profession != GW::Constants::Profession::None && st.primary == player_profession;
-                            load_tooltip = can_load ? "Load this build on your player" : "Your profession doesn't match this build";
+                            if (!can_load && build_profession != GW::Constants::Profession::None) {
+                                // Check if there's an available character we could reroll to.
+                                can_reroll = RerollWindow::FindAvailableCharForProfession(build_profession) != nullptr;
+                            }
+                            if (can_load) {
+                                load_tooltip = "Load this build on your player";
+                            } else if (can_reroll) {
+                                load_tooltip = "Reroll to a matching character and load this build";
+                            } else {
+                                load_tooltip = "Your profession doesn't match this build and no available character has the right profession";
+                            }
                         }
                     } else {
                         can_load = ToolboxUtils::IsHeroUnlocked(build.hero_id);
                         load_tooltip = can_load ? "Load this build on the hero" : "Hero not unlocked";
                     }
-                    if (!can_load) ImGui::BeginDisabled();
-                    if (ImGui::Button("Load")) {
-                        build.Load();
+
+                    if (can_reroll && !can_load) {
+                        // Show "Reroll" button instead of a disabled "Load".
+                        if (ImGui::Button("Reroll")) {
+                            if (RerollWindow::Instance().RerollToProfession(build_profession, /*same_map=*/true, /*same_party=*/true)) {
+                                pending_reroll_build_code = build.code;
+                            }
+                        }
+                    } else {
+                        if (!can_load) ImGui::BeginDisabled();
+                        if (ImGui::Button("Load")) {
+                            build.Load();
+                        }
+                        if (!can_load) ImGui::EndDisabled();
                     }
-                    if (!can_load) ImGui::EndDisabled();
                     if (load_tooltip && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
                         ImGui::SetTooltip(load_tooltip);
                     }
@@ -611,6 +639,13 @@ void HeroBuildsWindow::Update(float)
             visible = false;
         }
         last_instance_type = instance_type;
+    }
+
+    // Once a reroll-triggered load is pending and the reroll has finished, load the build.
+    if (!pending_reroll_build_code.empty() && !RerollWindow::Instance().IsRerolling()) {
+        const Build pending_build("", pending_reroll_build_code);
+        pending_reroll_build_code.clear();
+        pending_build.Load();
     }
 
     // GC detached pool: remove closed entries with no external owners

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -494,6 +494,9 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
             tbuild.focus_next_frame = false;
         }
         if (ImGui::Begin(winname.c_str(), &tbuild.edit_open)) {
+            const auto* me = GW::Agents::GetControlledCharacter();
+            const auto player_profession = me ? static_cast<GW::Constants::Profession>(me->primary) : GW::Constants::Profession::None;
+
             for (size_t j = 0; j < tbuild.builds.size(); j++) {
                 const auto& build = tbuild.builds[j];
                 if (build.code.empty() && build.hero_id == HeroID::NoHero) continue;
@@ -505,7 +508,33 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
                     disp_name = std::format("#{} {}", j + 1, bname);
                 }
                 if (!disp_name.empty()) ImGui::TextUnformatted(disp_name.c_str());
-                if (!build.code.empty()) GuiUtils::DrawSkillbar(build.code.c_str(), false);
+                if (!build.code.empty()) GuiUtils::DrawSkillbar(build.code.c_str(), true);
+
+                if (!build.code.empty()) {
+                    ImGui::PushID(static_cast<int>(j));
+                    bool can_load = false;
+                    const char* load_tooltip = nullptr;
+                    if (build.IsPlayerBuild()) {
+                        GW::SkillbarMgr::SkillTemplate st{};
+                        if (GW::SkillbarMgr::DecodeSkillTemplate(st, build.code.c_str())) {
+                            can_load = player_profession != GW::Constants::Profession::None && st.primary == player_profession;
+                            load_tooltip = can_load ? "Load this build on your player" : "Your profession doesn't match this build";
+                        }
+                    } else {
+                        can_load = ToolboxUtils::IsHeroUnlocked(build.hero_id);
+                        load_tooltip = can_load ? "Load this build on the hero" : "Hero not unlocked";
+                    }
+                    if (!can_load) ImGui::BeginDisabled();
+                    if (ImGui::Button("Load")) {
+                        build.Load();
+                    }
+                    if (!can_load) ImGui::EndDisabled();
+                    if (load_tooltip && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                        ImGui::SetTooltip(load_tooltip);
+                    }
+                    ImGui::PopID();
+                }
+
                 ImGui::Spacing();
             }
             ImGui::Separator();

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -30,8 +30,6 @@
 #include <Utils/TeamBuildEncoder.h>
 #include <Utils/TextUtils.h>
 #include <Utils/ToolboxUtils.h>
-#include <Windows/RerollWindow.h>
-
 constexpr const wchar_t* INI_FILENAME = L"herobuilds.ini";
 
 namespace {
@@ -529,18 +527,6 @@ void HeroBuildsWindow::Update(float)
             visible = false;
         }
         last_instance_type = instance_type;
-    }
-
-    // Once a reroll-triggered load is pending and the reroll has finished, load the build.
-    if (!RerollWindow::IsRerolling()) {
-        for (auto& tbuild_ptr : detached_pool) {
-            if (!tbuild_ptr->pending_reroll_build_code.empty()) {
-                const Build pending_build("", tbuild_ptr->pending_reroll_build_code);
-                tbuild_ptr->pending_reroll_build_code.clear();
-                pending_build.Load();
-                break; // only one reroll can be in flight at a time
-            }
-        }
     }
 
     // GC detached pool: remove closed entries with no external owners

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -30,7 +30,6 @@
 #include <Utils/TeamBuildEncoder.h>
 #include <Utils/TextUtils.h>
 #include <Utils/ToolboxUtils.h>
-#include <Windows/BuildsWindow.h>
 #include <Windows/RerollWindow.h>
 
 constexpr const wchar_t* INI_FILENAME = L"herobuilds.ini";
@@ -43,9 +42,6 @@ namespace {
     // Pool of received/detached teambuilds shown as standalone windows (not in the main list).
     // Entries are removed when their window is closed and no other owner holds the shared_ptr.
     std::vector<std::shared_ptr<TeamBuild>> detached_pool{};
-
-    // Build code queued to be loaded once an in-progress reroll completes.
-    std::string pending_reroll_build_code{};
 
     ToolboxIni* inifile = nullptr;
 
@@ -212,119 +208,6 @@ namespace {
             return b.hero_id != GW::Constants::HeroID::NoHero;
         });
         return tb;
-    }
-
-    void DrawDetachedTeambuild(Teambuild* tbuild_pt) {
-        
-        if (!(tbuild_pt && tbuild_pt->edit_open)) return;
-        TeamBuild& tbuild = *tbuild_ptr;
-        const auto winname = std::format("{}###detached_{}", tbuild.name, tbuild.ui_id);
-        ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
-        ImGui::SetNextWindowSize(ImVec2(420, 0), ImGuiCond_FirstUseEver);
-        if (tbuild.focus_next_frame) {
-            ImGui::SetNextWindowCollapsed(false);
-            ImGui::SetNextWindowFocus();
-            tbuild.focus_next_frame = false;
-        }
-        if (ImGui::Begin(winname.c_str(), &tbuild.edit_open)) {
-            const auto* me = GW::Agents::GetControlledCharacter();
-            const auto player_profession = me ? static_cast<GW::Constants::Profession>(me->primary) : GW::Constants::Profession::None;
-
-            for (size_t j = 0; j < tbuild.builds.size(); j++) {
-                const auto& build = tbuild.builds[j];
-                if (build.code.empty() && build.hero_id == HeroID::NoHero) continue;
-                std::string disp_name;
-                if (tbuild.has_hero_slots) {
-                    HeroBuildName(build, &disp_name);
-                }
-                else {
-                    const auto& bname = !build.name.empty() ? build.name : build.GetFallbackBuildName();
-                    disp_name = std::format("#{} {}", j + 1, bname);
-                }
-                if (!disp_name.empty()) ImGui::TextUnformatted(disp_name.c_str());
-                if (!build.code.empty()) GuiUtils::DrawSkillbar(build.code.c_str(), true);
-
-                if (!build.code.empty()) {
-                    ImGui::PushID(static_cast<int>(j));
-                    bool can_load = false;
-                    bool can_reroll = false;
-                    const char* load_tooltip = nullptr;
-                    GW::Constants::Profession build_profession = GW::Constants::Profession::None;
-
-                    if (build.IsPlayerBuild()) {
-                        GW::SkillbarMgr::SkillTemplate st{};
-                        if (GW::SkillbarMgr::DecodeSkillTemplate(st, build.code.c_str())) {
-                            build_profession = st.primary;
-                            can_load = player_profession != GW::Constants::Profession::None && st.primary == player_profession;
-                            if (!can_load && build_profession != GW::Constants::Profession::None) {
-                                // Check if there's an available character we could reroll to.
-                                can_reroll = RerollWindow::FindAvailableCharForProfession(build_profession) != nullptr;
-                            }
-                            if (can_load) {
-                                load_tooltip = "Load this build on your player";
-                            }
-                            else if (can_reroll) {
-                                load_tooltip = "Reroll to a matching character and load this build";
-                            }
-                            else {
-                                load_tooltip = "Your profession doesn't match this build and no available character has the right profession";
-                            }
-                        }
-                    }
-                    else {
-                        can_load = ToolboxUtils::IsHeroUnlocked(build.hero_id);
-                        load_tooltip = can_load ? "Load this build on the hero" : "Hero not unlocked";
-                    }
-
-                    if (can_reroll && !can_load) {
-                        // Show "Reroll" button instead of a disabled "Load".
-                        if (ImGui::Button("Reroll")) {
-                            if (RerollWindow::RerollToProfession(build_profession, /*same_map=*/true, /*same_party=*/true)) {
-                                pending_reroll_build_code = build.code;
-                            }
-                        }
-                    }
-                    else {
-                        if (!can_load) ImGui::BeginDisabled();
-                        if (ImGui::Button("Load")) {
-                            build.Load();
-                        }
-                        if (!can_load) ImGui::EndDisabled();
-                    }
-                    if (load_tooltip && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-                        ImGui::SetTooltip(load_tooltip);
-                    }
-                    ImGui::PopID();
-                }
-
-                ImGui::Spacing();
-            }
-            ImGui::Separator();
-            if (tbuild.has_hero_slots) {
-                if (ImGui::Button("Load All")) {
-                    tbuild.Load();
-                }
-                if (ImGui::IsItemHovered()) ImGui::SetTooltip("Load all builds onto your heroes");
-                ImGui::SameLine();
-            }
-            if (ImGui::Button("Add to My Builds")) {
-                TeamBuild copy = tbuild;
-                copy.edit_open = false;
-                if (copy.has_hero_slots) {
-                    teambuilds.push_back(std::move(copy));
-                    builds_changed = true;
-                }
-                else {
-                    BuildsWindow::Instance().AddTeambuild(std::move(copy));
-                }
-            }
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip(tbuild.has_hero_slots ? "Save this teambuild to your Hero Builds list" : "Save this teambuild to your Builds list");
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Close")) tbuild.edit_open = false;
-        }
-        ImGui::End();
     }
 
 } // namespace
@@ -597,9 +480,8 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
     }
 
     // Draw detached teambuild windows (received builds not in the main list).
-    // Build names are lazily populated with the elite skill from each slot.
     for (auto& tbuild_ptr : detached_pool) {
-        DrawDetachedTeambuild(tbuild_ptr);
+        tbuild_ptr->DrawDetachedWindow(teambuilds, builds_changed);
     }
 }
 
@@ -650,10 +532,15 @@ void HeroBuildsWindow::Update(float)
     }
 
     // Once a reroll-triggered load is pending and the reroll has finished, load the build.
-    if (!pending_reroll_build_code.empty() && !RerollWindow::IsRerolling()) {
-        const Build pending_build("", pending_reroll_build_code);
-        pending_reroll_build_code.clear();
-        pending_build.Load();
+    if (!RerollWindow::IsRerolling()) {
+        for (auto& tbuild_ptr : detached_pool) {
+            if (!tbuild_ptr->pending_reroll_build_code.empty()) {
+                const Build pending_build("", tbuild_ptr->pending_reroll_build_code);
+                tbuild_ptr->pending_reroll_build_code.clear();
+                pending_build.Load();
+                break; // only one reroll can be in flight at a time
+            }
+        }
     }
 
     // GC detached pool: remove closed entries with no external owners

--- a/GWToolboxdll/Windows/RerollWindow.cpp
+++ b/GWToolboxdll/Windows/RerollWindow.cpp
@@ -177,6 +177,10 @@ namespace {
     std::vector<std::wstring> exclude_charnames_from_reroll_cmd;
     char excluded_char_add_buf[20] = {0};
 
+    // Maps profession (1-10) → preferred character name for RerollToProfession().
+    // An empty string means "no preference" – fall through to first available match.
+    std::unordered_map<uint32_t, std::wstring> preferred_chars_by_profession;
+
     GW::HookEntry OnGoToCharSelect_Entry;
 
     bool IsExcludedFromReroll(const wchar_t* player_name)
@@ -209,6 +213,66 @@ namespace {
             }
             ImGui::TreePop();
         }
+    }
+
+    void DrawPreferredCharacters()
+    {
+        ImGui::Spacing();
+        if (!ImGui::TreeNodeEx("Preferred Characters per Profession", ImGuiTreeNodeFlags_FramePadding | ImGuiTreeNodeFlags_SpanAvailWidth)) {
+            return;
+        }
+        ImGui::TextDisabled("Choose which character to reroll to for each profession.");
+        ImGui::TextDisabled("Leave blank to use the first available character.");
+
+        constexpr std::array<const char*, 10> profession_names = {
+            "Warrior", "Ranger", "Monk", "Necromancer", "Mesmer",
+            "Elementalist", "Assassin", "Ritualist", "Paragon", "Dervish"
+        };
+
+        const auto available_chars_ptr = GW::AccountMgr::GetAvailableChars();
+
+        for (size_t i = 0; i < profession_names.size(); i++) {
+            const auto prof = static_cast<GW::Constants::Profession>(i + 1);
+            const auto prof_key = static_cast<uint32_t>(prof);
+            auto& pref = preferred_chars_by_profession[prof_key];
+
+            ImGui::PushID(static_cast<int>(i));
+
+            // Collect available chars for this profession for the combo.
+            std::vector<const wchar_t*> candidates;
+            if (available_chars_ptr && available_chars_ptr->valid()) {
+                for (const auto& c : *available_chars_ptr) {
+                    if (c.primary() == prof) {
+                        candidates.push_back(c.player_name);
+                    }
+                }
+            }
+
+            const float label_w = 100.f * ImGui::FontScale();
+            ImGui::Text("%-13s", profession_names[i]);
+            ImGui::SameLine(label_w);
+
+            const auto current_str = TextUtils::WStringToString(pref);
+            const auto preview = pref.empty() ? "(any)" : current_str.c_str();
+
+            ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x * 2);
+            if (ImGui::BeginCombo("##pref", preview)) {
+                // "(any)" option
+                if (ImGui::Selectable("(any)", pref.empty())) {
+                    pref.clear();
+                }
+                for (const auto* cname : candidates) {
+                    const auto cname_str = TextUtils::WStringToString(cname);
+                    const bool selected = !pref.empty() && wcscmp(cname, pref.c_str()) == 0;
+                    if (ImGui::Selectable(cname_str.c_str(), selected)) {
+                        pref = cname;
+                    }
+                }
+                ImGui::EndCombo();
+            }
+            ImGui::PopID();
+        }
+        ImGui::TreePop();
     }
 
     bool IsInMap(const bool include_district = true)
@@ -304,6 +368,58 @@ namespace {
         return true;
     }
 
+    // Finds the best available character for the given profession and initiates a reroll.
+    // Preferred characters (if configured) are tried first, then the first non-excluded match.
+    bool RerollToProfession(const GW::Constants::Profession profession, const bool _same_map, const bool _same_party)
+    {
+        const auto available_characters = GW::AccountMgr::GetAvailableChars();
+        if (!available_characters || !available_characters->valid()) {
+            return false;
+        }
+
+        // Check the configured preferred character first.
+        const auto pref_it = preferred_chars_by_profession.find(static_cast<uint32_t>(profession));
+        if (pref_it != preferred_chars_by_profession.end() && !pref_it->second.empty()) {
+            const auto pref_char = GW::AccountMgr::GetAvailableCharacter(pref_it->second.c_str());
+            if (pref_char && pref_char->primary() == profession) {
+                return Reroll(pref_it->second.c_str(), _same_map, _same_party);
+            }
+        }
+
+        // Fall back to the first non-excluded available character with the matching profession.
+        for (const auto& available_char : *available_characters) {
+            if (IsExcludedFromReroll(available_char.player_name)) {
+                continue;
+            }
+            if (available_char.primary() == profession) {
+                return Reroll(available_char.player_name, _same_map, _same_party);
+            }
+        }
+        return false;
+    }
+
+    // Returns the character name that RerollToProfession would use, or nullptr if none available.
+    const wchar_t* FindAvailableCharForProfession(const GW::Constants::Profession profession)
+    {
+        const auto available_characters = GW::AccountMgr::GetAvailableChars();
+        if (!available_characters || !available_characters->valid()) {
+            return nullptr;
+        }
+        const auto pref_it = preferred_chars_by_profession.find(static_cast<uint32_t>(profession));
+        if (pref_it != preferred_chars_by_profession.end() && !pref_it->second.empty()) {
+            const auto pref_char = GW::AccountMgr::GetAvailableCharacter(pref_it->second.c_str());
+            if (pref_char && pref_char->primary() == profession) {
+                return pref_char->player_name;
+            }
+        }
+        for (const auto& available_char : *available_characters) {
+            if (available_char.primary() == profession) {
+                return available_char.player_name;
+            }
+        }
+        return nullptr;
+    }
+
     void CHAT_CMD_FUNC(CmdReroll)
     {
         if (argc < 2) {
@@ -330,26 +446,23 @@ namespace {
             L"dervish"
         };
 
-        GW::Constants::Profession profession_match = GW::Constants::Profession::None;
-
-        // Search by profession
+        // Search by profession name → use RerollToProfession (respects preferred chars).
         for (size_t i = 1; i < to_find.size(); i++) {
             if (wcsstr(to_find.at(i), character_or_profession.c_str())) {
-                profession_match = (GW::Constants::Profession)i;
-                break;
+                const auto prof = static_cast<GW::Constants::Profession>(i);
+                if (!RerollToProfession(prof, travel_to_same_location_after_rerolling, rejoin_party_after_rerolling)) {
+                    Log::Error("No available character found for that profession");
+                }
+                return;
             }
         }
 
-        // Search by character name (exact match first, then substring)
+        // Search by character name (exact match first, then substring).
         const wchar_t* substring_match = nullptr;
         for (const auto& available_char : *available_characters) {
             const auto player_name = available_char.player_name;
             if (IsExcludedFromReroll(player_name)) {
                 continue;
-            }
-            if (profession_match != GW::Constants::Profession::None && profession_match == available_char.primary()) {
-                substring_match = player_name;
-                break;
             }
             const auto lower_name = TextUtils::ToLower(player_name);
             if (!substring_match && wcsstr(lower_name.c_str(), character_or_profession.c_str())) {
@@ -468,6 +581,7 @@ void RerollWindow::Draw(IDirect3DDevice9*)
         ImGui::PopStyleVar();
     }
     DrawExcludedCharacters();
+    DrawPreferredCharacters();
 
     ImGui::End();
 }
@@ -672,6 +786,21 @@ bool RerollWindow::Reroll(const wchar_t* character_name, bool _same_map, const b
     return ::Reroll(character_name, _same_map, _same_party, _ignore_current_character, _do_not_prompt);
 }
 
+bool RerollWindow::RerollToProfession(const GW::Constants::Profession profession, const bool same_map, const bool same_party)
+{
+    return ::RerollToProfession(profession, same_map, same_party);
+}
+
+const wchar_t* RerollWindow::FindAvailableCharForProfession(const GW::Constants::Profession profession)
+{
+    return ::FindAvailableCharForProfession(profession);
+}
+
+bool RerollWindow::IsRerolling() const
+{
+    return reroll_stage != RerollStage::None;
+}
+
 void RerollWindow::LoadSettings(ToolboxIni* ini)
 {
     ToolboxWindow::LoadSettings(ini);
@@ -685,6 +814,17 @@ void RerollWindow::LoadSettings(ToolboxIni* ini)
         auto charname_w = TextUtils::StringToWString(cstring);
         if (charname_w.length() && !IsExcludedFromReroll(charname_w.c_str())) {
             exclude_charnames_from_reroll_cmd.push_back(LowerCaseRemovePunct(charname_w));
+        }
+    }
+
+    // Load preferred characters per profession (stored as "preferred_prof_N" keys).
+    preferred_chars_by_profession.clear();
+    for (uint32_t p = 1; p <= 10; p++) {
+        char key[32];
+        snprintf(key, sizeof(key), "preferred_prof_%u", p);
+        const char* val = ini->GetValue(Name(), key, "");
+        if (val && *val) {
+            preferred_chars_by_profession[p] = TextUtils::StringToWString(val);
         }
     }
 }
@@ -704,4 +844,17 @@ void RerollWindow::SaveSettings(ToolboxIni* ini)
         excluded_charnames_ini += TextUtils::WStringToString(excluded);
     }
     ini->SetValue(Name(), "exclude_charnames_from_reroll_cmd", excluded_charnames_ini.c_str());
+
+    // Save preferred characters per profession.
+    for (uint32_t p = 1; p <= 10; p++) {
+        char key[32];
+        snprintf(key, sizeof(key), "preferred_prof_%u", p);
+        const auto it = preferred_chars_by_profession.find(p);
+        if (it != preferred_chars_by_profession.end() && !it->second.empty()) {
+            ini->SetValue(Name(), key, TextUtils::WStringToString(it->second).c_str());
+        }
+        else {
+            ini->Delete(Name(), key);
+        }
+    }
 }

--- a/GWToolboxdll/Windows/RerollWindow.cpp
+++ b/GWToolboxdll/Windows/RerollWindow.cpp
@@ -177,9 +177,22 @@ namespace {
     std::vector<std::wstring> exclude_charnames_from_reroll_cmd;
     char excluded_char_add_buf[20] = {0};
 
-    // Maps profession (1-10) → preferred character name for RerollToProfession().
-    // An empty string means "no preference" – fall through to first available match.
-    std::unordered_map<uint32_t, std::wstring> preferred_chars_by_profession;
+    // Maps account_uuid_str → (profession_id → preferred character name).
+    // An empty profession entry means "no preference" for that profession.
+    std::unordered_map<std::string, std::unordered_map<uint32_t, std::wstring>> preferred_chars_per_account;
+
+    std::string GetCurrentAccountUuidStr()
+    {
+        const auto uuid = GW::AccountMgr::GetAccountUuid();
+        const GUID empty{};
+        if (memcmp(&uuid, &empty, sizeof(uuid)) == 0) return {};
+        return TextUtils::GuidToString(&uuid);
+    }
+
+    std::unordered_map<uint32_t, std::wstring>& GetCurrentAccountPrefs()
+    {
+        return preferred_chars_per_account[GetCurrentAccountUuidStr()];
+    }
 
     GW::HookEntry OnGoToCharSelect_Entry;
 
@@ -231,10 +244,11 @@ namespace {
 
         const auto available_chars_ptr = GW::AccountMgr::GetAvailableChars();
 
+        auto& account_prefs = GetCurrentAccountPrefs();
         for (size_t i = 0; i < profession_names.size(); i++) {
             const auto prof = static_cast<GW::Constants::Profession>(i + 1);
             const auto prof_key = static_cast<uint32_t>(prof);
-            auto& pref = preferred_chars_by_profession[prof_key];
+            auto& pref = account_prefs[prof_key];
 
             ImGui::PushID(static_cast<int>(i));
 
@@ -378,11 +392,14 @@ namespace {
         }
 
         // Check the configured preferred character first.
-        const auto pref_it = preferred_chars_by_profession.find(static_cast<uint32_t>(profession));
-        if (pref_it != preferred_chars_by_profession.end() && !pref_it->second.empty()) {
-            const auto pref_char = GW::AccountMgr::GetAvailableCharacter(pref_it->second.c_str());
-            if (pref_char && pref_char->primary() == profession) {
-                return Reroll(pref_it->second.c_str(), _same_map, _same_party);
+        const auto account_it = preferred_chars_per_account.find(GetCurrentAccountUuidStr());
+        if (account_it != preferred_chars_per_account.end()) {
+            const auto pref_it = account_it->second.find(static_cast<uint32_t>(profession));
+            if (pref_it != account_it->second.end() && !pref_it->second.empty()) {
+                const auto pref_char = GW::AccountMgr::GetAvailableCharacter(pref_it->second.c_str());
+                if (pref_char && pref_char->primary() == profession) {
+                    return Reroll(pref_it->second.c_str(), _same_map, _same_party);
+                }
             }
         }
 
@@ -405,11 +422,14 @@ namespace {
         if (!available_characters || !available_characters->valid()) {
             return nullptr;
         }
-        const auto pref_it = preferred_chars_by_profession.find(static_cast<uint32_t>(profession));
-        if (pref_it != preferred_chars_by_profession.end() && !pref_it->second.empty()) {
-            const auto pref_char = GW::AccountMgr::GetAvailableCharacter(pref_it->second.c_str());
-            if (pref_char && pref_char->primary() == profession) {
-                return pref_char->player_name;
+        const auto account_it = preferred_chars_per_account.find(GetCurrentAccountUuidStr());
+        if (account_it != preferred_chars_per_account.end()) {
+            const auto pref_it = account_it->second.find(static_cast<uint32_t>(profession));
+            if (pref_it != account_it->second.end() && !pref_it->second.empty()) {
+                const auto pref_char = GW::AccountMgr::GetAvailableCharacter(pref_it->second.c_str());
+                if (pref_char && pref_char->primary() == profession) {
+                    return pref_char->player_name;
+                }
             }
         }
         for (const auto& available_char : *available_characters) {
@@ -581,9 +601,14 @@ void RerollWindow::Draw(IDirect3DDevice9*)
         ImGui::PopStyleVar();
     }
     DrawExcludedCharacters();
-    DrawPreferredCharacters();
 
     ImGui::End();
+}
+
+void RerollWindow::DrawSettingsInternal()
+{
+    ToolboxWindow::DrawSettingsInternal();
+    DrawPreferredCharacters();
 }
 
 void RerollWindow::Initialize()
@@ -796,7 +821,7 @@ const wchar_t* RerollWindow::FindAvailableCharForProfession(const GW::Constants:
     return ::FindAvailableCharForProfession(profession);
 }
 
-bool RerollWindow::IsRerolling() const
+bool RerollWindow::IsRerolling()
 {
     return reroll_stage != RerollStage::None;
 }
@@ -817,14 +842,23 @@ void RerollWindow::LoadSettings(ToolboxIni* ini)
         }
     }
 
-    // Load preferred characters per profession (stored as "preferred_prof_N" keys).
-    preferred_chars_by_profession.clear();
-    for (uint32_t p = 1; p <= 10; p++) {
-        char key[32];
-        snprintf(key, sizeof(key), "preferred_prof_%u", p);
-        const char* val = ini->GetValue(Name(), key, "");
-        if (val && *val) {
-            preferred_chars_by_profession[p] = TextUtils::StringToWString(val);
+    // Load per-account preferred characters. Keys are "pref_{uuid}_{n}" (n = 1-10).
+    preferred_chars_per_account.clear();
+    {
+        TNamesDepend keys;
+        ini->GetAllKeys(Name(), keys);
+        for (const auto& entry : keys) {
+            const std::string_view k = entry.pItem;
+            if (!k.starts_with("pref_") || k.size() < 43) continue;
+            const auto uuid_str = std::string(k.substr(5, 36));
+            if (k.size() <= 42 || k[41] != '_') continue;
+            const auto n_str = k.substr(42);
+            const auto n = static_cast<uint32_t>(std::strtoul(n_str.data(), nullptr, 10));
+            if (n < 1 || n > 10) continue;
+            const char* val = ini->GetValue(Name(), k.data(), "");
+            if (val && *val) {
+                preferred_chars_per_account[uuid_str][n] = TextUtils::StringToWString(val);
+            }
         }
     }
 }
@@ -845,16 +879,25 @@ void RerollWindow::SaveSettings(ToolboxIni* ini)
     }
     ini->SetValue(Name(), "exclude_charnames_from_reroll_cmd", excluded_charnames_ini.c_str());
 
-    // Save preferred characters per profession.
+    // Remove legacy preferred_prof_N keys.
     for (uint32_t p = 1; p <= 10; p++) {
         char key[32];
         snprintf(key, sizeof(key), "preferred_prof_%u", p);
-        const auto it = preferred_chars_by_profession.find(p);
-        if (it != preferred_chars_by_profession.end() && !it->second.empty()) {
-            ini->SetValue(Name(), key, TextUtils::WStringToString(it->second).c_str());
-        }
-        else {
-            ini->Delete(Name(), key);
+        ini->Delete(Name(), key);
+    }
+
+    // Save per-account preferred characters as "pref_{uuid}_{n}" keys.
+    for (const auto& [uuid_str, prof_map] : preferred_chars_per_account) {
+        for (uint32_t p = 1; p <= 10; p++) {
+            char key[64];
+            snprintf(key, sizeof(key), "pref_%s_%u", uuid_str.c_str(), p);
+            const auto it = prof_map.find(p);
+            if (it != prof_map.end() && !it->second.empty()) {
+                ini->SetValue(Name(), key, TextUtils::WStringToString(it->second).c_str());
+            }
+            else {
+                ini->Delete(Name(), key);
+            }
         }
     }
 }

--- a/GWToolboxdll/Windows/RerollWindow.h
+++ b/GWToolboxdll/Windows/RerollWindow.h
@@ -35,9 +35,11 @@ public:
     bool Reroll(const wchar_t* character_name, bool same_map = true, bool same_party = true, const bool ignore_current_character = false, const bool do_not_prompt = false);
     bool Reroll(const wchar_t* character_name, GW::Constants::MapID _map_id);
 
+    void DrawSettingsInternal() override;
+
     // Find the best available character for the given profession (checks preferred
     // characters first, then falls back to the first unlisted match) and initiate a reroll.
-    bool RerollToProfession(GW::Constants::Profession profession, bool same_map = true, bool same_party = true);
+    static bool RerollToProfession(GW::Constants::Profession profession, bool same_map = true, bool same_party = true);
 
     // Returns the name of the available character that would be used by RerollToProfession,
     // or nullptr if no character with the given profession exists.
@@ -45,5 +47,5 @@ public:
 
     // Returns true while a reroll is in progress (i.e. between the Reroll() call and
     // the character being fully loaded into the target map).
-    [[nodiscard]] bool IsRerolling() const;
+    [[nodiscard]] static bool IsRerolling();
 };

--- a/GWToolboxdll/Windows/RerollWindow.h
+++ b/GWToolboxdll/Windows/RerollWindow.h
@@ -4,6 +4,7 @@
 
 namespace GW::Constants {
     enum class MapID : uint32_t;
+    enum class Profession : uint32_t;
     enum class ServerRegion;
     enum class Language;
 }
@@ -33,4 +34,16 @@ public:
 
     bool Reroll(const wchar_t* character_name, bool same_map = true, bool same_party = true, const bool ignore_current_character = false, const bool do_not_prompt = false);
     bool Reroll(const wchar_t* character_name, GW::Constants::MapID _map_id);
+
+    // Find the best available character for the given profession (checks preferred
+    // characters first, then falls back to the first unlisted match) and initiate a reroll.
+    bool RerollToProfession(GW::Constants::Profession profession, bool same_map = true, bool same_party = true);
+
+    // Returns the name of the available character that would be used by RerollToProfession,
+    // or nullptr if no character with the given profession exists.
+    [[nodiscard]] static const wchar_t* FindAvailableCharForProfession(GW::Constants::Profession profession);
+
+    // Returns true while a reroll is in progress (i.e. between the Reroll() call and
+    // the character being fully loaded into the target map).
+    [[nodiscard]] bool IsRerolling() const;
 };


### PR DESCRIPTION
Closes #2164

When viewing a teambuild from a chat link, each skillbar now shows:
- Build attributes (profession, attribute names and values)
- A Load button enabled when the hero is unlocked (hero builds) or the player's primary profession matches the build (player builds); disabled with a tooltip explaining why when conditions aren't met

Generated with [Claude Code](https://claude.ai/code)