### PR TITLE
fix: hotkey group trigger propagation and Map ID shared-state bugs

### DIFF
--- a/GWToolboxdll/Windows/Hotkeys/TBHotkey.cpp
+++ b/GWToolboxdll/Windows/Hotkeys/TBHotkey.cpp
@@ -620,16 +620,15 @@ bool TBHotkey::DrawSettings()
             ImGui::PopID();
         }
 
-        static char map_id_input_buf[4];
-        bool add_map_id = ImGui::InputTextWithHint("###add_map_id", "Add Map ID", map_id_input_buf, _countof(map_id_input_buf), ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_EnterReturnsTrue);
+        char map_id_input_buf[4] = {};
+        bool add_map_id = ImGui::InputTextWithHint("##add_map_id", "Add Map ID", map_id_input_buf, _countof(map_id_input_buf), ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_EnterReturnsTrue);
         if (add_map_id) {
             uint32_t map_id_out;
             if (*map_id_input_buf && TextUtils::ParseUInt(map_id_input_buf, &map_id_out)) {
-                if (!std::ranges::contains(map_ids, reinterpret_cast<uint32_t>(map_id_input_buf))) {
+                if (!std::ranges::contains(map_ids, map_id_out)) {
                     map_ids.push_back(map_id_out);
                     hotkey_changed = true;
                 }
-                memset(map_id_input_buf, 0, sizeof(map_id_input_buf));
             }
         }
         ImGui::Unindent();
@@ -667,15 +666,14 @@ bool TBHotkey::DrawSettings()
             }
             ImGui::PopID();
         }
-        static char player_name_input_buf[20];
-        bool add_player_name = ImGui::InputTextWithHint("###player_name_input_buf", "Add Player Name", player_name_input_buf, _countof(player_name_input_buf), ImGuiInputTextFlags_EnterReturnsTrue);
+        char player_name_input_buf[20] = {};
+        bool add_player_name = ImGui::InputTextWithHint("##player_name_input_buf", "Add Player Name", player_name_input_buf, _countof(player_name_input_buf), ImGuiInputTextFlags_EnterReturnsTrue);
         if (add_player_name && *player_name_input_buf) {
             const auto sanitised = TextUtils::UcWords(player_name_input_buf);
             if (!std::ranges::contains(player_names, sanitised)) {
                 player_names.push_back(sanitised);
                 hotkey_changed = true;
             }
-            memset(player_name_input_buf, 0, sizeof(player_name_input_buf));
         }
         ImGui::Unindent();
     }

--- a/GWToolboxdll/Windows/HotkeysWindow.cpp
+++ b/GWToolboxdll/Windows/HotkeysWindow.cpp
@@ -207,11 +207,18 @@ namespace {
             return false;
         }
         bool is_in_controller_mode = GW::UI::IsInControllerMode();
+        // Check if the hotkey or any ancestor group has the trigger flag set.
+        auto inherited_trigger = [&mt](const TBHotkey* hk) -> bool {
+            for (const TBHotkey* cur = hk; cur; cur = cur->group) {
+                if (cur->trigger_on_explorable && mt == GW::Constants::InstanceType::Explorable) return true;
+                if (cur->trigger_on_outpost && mt == GW::Constants::InstanceType::Outpost) return true;
+            }
+            return false;
+        };
         // NB: CheckSetValidHotkeys() has already checked validity of char/map etc
         for (TBHotkey* hk : valid_hotkeys) {
-            if (((hk->trigger_on_explorable && mt == GW::Constants::InstanceType::Explorable)
-                    || (hk->trigger_on_outpost && mt == GW::Constants::InstanceType::Outpost))
-                && !hk->pressed 
+            if (inherited_trigger(hk)
+                && !hk->pressed
                 &&
                 ((is_in_controller_mode && hk->trigger_in_controller_mode) || (!is_in_controller_mode && hk->trigger_in_desktop_mode))) {
                 hk->pressed = true;


### PR DESCRIPTION
Fixes two bugs reported in #2192:

- Group "Trigger hotkey when entering explorable area" setting now propagates to all child hotkeys by walking the group hierarchy in OnMapChanged()
- Adding a Map ID to one hotkey no longer affects all hotkeys (fixed ImGui triple-### ID bug and broken duplicate check using pointer address instead of value)
- Same ID fix applied to Character Names input

Closes #2192

Generated with [Claude Code](https://claude.ai/code)