### PR TITLE
fix: resolve ImGui ID collisions in salvage popup

### DIFF
--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -1342,8 +1342,9 @@ namespace {
             ImGui::BeginChild("block_from_being_salvaged", ImVec2(0.0F, list_height));
 
             const float wrap_width2 = ImGui::GetContentRegionAvail().x;
+            int salvage_block_idx = 0;
             for (const auto& it : block_from_being_salvaged) {
-                ImGui::PushID(it.second.c_str());
+                ImGui::PushID(salvage_block_idx++);
 
                 const auto button_label = std::format("{} | X", it.second);
 
@@ -2242,7 +2243,7 @@ void InventoryManager::Draw(IDirect3DDevice9*)
                     potential_salvage_all_items[i]->proceed = check_all_items;
                 }
             }
-            for (size_t i = 0; i < potential_salvage_all_items.size(); i++) {
+            for (int i = 0; i < static_cast<int>(potential_salvage_all_items.size()); i++) {
                 PotentialItem* pi = potential_salvage_all_items[i];
                 if (!pi) {
                     continue;
@@ -2272,7 +2273,7 @@ void InventoryManager::Draw(IDirect3DDevice9*)
                         ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_Text));
                         break;
                 }
-                ImGui::PushID(static_cast<int>(pi->item_id));
+                ImGui::PushID(i);
                 ImGui::Checkbox(pi->name->string().c_str(), &pi->proceed);
                 const float item_name_length = ImGui::CalcTextSize(pi->name->string().c_str(), nullptr, true).x;
                 longest_item_name_length = item_name_length > longest_item_name_length ? item_name_length : longest_item_name_length;


### PR DESCRIPTION
Fix ImGui ID collision errors in the Salvage All popup and the salvage ignore list settings.

**Changes:**
- In "Salvage All?" popup: use `int i` loop variable directly for `PushID` (no cast needed)
- In "block_from_being_salvaged" settings list: use sequential counter instead of display name string

Closes #2225

Generated with [Claude Code](https://claude.ai/code)) • [View job run](https://github.com/gwdevhub/GWToolboxpp/actions/runs/27180587769