### PR TITLE
feat: add UI message callback timing to Performance window

### DIFF
--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -723,6 +723,11 @@ void GWToolbox::SetProfilingEnabled(bool enabled)
     profiling_enabled = enabled;
 }
 
+bool GWToolbox::IsProfilingEnabled()
+{
+    return profiling_enabled;
+}
+
 bool GWToolbox::ShouldDisableToolbox(GW::Constants::MapID map_id)
 {
     const auto m = GW::Map::GetMapInfo(map_id);

--- a/GWToolboxdll/GWToolbox.h
+++ b/GWToolboxdll/GWToolbox.h
@@ -64,6 +64,7 @@ public:
     static bool ToggleModule(ToolboxModule& m, bool enable = true);
 
     static void SetProfilingEnabled(bool enabled);
+    static bool IsProfilingEnabled();
 
 private:
     static void DrawInitialising(IDirect3DDevice9* device);

--- a/GWToolboxdll/Modules/AudioSettings.cpp
+++ b/GWToolboxdll/Modules/AudioSettings.cpp
@@ -246,7 +246,7 @@ void AudioSettings::Initialize()
     ASSERT(StopSound_Func);
     ASSERT(PlayMusicFromSoundScript_Func);
     #endif
-    GW::UI::RegisterUIMessageCallback(&OnUIMessage_HookEntry, GW::UI::UIMessage::kMapChange, OnPostUIMessage, 0x8000);
+    RegisterUIMessageCallback(&OnUIMessage_HookEntry, GW::UI::UIMessage::kMapChange, OnPostUIMessage, 0x8000);
 
 }
 void AudioSettings::Update(float) {

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -1846,7 +1846,7 @@ void ChatCommands::Initialize()
     };
 
 
-    GW::UI::RegisterUIMessageCallback(&OnSentChat_HookEntry, GW::UI::UIMessage::kSendChatMessage, OnSendChat);
+    RegisterUIMessageCallback(&OnSentChat_HookEntry, GW::UI::UIMessage::kSendChatMessage, OnSendChat);
 
 
 #if _DEBUG

--- a/GWToolboxdll/Modules/ChatFilter.cpp
+++ b/GWToolboxdll/Modules/ChatFilter.cpp
@@ -854,7 +854,7 @@ void ChatFilter::Initialize()
         GW::UI::UIMessage::kPlayerChatMessage
     };
     for (auto message_id : message_ids) {
-        GW::UI::RegisterUIMessageCallback(&BlockIfApplicable_Entry, message_id, OnUIMessage, -0x8001);
+        RegisterUIMessageCallback(&BlockIfApplicable_Entry, message_id, OnUIMessage, -0x8001);
     }
 }
 

--- a/GWToolboxdll/Modules/ChatSettings.cpp
+++ b/GWToolboxdll/Modules/ChatSettings.cpp
@@ -451,7 +451,7 @@ void ChatSettings::Initialize()
                                                  GW::UI::UIMessage::kPlayerChatMessage, GW::UI::UIMessage::kWriteToChatLog,  GW::UI::UIMessage::kWriteToChatLogWithSender, GW::UI::UIMessage::kRecvWhisper,
                                                  GW::UI::UIMessage::kStartWhisper,      GW::UI::UIMessage::kSendChatMessage, GW::UI::UIMessage::kAgentSpeechBubble,        GW::UI::UIMessage::kChatLinkClicked, GW::UI::UIMessage::kAddCustomChatLink};
     for (const auto message_id : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&OnUIMessage_Entry, message_id, OnUIMessage);
+        RegisterUIMessageCallback(&OnUIMessage_Entry, message_id, OnUIMessage);
     }
     ColorHexOrLabelToColor_Func = (ColorHexOrLabelToColor_pt)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("CtlTextMl.cpp", "value", 0, 0));
     if (ColorHexOrLabelToColor_Func) {

--- a/GWToolboxdll/Modules/DiscordModule.cpp
+++ b/GWToolboxdll/Modules/DiscordModule.cpp
@@ -725,7 +725,7 @@ void DiscordModule::Initialize()
 
 
     for (auto message_id : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&PostUIMessage_HookEntry, message_id, OnPostUIMessage, 0x4000);
+        RegisterUIMessageCallback(&PostUIMessage_HookEntry, message_id, OnPostUIMessage, 0x4000);
     }
 
     if (GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable) {

--- a/GWToolboxdll/Modules/ItemTooltipModule.cpp
+++ b/GWToolboxdll/Modules/ItemTooltipModule.cpp
@@ -396,7 +396,7 @@ void ItemTooltipModule::Initialize()
     // Priority 200 keeps us after PriceCheckerModule (100), ensuring prices
     // are already fetched before we try to display them.
     ItemDescriptionHandler::RegisterDescriptionCallback(OnGetItemDescription, 200);
-    GW::UI::RegisterUIMessageCallback(&UIMessage_HookEntry, GW::UI::UIMessage::kSetAgentNameTagAttribs, ::OnUIMessage);
+    RegisterUIMessageCallback(&UIMessage_HookEntry, GW::UI::UIMessage::kSetAgentNameTagAttribs, ::OnUIMessage);
 }
 
 void ItemTooltipModule::Terminate()

--- a/GWToolboxdll/Modules/LoginModule.cpp
+++ b/GWToolboxdll/Modules/LoginModule.cpp
@@ -61,7 +61,7 @@ void LoginModule::Update(float)
 void LoginModule::Initialize()
 {
     ToolboxModule::Initialize();
-    GW::UI::RegisterUIMessageCallback(&UIMessage_HookEntry,GW::UI::UIMessage::kSetPreGameContext_Value1, OnPostUIMessage, 0x8000);
+    RegisterUIMessageCallback(&UIMessage_HookEntry,GW::UI::UIMessage::kSetPreGameContext_Value1, OnPostUIMessage, 0x8000);
     GetStringParameter_Func = (GetStringParameter_pt)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("Param.cpp", "string - PARAM_STRING_FIRST < (sizeof(s_strings) / sizeof((s_strings)[0]))", 0, 0));
     DEBUG_ASSERT(GetStringParameter_Func);
     if (GetStringParameter_Func) {

--- a/GWToolboxdll/Modules/MouseFix.cpp
+++ b/GWToolboxdll/Modules/MouseFix.cpp
@@ -454,7 +454,7 @@ void MouseFix::Initialize()
     };
 
     for (const auto ui_message : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&UIMessage_HookEntry, ui_message, OnUIMessage);
+        RegisterUIMessageCallback(&UIMessage_HookEntry, ui_message, OnUIMessage);
     }
 }
 

--- a/GWToolboxdll/Modules/Obfuscator.cpp
+++ b/GWToolboxdll/Modules/Obfuscator.cpp
@@ -900,8 +900,8 @@ void Obfuscator::Initialize()
         RegisterUIMessageCallback(&stoc_hook, header, OnUIMessage, post_gw_altitude);
     }
 
-    GW::UI::RegisterUIMessageCallback(&ctos_hook, GW::UI::UIMessage::kWriteToChatLog, OnPrintChat);
-    GW::UI::RegisterUIMessageCallback(&ctos_hook, GW::UI::UIMessage::kSendChatMessage, OnSendChat);
+    RegisterUIMessageCallback(&ctos_hook, GW::UI::UIMessage::kWriteToChatLog, OnPrintChat);
+    RegisterUIMessageCallback(&ctos_hook, GW::UI::UIMessage::kSendChatMessage, OnSendChat);
 
     GW::Chat::CreateCommand(&ChatCmd_HookEntry, L"obfuscate", CmdObfuscate);
     GW::Chat::CreateCommand(&ChatCmd_HookEntry, L"hideme", CmdObfuscate);

--- a/GWToolboxdll/Modules/PartyBroadcastModule.cpp
+++ b/GWToolboxdll/Modules/PartyBroadcastModule.cpp
@@ -376,7 +376,7 @@ void PartyBroadcast::Initialize()
         GW::UI::UIMessage::kPartySearchIdChanged // Party search Remove
     };
     for (const auto message_id : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&OnUIMessage_Hook, message_id, OnUIMessage, 0x8000);
+        RegisterUIMessageCallback(&OnUIMessage_Hook, message_id, OnUIMessage, 0x8000);
     }
 }
 

--- a/GWToolboxdll/Modules/PartyWindowModule.cpp
+++ b/GWToolboxdll/Modules/PartyWindowModule.cpp
@@ -986,7 +986,7 @@ void PartyWindowModule::Initialize()
         GW::UI::UIMessage::kPartySearchUpdated
     };
     for (auto ui_message : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&OnPostUIMessage_HookEntry, ui_message, OnPostUIMessage, 0x8000);
+        RegisterUIMessageCallback(&OnPostUIMessage_HookEntry, ui_message, OnPostUIMessage, 0x8000);
     }
 }
 

--- a/GWToolboxdll/Modules/QuestModule.cpp
+++ b/GWToolboxdll/Modules/QuestModule.cpp
@@ -746,8 +746,8 @@ void QuestModule::Initialize()
     };
     for (const auto ui_message : ui_messages) {
         // Post callbacks, non blocking
-        GW::UI::RegisterUIMessageCallback(&pre_ui_message_entry, ui_message, OnPreUIMessage, -0x4000);
-        GW::UI::RegisterUIMessageCallback(&post_ui_message_entry, ui_message, OnPostUIMessage, 0x4000);
+        RegisterUIMessageCallback(&pre_ui_message_entry, ui_message, OnPreUIMessage, -0x4000);
+        RegisterUIMessageCallback(&post_ui_message_entry, ui_message, OnPostUIMessage, 0x4000);
     }
     RefreshQuestPath(GW::QuestMgr::GetActiveQuestId());
 

--- a/GWToolboxdll/Modules/ResignLogModule.cpp
+++ b/GWToolboxdll/Modules/ResignLogModule.cpp
@@ -226,7 +226,7 @@ void ResignLogModule::Initialize() {
     };
 
     for (auto message_id : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&ResignLog_HookEntry, message_id, OnUIMessage, 0x8000);
+        RegisterUIMessageCallback(&ResignLog_HookEntry, message_id, OnUIMessage, 0x8000);
     }
 
     GW::Chat::CreateCommand(&ChatCmd_HookEntry, L"resignlog", CmdResignLog);

--- a/GWToolboxdll/Modules/TextToSpeechModule.cpp
+++ b/GWToolboxdll/Modules/TextToSpeechModule.cpp
@@ -1729,8 +1729,8 @@ void TextToSpeechModule::Initialize()
     const GW::UI::UIMessage messages[] = {GW::UI::UIMessage::kDialogBody, GW::UI::UIMessage::kVendorWindow,           GW::UI::UIMessage::kAgentSpeechBubble,     GW::UI::UIMessage::kMapChange,
                                           GW::UI::UIMessage::kMapLoaded,  GW::UI::UIMessage::kPreferenceValueChanged, GW::UI::UIMessage::kDialogueMessageUpdated};
     for (auto message_id : messages) {
-        GW::UI::RegisterUIMessageCallback(&PreUIMessage_HookEntry, message_id, OnPreUIMessage, -0x1);
-        GW::UI::RegisterUIMessageCallback(&UIMessage_HookEntry, message_id, OnPostUIMessage, 0x4000);
+        RegisterUIMessageCallback(&PreUIMessage_HookEntry, message_id, OnPreUIMessage, -0x1);
+        RegisterUIMessageCallback(&UIMessage_HookEntry, message_id, OnPostUIMessage, 0x4000);
     }
     AudioSettings::RegisterPlaySoundCallback(&UIMessage_HookEntry, OnPlaySound);
 

--- a/GWToolboxdll/Modules/ToastNotifications.cpp
+++ b/GWToolboxdll/Modules/ToastNotifications.cpp
@@ -520,8 +520,8 @@ void ToastNotifications::Initialize()
     ToolboxModule::Initialize();
 
     is_platform_compatible = WinToastLib::WinToast::isCompatible();
-    GW::UI::RegisterUIMessageCallback(&OnWhisper_Entry, GW::UI::UIMessage::kRecvWhisper, OnRecvWhisper);
-    GW::UI::RegisterUIMessageCallback(&OnTeamChat_Entry, GW::UI::UIMessage::kPlayerChatMessage, OnTeamChatMessage);
+    RegisterUIMessageCallback(&OnWhisper_Entry, GW::UI::UIMessage::kRecvWhisper, OnRecvWhisper);
+    RegisterUIMessageCallback(&OnTeamChat_Entry, GW::UI::UIMessage::kPlayerChatMessage, OnTeamChatMessage);
     for (auto& callback : stoc_callbacks) {
         GW::StoC::RegisterPacketCallback(&callback.hook_entry, callback.header, callback.cb, 0x8000);
     }

--- a/GWToolboxdll/Modules/TwitchModule.cpp
+++ b/GWToolboxdll/Modules/TwitchModule.cpp
@@ -266,7 +266,7 @@ namespace {
         }
         hooked = true;
         // When starting a whisper to "<irc_nickname> @ <irc_channel>", rewrite recipient to be "<irc_channel>"
-        GW::UI::RegisterUIMessageCallback(&StartWhisperCallback_Entry, GW::UI::UIMessage::kStartWhisper, [](GW::HookStatus*, GW::UI::UIMessage, void* wparam, void*) {
+        RegisterUIMessageCallback(&StartWhisperCallback_Entry, GW::UI::UIMessage::kStartWhisper, [](GW::HookStatus*, GW::UI::UIMessage, void* wparam, void*) {
             wchar_t* name = *(wchar_t**)wparam;
             if (!(name && *name)) {
                 return;
@@ -278,7 +278,7 @@ namespace {
                 wcscpy(name, w_alias.c_str());
             }
         });
-        GW::UI::RegisterUIMessageCallback(&SendChatCallback_Entry, GW::UI::UIMessage::kSendChatMessage, [](GW::HookStatus* status, GW::UI::UIMessage, void* wparam, void*) {
+        RegisterUIMessageCallback(&SendChatCallback_Entry, GW::UI::UIMessage::kSendChatMessage, [](GW::HookStatus* status, GW::UI::UIMessage, void* wparam, void*) {
             const auto msg = *static_cast<const wchar_t**>(wparam);
             const auto chan = GW::Chat::GetChannel(*msg);
             if (chan != GW::Chat::Channel::CHANNEL_WHISPER || !connected) {

--- a/GWToolboxdll/ToolboxModule.cpp
+++ b/GWToolboxdll/ToolboxModule.cpp
@@ -1,8 +1,15 @@
 #include "stdafx.h"
 
 #include <ToolboxModule.h>
+#include <GWToolbox.h>
 
 namespace {
+    uint64_t QpcToMicroseconds(LONGLONG ticks)
+    {
+        static LARGE_INTEGER freq = [] { LARGE_INTEGER f; QueryPerformanceFrequency(&f); return f; }();
+        return static_cast<uint64_t>(ticks * 1000000 / freq.QuadPart);
+    }
+
     // static function to register content
     std::unordered_map<std::string, SectionDrawCallbackList> settings_draw_callbacks{};
     std::unordered_map<std::string, const char*> settings_icons{};
@@ -56,6 +63,28 @@ void ToolboxModule::RegisterSettingsContent()
             }
         },
         SettingsWeighting());
+}
+
+void ToolboxModule::RegisterUIMessageCallback(
+    GW::HookEntry* entry,
+    GW::UI::UIMessage message_id,
+    const GW::UI::UIMessageCallback& callback,
+    int altitude)
+{
+    GW::UI::RegisterUIMessageCallback(entry, message_id,
+        [this, callback](GW::HookStatus* status, GW::UI::UIMessage msg, void* wparam, void* lparam) {
+            if (GWToolbox::IsProfilingEnabled()) {
+                LARGE_INTEGER t0, t1;
+                QueryPerformanceCounter(&t0);
+                callback(status, msg, wparam, lparam);
+                QueryPerformanceCounter(&t1);
+                last_ui_message_time_us_ += QpcToMicroseconds(t1.QuadPart - t0.QuadPart);
+            }
+            else {
+                callback(status, msg, wparam, lparam);
+            }
+        },
+        altitude);
 }
 
 void ToolboxModule::RegisterSettingsContent(const char* section, const char* icon, const SectionDrawCallback& callback, float weighting)

--- a/GWToolboxdll/ToolboxModule.h
+++ b/GWToolboxdll/ToolboxModule.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <GWCA/Managers/UIMgr.h>
+
 using SectionDrawCallback = std::function<void(const std::string& section, bool is_showing)>;
 class ToolboxModule;
 class ToolboxIni;
@@ -87,6 +89,11 @@ public:
 
     uint64_t last_update_time_us_ = 0;
     uint64_t last_draw_time_us_ = 0;
+    mutable uint64_t last_ui_message_time_us_ = 0;
+
+    // Instrumented wrapper: times each invocation and accumulates into last_ui_message_time_us_
+    void RegisterUIMessageCallback(GW::HookEntry* entry, GW::UI::UIMessage message_id,
+                                   const GW::UI::UIMessageCallback& callback, int altitude = -0x8000);
 
 protected:
     // Weighting used to decide where to position the DrawSettingInternal() for this module. Useful when more than 1 module has the same SettingsName().

--- a/GWToolboxdll/Widgets/ActiveQuestWidget.cpp
+++ b/GWToolboxdll/Widgets/ActiveQuestWidget.cpp
@@ -71,7 +71,7 @@ void ActiveQuestWidget::Initialize() {
         GW::UI::UIMessage::kObjectiveUpdated
     });
     for (const auto message_id : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&hook_entry, message_id, SetForceUpdate);
+        RegisterUIMessageCallback(&hook_entry, message_id, SetForceUpdate);
     }
 }
 

--- a/GWToolboxdll/Widgets/BountyKillTrackerWidget.cpp
+++ b/GWToolboxdll/Widgets/BountyKillTrackerWidget.cpp
@@ -305,7 +305,7 @@ void BountyKillTrackerWidget::Initialize()
         GW::UI::UIMessage::kMapChange,
     };
     for (const auto msg : messages) {
-        GW::UI::RegisterUIMessageCallback(&UIMessage_HookEntry, msg, OnUIMessage, -0x6000);
+        RegisterUIMessageCallback(&UIMessage_HookEntry, msg, OnUIMessage, -0x6000);
     }
 }
 

--- a/GWToolboxdll/Widgets/EffectsMonitorWidget.cpp
+++ b/GWToolboxdll/Widgets/EffectsMonitorWidget.cpp
@@ -293,7 +293,7 @@ void EffectsMonitorWidget::Draw(IDirect3DDevice9*)
 void EffectsMonitorWidget::Initialize()
 {
     ToolboxWidget::Initialize();
-    GW::UI::RegisterUIMessageCallback(&OnPreUIMessage_HookEntry, GW::UI::UIMessage::kEffectAdd, OnPreUIMessage, -0x6000);
+    RegisterUIMessageCallback(&OnPreUIMessage_HookEntry, GW::UI::UIMessage::kEffectAdd, OnPreUIMessage, -0x6000);
 
     GW::UI::UIMessage spirit_messages[] = {
         GW::UI::UIMessage::kAgentSkillActivated,
@@ -301,7 +301,7 @@ void EffectsMonitorWidget::Initialize()
         GW::UI::UIMessage::kAgentDestroy
     };
     for (auto msg : spirit_messages) {
-        GW::UI::RegisterUIMessageCallback(&spirit_ui_hook, msg, OnSpiritUIMessage, 0x100);
+        RegisterUIMessageCallback(&spirit_ui_hook, msg, OnSpiritUIMessage, 0x100);
     }
 }
 void EffectsMonitorWidget::Terminate()

--- a/GWToolboxdll/Widgets/FavorTracker.cpp
+++ b/GWToolboxdll/Widgets/FavorTracker.cpp
@@ -172,7 +172,7 @@ void FavorTracker::Initialize()
         GW::UI::UIMessage::kWriteToChatLog
     };
     for (const auto message_id : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&OnUIMessage_Entry, message_id, OnPreUIMessage, -0x4500);
+        RegisterUIMessageCallback(&OnUIMessage_Entry, message_id, OnPreUIMessage, -0x4500);
     }
 }
 

--- a/GWToolboxdll/Widgets/SkillMonitorWidget.cpp
+++ b/GWToolboxdll/Widgets/SkillMonitorWidget.cpp
@@ -191,7 +191,7 @@ void SkillMonitorWidget::Initialize()
     SnapsToPartyWindow::Initialize();
     GW::UI::UIMessage ui_messages[] = {GW::UI::UIMessage::kAgentSkillActivated, GW::UI::UIMessage::kAgentSkillActivatedInstantly, GW::UI::UIMessage::kAgentSkillCancelled, GW::UI::UIMessage::kAgentSkillStartedCast};
     for (auto message_id : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&PostUIMessage_Entry, message_id, OnPostUIMessage, 0x4000);
+        RegisterUIMessageCallback(&PostUIMessage_Entry, message_id, OnPostUIMessage, 0x4000);
     }
 }
 

--- a/GWToolboxdll/Widgets/SkillbarWidget.cpp
+++ b/GWToolboxdll/Widgets/SkillbarWidget.cpp
@@ -627,8 +627,8 @@ void SkillbarWidget::DrawSettingsInternal()
 void SkillbarWidget::Initialize()
 {
     ToolboxWidget::Initialize();
-    GW::UI::RegisterUIMessageCallback(&OnUIMessage_HookEntry, GW::UI::UIMessage::kUIPositionChanged, OnUIMessage, 0x8000);
-    GW::UI::RegisterUIMessageCallback(&OnUIMessage_HookEntry, GW::UI::UIMessage::kPreferenceValueChanged, OnUIMessage, 0x8000);
+    RegisterUIMessageCallback(&OnUIMessage_HookEntry, GW::UI::UIMessage::kUIPositionChanged, OnUIMessage, 0x8000);
+    RegisterUIMessageCallback(&OnUIMessage_HookEntry, GW::UI::UIMessage::kPreferenceValueChanged, OnUIMessage, 0x8000);
 
     ChatCommands::RegisterSettingChatCommand(L"skillbar_effects_overlay", &display_effect_monitor, L"Toggles the effect monitor overlay on the skillbar widget");
     ChatCommands::RegisterSettingChatCommand(L"skillbar_skills_overlay", &display_skill_overlay, L"Toggles the skill monitor overlay on the skillbar widget");

--- a/GWToolboxdll/Widgets/SnapsToPartyWindow.cpp
+++ b/GWToolboxdll/Widgets/SnapsToPartyWindow.cpp
@@ -163,7 +163,7 @@ void SnapsToPartyWindow::Initialize()
 {
     ToolboxWidget::Initialize();
     is_movable = is_resizable = false;
-    GW::UI::RegisterUIMessageCallback(&OnUIMessage_HookEntry, GW::UI::UIMessage::kPreferenceValueChanged, OnUIMessage, 0x8000);
+    RegisterUIMessageCallback(&OnUIMessage_HookEntry, GW::UI::UIMessage::kPreferenceValueChanged, OnUIMessage, 0x8000);
 }
 
 void SnapsToPartyWindow::Terminate()

--- a/GWToolboxdll/Widgets/TitleTrackerWidget.cpp
+++ b/GWToolboxdll/Widgets/TitleTrackerWidget.cpp
@@ -338,7 +338,7 @@ void TitleTrackerWidget::Initialize()
     });
     static constexpr GW::UI::UIMessage ui_messages[] = {GW::UI::UIMessage::kTitleProgressUpdated, GW::UI::UIMessage::kExperienceGained, GW::UI::UIMessage::kUIPositionChanged};
     for (const auto& msg : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&OnPostUIMessage_HookEntry, msg, OnPostUIMessage, 0x8000);
+        RegisterUIMessageCallback(&OnPostUIMessage_HookEntry, msg, OnPostUIMessage, 0x8000);
     }
     for (size_t i = 0; i != (size_t)GW::Constants::TitleID::Codex; i++) {
         title_progress_by_id.push_back(new TitleProgress(static_cast<GW::Constants::TitleID>(i)));

--- a/GWToolboxdll/Widgets/WorldMapWidget.cpp
+++ b/GWToolboxdll/Widgets/WorldMapWidget.cpp
@@ -906,7 +906,7 @@ void WorldMapWidget::Initialize()
     const GW::UI::UIMessage ui_messages[] = {GW::UI::UIMessage::kQuestAdded,      GW::UI::UIMessage::kSendSetActiveQuest, GW::UI::UIMessage::kMapLoaded,
                                              GW::UI::UIMessage::kOnScreenMessage, GW::UI::UIMessage::kSendAbandonQuest,   GW::UI::UIMessage::kLoadMapContext};
     for (auto ui_message : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&OnUIMessage_HookEntry, ui_message, OnUIMessage, 0x8000);
+        RegisterUIMessageCallback(&OnUIMessage_HookEntry, ui_message, OnUIMessage, 0x8000);
     }
 
     AppendMapFileInfo();

--- a/GWToolboxdll/Windows/AccountInventoryWindow.cpp
+++ b/GWToolboxdll/Windows/AccountInventoryWindow.cpp
@@ -1167,7 +1167,7 @@ void AccountInventoryWindow::Initialize()
         GW::UI::UIMessage::kLogout
     };
     for (auto message_id : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&OnUIMessage_HookEntry, (GW::UI::UIMessage)message_id,
+        RegisterUIMessageCallback(&OnUIMessage_HookEntry, (GW::UI::UIMessage)message_id,
             [this] (GW::HookStatus*, GW::UI::UIMessage message_id, void* wparam, void*) {
                 switch (message_id) {
                     case GW::UI::UIMessage::kItemUpdated: {

--- a/GWToolboxdll/Windows/DailyQuestsWindow.cpp
+++ b/GWToolboxdll/Windows/DailyQuestsWindow.cpp
@@ -1819,8 +1819,8 @@ void DailyQuests::Initialize()
         GW::Chat::CreateCommand(&ChatCmd_HookEntry, it.first, it.second);
     }
 
-    GW::UI::RegisterUIMessageCallback(&OnUIMessage_HookEntry, GW::UI::UIMessage::kPreferenceValueChanged, OnUIMessage, 0x8000);
-    GW::UI::RegisterUIMessageCallback(&OnUIMessage_HookEntry, GW::UI::UIMessage::kMapLoaded, OnUIMessage, 0x8000);
+    RegisterUIMessageCallback(&OnUIMessage_HookEntry, GW::UI::UIMessage::kPreferenceValueChanged, OnUIMessage, 0x8000);
+    RegisterUIMessageCallback(&OnUIMessage_HookEntry, GW::UI::UIMessage::kMapLoaded, OnUIMessage, 0x8000);
 }
 
 void DailyQuests::Terminate()

--- a/GWToolboxdll/Windows/GWMarketWindow.cpp
+++ b/GWToolboxdll/Windows/GWMarketWindow.cpp
@@ -1664,7 +1664,7 @@ void GWMarketWindow::Initialize()
 
     const GW::UI::UIMessage ui_messages[] = {GW::UI::UIMessage::kMapLoaded};
     for (auto ui_message : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&OnPostUIMessage_HookEntry, ui_message, OnPostUIMessage, 0x4000);
+        RegisterUIMessageCallback(&OnPostUIMessage_HookEntry, ui_message, OnPostUIMessage, 0x4000);
     }
     OnPostUIMessage(0, GW::UI::UIMessage::kMapLoaded, 0, 0);
 }

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -268,8 +268,8 @@ void HeroBuildsWindow::Initialize()
     TeamBuild::SetSkillToggleSprite(skill_toggle_sprite);
     GW::Chat::CreateCommand(&ChatCmd_HookEntry, L"heroteam", &CmdHeroTeamBuild);
     GW::Chat::CreateCommand(&ChatCmd_HookEntry, L"herobuild", &CmdHeroTeamBuild);
-    GW::UI::RegisterUIMessageCallback(&OnOpenTemplate_Entry, GW::UI::UIMessage::kChatLinkClicked, OnChatLinkClicked);
-    GW::UI::RegisterUIMessageCallback(&OnOpenTemplate_Entry, GW::UI::UIMessage::kAddCustomChatLink, OnCreateChatLink);
+    RegisterUIMessageCallback(&OnOpenTemplate_Entry, GW::UI::UIMessage::kChatLinkClicked, OnChatLinkClicked);
+    RegisterUIMessageCallback(&OnOpenTemplate_Entry, GW::UI::UIMessage::kAddCustomChatLink, OnCreateChatLink);
 }
 
 void HeroBuildsWindow::Terminate()

--- a/GWToolboxdll/Windows/InfoWindow.cpp
+++ b/GWToolboxdll/Windows/InfoWindow.cpp
@@ -1145,7 +1145,7 @@ void InfoWindow::Initialize()
                                                                         [this](GW::HookStatus*, const GW::Packet::StoC::QuotedItemPrice* packet) -> void {
                                                                             quoted_item_id = packet->itemid;
                                                                         });
-    GW::UI::RegisterUIMessageCallback(&InstanceLoadFile_Entry, GW::UI::UIMessage::kLoadMapContext, OnPostUIMessage, 0x8000);
+    RegisterUIMessageCallback(&InstanceLoadFile_Entry, GW::UI::UIMessage::kLoadMapContext, OnPostUIMessage, 0x8000);
 }
 
 void InfoWindow::Draw(IDirect3DDevice9*)

--- a/GWToolboxdll/Windows/MaterialsWindow.cpp
+++ b/GWToolboxdll/Windows/MaterialsWindow.cpp
@@ -451,7 +451,7 @@ void MaterialsWindow::Initialize()
         GW::UI::UIMessage::kVendorTransComplete,
     };
     for (auto message_id : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&PostUIMessage_Entry, message_id, OnPostUIMessage, 0x4000);
+        RegisterUIMessageCallback(&PostUIMessage_Entry, message_id, OnPostUIMessage, 0x4000);
     }
 
 }

--- a/GWToolboxdll/Windows/Pathfinding/PathfindingWindow.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/PathfindingWindow.cpp
@@ -348,5 +348,5 @@ void PathfindingWindow::Initialize()
 {
     ToolboxWindow::Initialize();
 
-    GW::UI::RegisterUIMessageCallback(&gw_ui_hookentry, GW::UI::UIMessage::kLoadMapContext, OnUIMessage, 0x4000);
+    RegisterUIMessageCallback(&gw_ui_hookentry, GW::UI::UIMessage::kLoadMapContext, OnUIMessage, 0x4000);
 }

--- a/GWToolboxdll/Windows/PconsWindow.cpp
+++ b/GWToolboxdll/Windows/PconsWindow.cpp
@@ -433,7 +433,7 @@ void PconsWindow::Initialize()
         GW::UI::UIMessage::kInventorySlotUpdated
     };
     for (auto message_id : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&OnUIMessage_HookEntry, message_id, OnUIMessage);
+        RegisterUIMessageCallback(&OnUIMessage_HookEntry, message_id, OnUIMessage);
     }
 
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::GenericValue>(&GenericValue_Entry, &OnGenericValue);

--- a/GWToolboxdll/Windows/PerformanceWindow.cpp
+++ b/GWToolboxdll/Windows/PerformanceWindow.cpp
@@ -87,7 +87,7 @@ namespace {
     constexpr int WINDOW_SECONDS = 5;
 
     struct ModuleStats {
-        Stats update, draw;
+        Stats update, draw, ui_msg;
     };
 
     // Ring buffer of 1-second snapshots
@@ -129,6 +129,7 @@ namespace {
                 auto& dm = displayed_modules[name];
                 dm.update.Merge(ms.update);
                 dm.draw.Merge(ms.draw);
+                dm.ui_msg.Merge(ms.ui_msg);
             }
         }
 
@@ -188,10 +189,15 @@ void PerformanceWindow::Draw(IDirect3DDevice9* device)
     uint64_t total_update_us = 0, total_draw_us = 0;
 
     for (const auto* m : GWToolbox::GetAllModules()) {
-        if (m->last_update_time_us_ == 0 && m->last_draw_time_us_ == 0) continue;
+        const bool has_data = m->last_update_time_us_ || m->last_draw_time_us_ || m->last_ui_message_time_us_;
+        if (!has_data) continue;
         auto& ms = acc_modules[m->Name()];
         ms.update.Record(m->last_update_time_us_);
         ms.draw.Record(m->last_draw_time_us_);
+        if (m->last_ui_message_time_us_ > 0) {
+            ms.ui_msg.Record(m->last_ui_message_time_us_);
+            m->last_ui_message_time_us_ = 0;
+        }
         total_update_us += m->last_update_time_us_;
         total_draw_us += m->last_draw_time_us_;
     }
@@ -207,70 +213,11 @@ void PerformanceWindow::Draw(IDirect3DDevice9* device)
         window_start_tick = now;
     }
 
-    ImGui::SetNextWindowSize(ImVec2(500.f, 400.f), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(560.f, 440.f), ImGuiCond_FirstUseEver);
     if (!ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
         ImGui::End();
         return;
     }
-
-    // Frame overview (single thread: update → render → present)
-    if (displayed_frame.count > 0) {
-        const auto& f = displayed_frame;
-        const auto& tu = displayed_tb_update;
-        const auto& td = displayed_tb_draw;
-        const auto& p = displayed_present;
-
-        const float fps = f.Avg() > 0 ? 1000000.f / f.Avg() : 0.f;
-
-        if (ImGui::BeginTable("##frame_timing", 3,
-                ImGuiTableFlags_BordersInnerH | ImGuiTableFlags_SizingStretchProp)) {
-            ImGui::TableSetupColumn("");
-            ImGui::TableSetupColumn("avg (us)");
-            ImGui::TableSetupColumn("max (us)");
-            ImGui::TableHeadersRow();
-
-            ImGui::TableNextRow();
-            ImGui::TableNextColumn(); ImGui::Text("Frame (%.1f fps)", fps);
-            ImGui::TableNextColumn(); ImGui::Text("%llu", f.Avg());
-            ImGui::TableNextColumn(); ImGui::Text("%llu", f.max_us);
-
-            if (tu.count > 0) {
-                ImGui::TableNextRow();
-                ImGui::TableNextColumn(); ImGui::TextUnformatted("  TB Update");
-                ImGui::TableNextColumn(); ImGui::Text("%llu", tu.Avg());
-                ImGui::TableNextColumn(); ImGui::Text("%llu", tu.max_us);
-            }
-
-            if (td.count > 0) {
-                ImGui::TableNextRow();
-                ImGui::TableNextColumn(); ImGui::TextUnformatted("  TB Draw");
-                ImGui::TableNextColumn(); ImGui::Text("%llu", td.Avg());
-                ImGui::TableNextColumn(); ImGui::Text("%llu", td.max_us);
-            }
-
-            if (p.count > 0) {
-                ImGui::TableNextRow();
-                ImGui::TableNextColumn(); ImGui::TextUnformatted("  Present");
-                ImGui::TableNextColumn(); ImGui::Text("%llu", p.Avg());
-                ImGui::TableNextColumn(); ImGui::Text("%llu", p.max_us);
-            }
-
-            const uint64_t tb_total_avg = tu.Avg() + td.Avg();
-            const uint64_t known_avg = tb_total_avg + p.Avg();
-            const uint64_t gw_avg = f.Avg() > known_avg ? f.Avg() - known_avg : 0;
-            ImGui::TableNextRow();
-            ImGui::TableNextColumn(); ImGui::TextUnformatted("  GW");
-            ImGui::TableNextColumn(); ImGui::Text("~%llu", gw_avg);
-            ImGui::TableNextColumn();
-
-            ImGui::EndTable();
-        }
-    }
-
-    ImGui::Separator();
-
-    // Per-module breakdown
-    enum SortCol : int { Col_Name, Col_UpdMin, Col_UpdAvg, Col_UpdMax, Col_DrawMin, Col_DrawAvg, Col_DrawMax };
 
     struct DisplayEntry {
         const char* name;
@@ -278,56 +225,183 @@ void PerformanceWindow::Draw(IDirect3DDevice9* device)
     };
     static std::vector<DisplayEntry> entries;
     entries.clear();
-
     for (const auto& [name, ms] : displayed_modules) {
         entries.push_back({name.c_str(), ms});
     }
 
-    if (ImGui::BeginTable("##module_timing", 7,
-            ImGuiTableFlags_BordersInnerH | ImGuiTableFlags_SizingStretchProp
-            | ImGuiTableFlags_ScrollY | ImGuiTableFlags_Sortable | ImGuiTableFlags_SortTristate,
-            ImGui::GetContentRegionAvail())) {
-        ImGui::TableSetupColumn("Module",      ImGuiTableColumnFlags_DefaultSort, 0.f, Col_Name);
-        ImGui::TableSetupColumn("Upd min",     ImGuiTableColumnFlags_NoSort,      0.f, Col_UpdMin);
-        ImGui::TableSetupColumn("Upd avg",     0,                                 0.f, Col_UpdAvg);
-        ImGui::TableSetupColumn("Upd max",     0,                                 0.f, Col_UpdMax);
-        ImGui::TableSetupColumn("Draw min",    ImGuiTableColumnFlags_NoSort,      0.f, Col_DrawMin);
-        ImGui::TableSetupColumn("Draw avg",    0,                                 0.f, Col_DrawAvg);
-        ImGui::TableSetupColumn("Draw max",    0,                                 0.f, Col_DrawMax);
-        ImGui::TableSetupScrollFreeze(0, 1);
-        ImGui::TableHeadersRow();
+    if (ImGui::BeginTabBar("##perf_tabs")) {
 
-        if (const auto* sort_specs = ImGui::TableGetSortSpecs()) {
-            if (sort_specs->SpecsCount > 0) {
-                const auto& spec = sort_specs->Specs[0];
-                const bool ascending = spec.SortDirection == ImGuiSortDirection_Ascending;
-                std::ranges::sort(entries, [&](const auto& a, const auto& b) {
-                    uint64_t va = 0, vb = 0;
-                    switch (static_cast<SortCol>(spec.ColumnUserID)) {
-                        case Col_Name:    return ascending ? strcmp(a.name, b.name) < 0 : strcmp(a.name, b.name) > 0;
-                        case Col_UpdAvg:  va = a.stats.update.Avg(); vb = b.stats.update.Avg(); break;
-                        case Col_UpdMax:  va = a.stats.update.max_us; vb = b.stats.update.max_us; break;
-                        case Col_DrawAvg: va = a.stats.draw.Avg(); vb = b.stats.draw.Avg(); break;
-                        case Col_DrawMax: va = a.stats.draw.max_us; vb = b.stats.draw.max_us; break;
-                        default: return false;
+        // ── Tab 1: Modules (frame overview + per-module update/draw) ──────────
+        if (ImGui::BeginTabItem("Modules")) {
+
+            if (displayed_frame.count > 0) {
+                const auto& f = displayed_frame;
+                const auto& tu = displayed_tb_update;
+                const auto& td = displayed_tb_draw;
+                const auto& p = displayed_present;
+                const float fps = f.Avg() > 0 ? 1000000.f / f.Avg() : 0.f;
+
+                if (ImGui::BeginTable("##frame_timing", 3,
+                        ImGuiTableFlags_BordersInnerH | ImGuiTableFlags_SizingStretchProp)) {
+                    ImGui::TableSetupColumn("");
+                    ImGui::TableSetupColumn("avg (us)");
+                    ImGui::TableSetupColumn("max (us)");
+                    ImGui::TableHeadersRow();
+
+                    ImGui::TableNextRow();
+                    ImGui::TableNextColumn(); ImGui::Text("Frame (%.1f fps)", fps);
+                    ImGui::TableNextColumn(); ImGui::Text("%llu", f.Avg());
+                    ImGui::TableNextColumn(); ImGui::Text("%llu", f.max_us);
+
+                    if (tu.count > 0) {
+                        ImGui::TableNextRow();
+                        ImGui::TableNextColumn(); ImGui::TextUnformatted("  TB Update");
+                        ImGui::TableNextColumn(); ImGui::Text("%llu", tu.Avg());
+                        ImGui::TableNextColumn(); ImGui::Text("%llu", tu.max_us);
                     }
-                    return ascending ? va < vb : va > vb;
-                });
+                    if (td.count > 0) {
+                        ImGui::TableNextRow();
+                        ImGui::TableNextColumn(); ImGui::TextUnformatted("  TB Draw");
+                        ImGui::TableNextColumn(); ImGui::Text("%llu", td.Avg());
+                        ImGui::TableNextColumn(); ImGui::Text("%llu", td.max_us);
+                    }
+                    if (p.count > 0) {
+                        ImGui::TableNextRow();
+                        ImGui::TableNextColumn(); ImGui::TextUnformatted("  Present");
+                        ImGui::TableNextColumn(); ImGui::Text("%llu", p.Avg());
+                        ImGui::TableNextColumn(); ImGui::Text("%llu", p.max_us);
+                    }
+
+                    const uint64_t known_avg = tu.Avg() + td.Avg() + p.Avg();
+                    const uint64_t gw_avg = f.Avg() > known_avg ? f.Avg() - known_avg : 0;
+                    ImGui::TableNextRow();
+                    ImGui::TableNextColumn(); ImGui::TextUnformatted("  GW");
+                    ImGui::TableNextColumn(); ImGui::Text("~%llu", gw_avg);
+                    ImGui::TableNextColumn();
+
+                    ImGui::EndTable();
+                }
+                ImGui::Separator();
             }
+
+            enum SortColMod : int { MCN, MCUpdMin, MCUpdAvg, MCUpdMax, MCDrawMin, MCDrawAvg, MCDrawMax };
+
+            static std::vector<DisplayEntry> mod_entries;
+            mod_entries = entries;
+
+            if (ImGui::BeginTable("##module_timing", 7,
+                    ImGuiTableFlags_BordersInnerH | ImGuiTableFlags_SizingStretchProp
+                    | ImGuiTableFlags_ScrollY | ImGuiTableFlags_Sortable | ImGuiTableFlags_SortTristate,
+                    ImGui::GetContentRegionAvail())) {
+                ImGui::TableSetupColumn("Module",   ImGuiTableColumnFlags_DefaultSort, 0.f, MCN);
+                ImGui::TableSetupColumn("Upd min",  ImGuiTableColumnFlags_NoSort,      0.f, MCUpdMin);
+                ImGui::TableSetupColumn("Upd avg",  0,                                 0.f, MCUpdAvg);
+                ImGui::TableSetupColumn("Upd max",  0,                                 0.f, MCUpdMax);
+                ImGui::TableSetupColumn("Draw min", ImGuiTableColumnFlags_NoSort,      0.f, MCDrawMin);
+                ImGui::TableSetupColumn("Draw avg", 0,                                 0.f, MCDrawAvg);
+                ImGui::TableSetupColumn("Draw max", 0,                                 0.f, MCDrawMax);
+                ImGui::TableSetupScrollFreeze(0, 1);
+                ImGui::TableHeadersRow();
+
+                if (const auto* ss = ImGui::TableGetSortSpecs(); ss && ss->SpecsCount > 0) {
+                    const auto& spec = ss->Specs[0];
+                    const bool asc = spec.SortDirection == ImGuiSortDirection_Ascending;
+                    std::ranges::sort(mod_entries, [&](const auto& a, const auto& b) {
+                        uint64_t va = 0, vb = 0;
+                        switch (static_cast<SortColMod>(spec.ColumnUserID)) {
+                            case MCN:       return asc ? strcmp(a.name, b.name) < 0 : strcmp(a.name, b.name) > 0;
+                            case MCUpdAvg:  va = a.stats.update.Avg(); vb = b.stats.update.Avg(); break;
+                            case MCUpdMax:  va = a.stats.update.max_us; vb = b.stats.update.max_us; break;
+                            case MCDrawAvg: va = a.stats.draw.Avg(); vb = b.stats.draw.Avg(); break;
+                            case MCDrawMax: va = a.stats.draw.max_us; vb = b.stats.draw.max_us; break;
+                            default: return false;
+                        }
+                        return asc ? va < vb : va > vb;
+                    });
+                }
+
+                for (const auto& e : mod_entries) {
+                    const uint64_t total_avg = e.stats.update.Avg() + e.stats.draw.Avg();
+                    ImGui::TableNextRow();
+                    ImGui::TableNextColumn();
+                    if (total_avg >= static_cast<uint64_t>(slow_threshold_us))
+                        ImGui::TextColored(ImVec4(1.f, 0.3f, 0.3f, 1.f), "%s", e.name);
+                    else
+                        ImGui::TextUnformatted(e.name);
+                    DrawStatsColumns(e.stats.update);
+                    DrawStatsColumns(e.stats.draw);
+                }
+                ImGui::EndTable();
+            }
+
+            ImGui::EndTabItem();
         }
 
-        for (const auto& e : entries) {
-            const uint64_t total_avg = e.stats.update.Avg() + e.stats.draw.Avg();
-            ImGui::TableNextRow();
-            ImGui::TableNextColumn();
-            if (total_avg >= static_cast<uint64_t>(slow_threshold_us))
-                ImGui::TextColored(ImVec4(1.f, 0.3f, 0.3f, 1.f), "%s", e.name);
-            else
-                ImGui::TextUnformatted(e.name);
-            DrawStatsColumns(e.stats.update);
-            DrawStatsColumns(e.stats.draw);
+        // ── Tab 2: UI Messages (per-module UI message callback timing) ─────────
+        if (ImGui::BeginTabItem("UI Messages")) {
+            ImGui::TextUnformatted("Per-module time spent in UI message callbacks (us, over last 5s).");
+            ImGui::Separator();
+
+            enum SortColUI : int { UCIN, UCMin, UCAvg, UCMax, UCCount };
+
+            static std::vector<DisplayEntry> ui_entries;
+            ui_entries.clear();
+            for (const auto& e : entries) {
+                if (e.stats.ui_msg.count > 0)
+                    ui_entries.push_back(e);
+            }
+
+            if (ui_entries.empty()) {
+                ImGui::TextDisabled("No UI message callback data yet. Data appears once messages fire.");
+            }
+            else {
+                if (ImGui::BeginTable("##ui_msg_timing", 5,
+                        ImGuiTableFlags_BordersInnerH | ImGuiTableFlags_SizingStretchProp
+                        | ImGuiTableFlags_ScrollY | ImGuiTableFlags_Sortable | ImGuiTableFlags_SortTristate,
+                        ImGui::GetContentRegionAvail())) {
+                    ImGui::TableSetupColumn("Module",  ImGuiTableColumnFlags_DefaultSort, 0.f, UCIN);
+                    ImGui::TableSetupColumn("min",     ImGuiTableColumnFlags_NoSort,      0.f, UCMin);
+                    ImGui::TableSetupColumn("avg",     0,                                 0.f, UCAvg);
+                    ImGui::TableSetupColumn("max",     0,                                 0.f, UCMax);
+                    ImGui::TableSetupColumn("calls",   0,                                 0.f, UCCount);
+                    ImGui::TableSetupScrollFreeze(0, 1);
+                    ImGui::TableHeadersRow();
+
+                    if (const auto* ss = ImGui::TableGetSortSpecs(); ss && ss->SpecsCount > 0) {
+                        const auto& spec = ss->Specs[0];
+                        const bool asc = spec.SortDirection == ImGuiSortDirection_Ascending;
+                        std::ranges::sort(ui_entries, [&](const auto& a, const auto& b) {
+                            uint64_t va = 0, vb = 0;
+                            switch (static_cast<SortColUI>(spec.ColumnUserID)) {
+                                case UCIN:    return asc ? strcmp(a.name, b.name) < 0 : strcmp(a.name, b.name) > 0;
+                                case UCAvg:   va = a.stats.ui_msg.Avg(); vb = b.stats.ui_msg.Avg(); break;
+                                case UCMax:   va = a.stats.ui_msg.max_us; vb = b.stats.ui_msg.max_us; break;
+                                case UCCount: va = a.stats.ui_msg.count; vb = b.stats.ui_msg.count; break;
+                                default: return false;
+                            }
+                            return asc ? va < vb : va > vb;
+                        });
+                    }
+
+                    for (const auto& e : ui_entries) {
+                        ImGui::TableNextRow();
+                        ImGui::TableNextColumn();
+                        if (e.stats.ui_msg.Avg() >= static_cast<uint64_t>(slow_threshold_us))
+                            ImGui::TextColored(ImVec4(1.f, 0.3f, 0.3f, 1.f), "%s", e.name);
+                        else
+                            ImGui::TextUnformatted(e.name);
+                        DrawStatsColumns(e.stats.ui_msg);
+                        ImGui::TableNextColumn();
+                        ImGui::Text("%u", e.stats.ui_msg.count);
+                    }
+                    ImGui::EndTable();
+                }
+            }
+
+            ImGui::EndTabItem();
         }
-        ImGui::EndTable();
+
+        ImGui::EndTabBar();
     }
 
     ImGui::End();

--- a/GWToolboxdll/Windows/TargetInfoWindow.cpp
+++ b/GWToolboxdll/Windows/TargetInfoWindow.cpp
@@ -335,7 +335,7 @@ void TargetInfoWindow::Initialize()
         GW::UI::UIMessage::kMapChange
     };
     for (const auto message_id : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&ui_message_entry, message_id, OnUIMessage, 0x100);
+        RegisterUIMessageCallback(&ui_message_entry, message_id, OnUIMessage, 0x100);
     }
 }
 

--- a/GWToolboxdll/Windows/TradeWindow.cpp
+++ b/GWToolboxdll/Windows/TradeWindow.cpp
@@ -288,7 +288,7 @@ void TradeWindow::Initialize()
         GW::UI::UIMessage::kPlayerChatMessage
     };
     for (const auto ui_message : ui_messages) {
-        GW::UI::RegisterUIMessageCallback(&OnUIMessage_Entry, ui_message, OnUIMessage);
+        RegisterUIMessageCallback(&OnUIMessage_Entry, ui_message, OnUIMessage);
     }
 
 }


### PR DESCRIPTION
Implements # 2167.

Adds per-module UI message callback timing to the Performance window:

- `ToolboxModule::RegisterUIMessageCallback()` wraps each callback with QPC timing
- 44 call sites across 35 files updated to use the instrumented wrapper
- Performance window gains tabbed layout: "Modules" (existing) + "UI Messages" (new)
- UI Messages tab shows min/avg/max per-invocation timing and call count over 5s rolling window

Generated with [Claude Code](https://claude.ai/code)