### PR TITLE
fix: save and restore breakout button positions in Toolbox INI

### DIFF
--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -909,6 +909,12 @@ std::filesystem::path GWToolbox::SaveSettings()
     }
     ToolboxSettings::LoadModules(ini);
     ASSERT(Resources::SaveIniToFile(ini->location_on_disk, ini) == 0);
+    if (ImGui::GetCurrentContext()) {
+        auto& io = ImGui::GetIO();
+        if (io.IniFilename) {
+            ImGui::SaveIniSettingsToDisk(io.IniFilename);
+        }
+    }
     const auto dir = ini->location_on_disk.parent_path();
     const auto dirstr = dir.wstring();
     const auto printable = TextUtils::str_replace_all(dirstr, LR"(\\)", L"/");

--- a/GWToolboxdll/ToolboxUIElement.cpp
+++ b/GWToolboxdll/ToolboxUIElement.cpp
@@ -149,6 +149,10 @@ void ToolboxUIElement::LoadSettings(ToolboxIni* ini)
     LOAD_BOOL(show_closebutton);
     LOAD_BOOL(show_breakout_button);
     LOAD_BOOL(lock_breakout_button);
+    if (ini->KeyExists(Name(), "breakout_pos[0]")) {
+        LOAD_FLOAT(breakout_pos[0]); LOAD_FLOAT(breakout_pos[1]);
+        pending_breakout_pos = true;
+    }
     LOAD_STRING(snapped_frame_label);
     LOAD_FLOAT(snap_offset[0]); LOAD_FLOAT(snap_offset[1]);
     if (!snapped_frame_label.empty() && !ini->KeyExists(Name(), "snap_offset[0]")) {
@@ -192,6 +196,14 @@ void ToolboxUIElement::SaveSettings(ToolboxIni* ini)
             }
         }
     }
+    if (ImGui::GetCurrentContext() && show_breakout_button) {
+        char breakout_window_id[256];
+        snprintf(breakout_window_id, sizeof(breakout_window_id), "%s##breakout_btn", Name());
+        if (const auto bw = ImGui::FindWindowByName(breakout_window_id)) {
+            breakout_pos[0] = bw->Pos.x;
+            breakout_pos[1] = bw->Pos.y;
+        }
+    }
     ToolboxModule::SaveSettings(ini);
     SAVE_BOOL(visible);
     SAVE_BOOL(show_menubutton);
@@ -205,6 +217,7 @@ void ToolboxUIElement::SaveSettings(ToolboxIni* ini)
     SAVE_BOOL(show_closebutton);
     SAVE_BOOL(show_breakout_button);
     SAVE_BOOL(lock_breakout_button);
+    SAVE_FLOAT(breakout_pos[0]); SAVE_FLOAT(breakout_pos[1]);
     SAVE_STRING(snapped_frame_label);
     SAVE_FLOAT(snap_offset[0]); SAVE_FLOAT(snap_offset[1]);
     SAVE_BOOL(mobile_lock_move);
@@ -599,6 +612,11 @@ void ToolboxUIElement::DrawBreakoutButton(IDirect3DDevice9*)
 
     if (!ToolboxSettings::move_all && lock_breakout_button) {
         flags |= ImGuiWindowFlags_NoMove;
+    }
+
+    if (pending_breakout_pos) {
+        ImGui::SetNextWindowPos({breakout_pos[0], breakout_pos[1]}, ImGuiCond_Always);
+        pending_breakout_pos = false;
     }
 
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {6.f, 6.f});

--- a/GWToolboxdll/ToolboxUIElement.h
+++ b/GWToolboxdll/ToolboxUIElement.h
@@ -52,6 +52,8 @@ public:
     bool auto_size = false;
     bool show_breakout_button = false;
     bool lock_breakout_button = false;
+    float breakout_pos[2] = {60.f, 60.f};
+    bool pending_breakout_pos = false;
 
     // Mobile-mode layout settings (separate from normal-mode settings above)
     bool mobile_lock_move = false;


### PR DESCRIPTION
Fixes #2203

Breakout button positions were only stored in ImGui's `interface.ini`, not in the Toolbox INI, causing them to not save/load correctly.

## Changes
- `SaveSettings()` now captures each breakout button's current position and saves to Toolbox INI
- `LoadSettings()` reads the saved position and queues it for application
- `DrawBreakoutButton()` applies queued positions via `SetNextWindowPos`
- `SaveSettings()` also force-saves `interface.ini` immediately

Generated with [Claude Code](https://claude.ai/code)