### PR TITLE
feat: Show Melandru's Accord icon in Reroll list

### DIFF
--- a/GWToolboxdll/Utils/ToolboxUtils.h
+++ b/GWToolboxdll/Utils/ToolboxUtils.h
@@ -126,6 +126,13 @@ namespace GW {
         {
             return ((props[7] >> 9) & 0x1) == 0x1;
         }
+
+        // Returns true if character is on the Melandru's Accord server.
+        // Mirrors the reforged_or_dhuums_flags & 0x2 check used for in-game players.
+        bool is_melandrus_accord() const
+        {
+            return (props[0] & 0x2) != 0;
+        }
     };
     static_assert(sizeof(AvailableCharacterInfo) == 0x84);
 

--- a/GWToolboxdll/Windows/RerollWindow.cpp
+++ b/GWToolboxdll/Windows/RerollWindow.cpp
@@ -23,6 +23,7 @@
 #include <GWCA/Managers/ItemMgr.h>
 #include <GWCA/Managers/AgentMgr.h>
 
+#include <Modules/GwDatTextureModule.h>
 #include <Modules/Resources.h>
 #include <Windows/RerollWindow.h>
 #include <Timer.h>
@@ -37,6 +38,9 @@
 namespace {
 
     GW::HookEntry ChatCmd_HookEntry;
+
+    // GW file 0x5e700: 256x64 sprite sheet with 4x64px icons: none, reforged, dhuum's covenant, melandru's accord
+    IDirect3DTexture9** covenant_sprite = nullptr;
 
     bool travel_to_same_location_after_rerolling = true;
     bool rejoin_party_after_rerolling = true;
@@ -597,6 +601,17 @@ void RerollWindow::Draw(IDirect3DDevice9*)
                 ImGui::PopItemFlag();
                 ImGui::PopStyleColor();
             }
+            if (covenant_sprite && *covenant_sprite && character.is_melandrus_accord()) {
+                const ImVec2 item_min = ImGui::GetItemRectMin();
+                const ImVec2 item_max = ImGui::GetItemRectMax();
+                const float icon_h = ImGui::GetTextLineHeight();
+                const float icon_y = item_min.y + (item_max.y - item_min.y - icon_h) * 0.5f;
+                ImGui::GetWindowDrawList()->AddImage(
+                    reinterpret_cast<ImTextureID>(*covenant_sprite),
+                    {item_max.x - icon_h, icon_y}, {item_max.x, icon_y + icon_h},
+                    {0.75f, 0.f}, {1.f, 1.f}
+                );
+            }
         }
         ImGui::PopStyleVar();
     }
@@ -616,6 +631,8 @@ void RerollWindow::Initialize()
     ToolboxWindow::Initialize();
 
     reroll_stage = RerollStage::None;
+
+    covenant_sprite = GwDatTextureModule::LoadTextureFromFileId(0x5e700);
 
     // Add an entry to check available characters at login screen
     RegisterUIMessageCallback(&OnGoToCharSelect_Entry, GW::UI::UIMessage::kCheckUIState, OnUIMessage, 0x4000);


### PR DESCRIPTION
Loads GW sprite sheet `@0x5e700` and overlays the Melandru's Accord icon on the right edge of each character button in the Reroll window when the character's covenant flag is set.

Adds `is_melandrus_accord()` to `AvailableCharacterInfo`, mirroring the `reforged_or_dhuums_flags & 0x2` check used for in-game players.

Closes #2171

Generated with [Claude Code](https://claude.ai/code)