### PR TITLE
HotkeysWindow: shift+click group checkbox to bulk enable/disable children

### DIFF
--- a/GWToolboxdll/Windows/Hotkeys/TBHotkey.cpp
+++ b/GWToolboxdll/Windows/Hotkeys/TBHotkey.cpp
@@ -382,9 +382,25 @@ bool TBHotkey::Draw()
         if (show_active_in_header) {
             current_pos.x -= btn_size;
             ImGui::SetCursorPos(current_pos);
-            hotkey_changed |= ImGui::Checkbox("##active", &active);
+            const bool checkbox_changed = ImGui::Checkbox("##active", &active);
+            hotkey_changed |= checkbox_changed;
             if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip("The hotkey can trigger only when selected");
+                if (dynamic_cast<HotkeyGroup*>(this))
+                    ImGui::SetTooltip("The hotkey can trigger only when selected\nShift+Click to enable/disable all hotkeys in this group");
+                else
+                    ImGui::SetTooltip("The hotkey can trigger only when selected");
+            }
+            if (checkbox_changed && ImGui::GetIO().KeyShift) {
+                if (auto* grp = dynamic_cast<HotkeyGroup*>(this)) {
+                    auto set_active = [](auto& self, HotkeyGroup* g, bool val) -> void {
+                        for (auto* hk : g->hotkeys) {
+                            hk->active = val;
+                            if (auto* child = dynamic_cast<HotkeyGroup*>(hk))
+                                self(self, child, val);
+                        }
+                    };
+                    set_active(set_active, grp, active);
+                }
             }
             current_pos.x -= spacing;
         }
@@ -680,9 +696,25 @@ bool TBHotkey::DrawSettings()
 
     ImGui::Separator();
     if (!show_active_in_header) {
-        hotkey_changed |= ImGui::Checkbox("###active", &active);
+        const bool checkbox_changed = ImGui::Checkbox("###active", &active);
+        hotkey_changed |= checkbox_changed;
         if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip("The hotkey can trigger only when selected");
+            if (dynamic_cast<HotkeyGroup*>(this))
+                ImGui::SetTooltip("The hotkey can trigger only when selected\nShift+Click to enable/disable all hotkeys in this group");
+            else
+                ImGui::SetTooltip("The hotkey can trigger only when selected");
+        }
+        if (checkbox_changed && ImGui::GetIO().KeyShift) {
+            if (auto* grp = dynamic_cast<HotkeyGroup*>(this)) {
+                auto set_active = [](auto& self, HotkeyGroup* g, bool val) -> void {
+                    for (auto* hk : g->hotkeys) {
+                        hk->active = val;
+                        if (auto* child = dynamic_cast<HotkeyGroup*>(hk))
+                            self(self, child, val);
+                    }
+                };
+                set_active(set_active, grp, active);
+            }
         }
         ImGui::SameLine();
     }


### PR DESCRIPTION
Shift-clicking the active checkbox on a hotkey group now recursively enables or disables all hotkeys within the group (including nested groups). A tooltip is shown on group checkboxes to advertise the shift+click behaviour.

Closes #2213

Generated with [Claude Code](https://claude.ai/code)