### PR TITLE
fix: promote group children to parent scope when group is deleted

### DIFF
--- a/GWToolboxdll/Windows/Hotkeys/HotkeyGroup.cpp
+++ b/GWToolboxdll/Windows/Hotkeys/HotkeyGroup.cpp
@@ -48,9 +48,17 @@ HotkeyGroup::HotkeyGroup(const char* _label) : TBHotkey(0, 0)
 
 HotkeyGroup::~HotkeyGroup()
 {
-    // Unlink this group from children
+    // Promote children to this group's parent scope before unlinking.
+    // Without this, deleted groups leave children in all_hotkeys but not in
+    // top_level_hotkeys or any group's hotkeys list, causing SortHotkeys() to assert.
     for (TBHotkey* hk : hotkeys) {
-        if (hk->group == this) hk->group = nullptr;
+        if (hk->group != this) continue;
+        hk->group = group;
+        if (group) {
+            group->hotkeys.push_back(hk);
+        } else {
+            top_level_hotkeys.push_back(hk);
+        }
     }
     auto found = hotkey_groups.find(label);
     if (found != hotkey_groups.end() && found->second == this) hotkey_groups.erase(label);


### PR DESCRIPTION
Fixes a crash when creating a new hotkey after a hotkey group was previously deleted.

When a HotkeyGroup was deleted, its children had their group pointer set to null but were never added back to top_level_hotkeys or a grandparent group's hotkeys list. This left them orphaned: present in all_hotkeys but not reachable from the tree rooted at top_level_hotkeys.

The next call to SortHotkeys() (e.g. when adding a new hotkey) would rebuild all_hotkeys via flatten(top_level_hotkeys), producing a smaller count than size_before and firing the ASSERT on TBHotkey.cpp line 845.

The fix promotes each child to the deleted group's parent scope (or top_level_hotkeys if the group was top-level) in the HotkeyGroup destructor.

Closes #2190

Generated with [Claude Code](https://claude.ai/code)