### PR TITLE
docs: add Audio Settings module documentation

### DIFF
--- a/site/src/content/docs/audio_settings.mdx
+++ b/site/src/content/docs/audio_settings.mdx
@@ -1,0 +1,42 @@
+---
+title: "Audio Settings"
+section: features
+---
+
+import ToolboxPath from '../../components/ToolboxPath.astro';
+
+All settings for this feature live under <ToolboxPath steps={["Settings", "Audio Settings"]} />.
+
+The Audio Settings module lets you block specific in-game sound effects. This is useful for silencing repetitive or distracting sounds — for example, the error chime that plays when a chest is already being opened, when a hero can't cast on a given target, or when Panic prevents you from casting.
+
+## Blocking a Sound
+
+1. Open <ToolboxPath steps={["Settings", "Audio Settings"]} /> and expand **In-Game Sound Log**.
+2. Trigger the sound in-game (e.g. try to cast on an invalid target).
+3. The filename of the sound will appear in the log.
+4. Click **Block** next to it. The sound is now silenced and saved for future sessions.
+
+You can click **Play** on any logged entry to preview it before deciding whether to block it.
+
+## Blocked In-Game Sounds
+
+Expand this section to see everything you've already blocked. Each entry has:
+
+- **Play** — previews the sound effect.
+- **Unblock** — removes the block and restores the sound.
+
+## In-Game Sound Log
+
+Opening this section activates sound logging. Every sound effect triggered while the log is open is recorded here. Closing the section clears the log.
+
+- **Clear Logged Sounds** — empties the log without closing it.
+
+## In-Game Music Log
+
+Works the same as the Sound Log but captures background music tracks rather than sound effects.
+
+- **Clear Logged Music** — empties the music log.
+
+## Storage
+
+Blocked sounds are saved in <ToolboxPath steps={["Settings", "Open settings folder"]} /> inside `GWToolbox.ini` under the `[Audio Settings]` section.

--- a/site/src/lib/nav.ts
+++ b/site/src/lib/nav.ts
@@ -63,6 +63,7 @@ export const navGroups: NavGroup[] = [
       { slug: 'chatfilter', label: 'Chat Filter' },
       { slug: 'chatlog', label: 'Chat Log' },
       { slug: 'commands', label: 'Commands' },
+      { slug: 'audio_settings', label: 'Audio Settings' },
       { slug: 'text-to-speech', label: 'Text-to-Speech' },
       { slug: 'theme', label: 'Theme' },
       { slug: 'reroll', label: 'Reroll' },


### PR DESCRIPTION
Adds documentation for the Audio Settings module, covering how to log and block specific in-game sounds and music tracks.

Closes #2180

Generated with [Claude Code](https://claude.ai/code)