### PR TITLE
Fix hotkey groups triggered twice

### DIFF
--- a/GWToolboxdll/Windows/HotkeysWindow.cpp
+++ b/GWToolboxdll/Windows/HotkeysWindow.cpp
@@ -184,7 +184,7 @@ namespace {
         const auto primary = static_cast<GW::Constants::Profession>(me->primary);
         const bool is_pvp = me->IsPvP();
         valid_hotkeys.clear();
-        for (auto* hotkey : TBHotkey::all_hotkeys) {
+        for (auto* hotkey : TBHotkey::top_level_hotkeys) {
             AddHotkeyIfValid(hotkey, player_name.c_str(), instance_type, primary, map_id, is_pvp, valid_hotkeys);
         }
 


### PR DESCRIPTION
Child hotkeys inside groups were being added to `valid_hotkeys` twice because `CheckSetValidHotkeys` iterated `all_hotkeys` (which includes both groups and their children) while `AddHotkeyIfValid` also recursed into group children. This caused double-firing on map change and window focus triggers.

Fix: iterate `top_level_hotkeys` instead, so recursion is the only path that adds children.

Fixes #2193

Generated with [Claude Code](https://claude.ai/code)