### PR TITLE
fix: reset settings_folder_changed in LoadSettings to prevent use-after-free

### DIFF
--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -826,6 +826,9 @@ void GWToolbox::Initialize(LPVOID module)
 std::filesystem::path GWToolbox::LoadSettings()
 {
     const auto ini = OpenSettingsFile();
+    // Reset the flag so nested OpenSettingsFile() calls (via ToggleTBModule) don't
+    // free and reallocate the ini we just loaded, causing a use-after-free.
+    settings_folder_changed = false;
     ToolboxSettings::Instance().LoadSettings(ini);
     ToolboxSettings::LoadModules(ini);
     if (!ini->location_on_disk.empty()) {


### PR DESCRIPTION
Fixes the use-after-free in `OpenSettingsFile()` reentry during the first `/tb load <name>` after launch.

When `LoadSettings()` called `OpenSettingsFile()` and then `LoadModules()` triggered `ToggleTBModule` -> `OpenSettingsFile()` again while `settings_folder_changed` was still true, the second call would delete and reallocate the inifile, leaving the outer `LoadSettings` holding a dangling pointer.

Reset the flag immediately after the initial `OpenSettingsFile()` call so nested calls reuse the already-loaded file.

Closes #2174

Generated with [Claude Code](https://claude.ai/code)