### PR TITLE
docs: expand trade/inventory settings documentation

### DIFF
--- a/docs/items.md
+++ b/docs/items.md
@@ -16,7 +16,8 @@ The Inventory Manager module offers the following functionality:
 - **Auto-Salvage**: Automatically salvage all salvageable items of a specific rarity.
 - **Bulk Item Movement**: Easily move all items of a certain type (e.g., all materials, all tomes) between inventory and storage.
 - **Stack Splitting**: Quickly split stacks of items when moving them.
-- **Trade Improvements**: Automatically offer full stacks of items when trading.
+- **Move Whole Stacks by Default**: Automatically accept the maximum quantity when offering a stackable item in a trade window, skipping the quantity prompt. Hold Shift while dragging to prompt for a specific amount instead. Found under Settings → Inventory Settings.
+- **Move Items to Trade**: With a trade window open, double-clicking or Alt+Clicking an inventory item moves it into your trade offer automatically. Configurable under Settings → Inventory Settings.
 
 ## Item Filter
 

--- a/site/src/content/docs/items.mdx
+++ b/site/src/content/docs/items.mdx
@@ -24,7 +24,10 @@ The Inventory Manager module offers the following functionality:
 - **Pick which bags to salvage from**: tick only the bags you want the bulk operations to consider.
   <ToolboxPath steps={['Settings', 'Inventory Settings', 'Salvage from: Backpack / Belt Pouch / Bag 1 / Bag 2']} />
 - **Right-click context menu**: extra options on items in inventory or storage (move stack, identify, salvage, send to merchant).
-- **Trade improvements**: when offering an item in a trade window, Toolbox can automatically offer the full stack instead of one unit.
+- **Move whole stacks by default**: when offering a stackable item in a trade window, Toolbox automatically accepts the maximum quantity — bypassing the per-item quantity prompt entirely. Hold **Shift** while dragging to bring up the quantity prompt instead.
+  <ToolboxPath steps={['Settings', 'Inventory Settings', 'Move whole stacks by default']} />
+- **Move items to trade**: with a trade window open, you can move an item from your inventory directly into the trade offer by **Double Click** or **Alt+Click** — no dragging required. Enable one (or neither) under:
+  <ToolboxPath steps={['Settings', 'Inventory Settings', 'Move items to trade on']} />
 
 ## Item Filter
 


### PR DESCRIPTION
Add detail to the Item Management docs explaining the "Move whole stacks by default" setting (bypasses trade quantity prompt; hold Shift to still see it) and the "Move items to trade on: Double Click / Alt+Click" shortcuts.

Addresses #2170.

Generated with [Claude Code](https://claude.ai/code)