### PR TITLE
CompletionWindow: add 'hide unlocked skills' checkbox (account-wide) and rename 'learned' to 'learnt'

### DIFF
--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -262,6 +262,7 @@ namespace {
 
     bool hide_unlocked_achievements = false;
     bool hide_unlocked_skills = false;
+    bool hide_account_unlocked_skills = false;
     bool hide_completed_vanquishes = false;
     bool hide_completed_missions = false;
     bool hide_collected_hats = false;
@@ -1219,6 +1220,7 @@ bool PvESkill::Draw(IDirect3DDevice9* device)
 void PvESkill::CheckProgress(const std::wstring& player_name)
 {
     is_completed = false;
+    is_account_unlocked = GW::SkillbarMgr::GetIsSkillUnlocked(skill_id);
     const auto& skills = character_completion;
     if (!skills.contains(player_name)) {
         return;
@@ -2386,7 +2388,9 @@ void CompletionWindow::Draw(IDirect3DDevice9* device)
         }
         ImGui::SameLine(checkbox_offset);
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, {0, 0});
-        ImGui::Checkbox("Hide learned skills", &hide_unlocked_skills);
+        ImGui::Checkbox("Hide learnt skills", &hide_unlocked_skills);
+        ImGui::SameLine();
+        ImGui::Checkbox("Hide unlocked skills", &hide_account_unlocked_skills);
         ImGui::PopStyleVar();
         ImGui::PopID();
     };
@@ -2402,9 +2406,12 @@ void CompletionWindow::Draw(IDirect3DDevice9* device)
                     continue;
                 }
             }
+            if (hide_account_unlocked_skills && camp_missions[i]->is_account_unlocked) {
+                continue;
+            }
             filtered.push_back(camp_missions[i]);
         }
-        if (hide_unlocked_skills && filtered.empty()) {
+        if ((hide_unlocked_skills || hide_account_unlocked_skills) && filtered.empty()) {
             continue;
         }
         char label[128];
@@ -2425,9 +2432,12 @@ void CompletionWindow::Draw(IDirect3DDevice9* device)
                     continue;
                 }
             }
+            if (hide_account_unlocked_skills && camp_missions[i]->is_account_unlocked) {
+                continue;
+            }
             filtered.push_back(camp_missions[i]);
         }
-        if (hide_unlocked_skills && filtered.empty()) {
+        if ((hide_unlocked_skills || hide_account_unlocked_skills) && filtered.empty()) {
             continue;
         }
         char label[128];
@@ -2830,6 +2840,7 @@ void CompletionWindow::LoadSettings(ToolboxIni* ini)
 
     LOAD_BOOL(show_as_list);
     LOAD_BOOL(hide_unlocked_skills);
+    LOAD_BOOL(hide_account_unlocked_skills);
     LOAD_BOOL(hide_completed_vanquishes);
     LOAD_BOOL(hide_completed_missions);
     LOAD_BOOL(hide_unlocked_achievements);
@@ -2961,6 +2972,7 @@ void CompletionWindow::SaveSettings(ToolboxIni* ini)
 
     SAVE_BOOL(show_as_list);
     SAVE_BOOL(hide_unlocked_skills);
+    SAVE_BOOL(hide_account_unlocked_skills);
     SAVE_BOOL(hide_completed_vanquishes);
     SAVE_BOOL(hide_completed_missions);
     SAVE_BOOL(hide_unlocked_achievements);

--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -2374,19 +2374,20 @@ void CompletionWindow::Draw(IDirect3DDevice9* device)
         }
     }
 
-    auto skills_title = [&, checkbox_offset](const char* title) {
+    auto skills_title = [&](const char* title) {
         ImGui::PushID(title);
         ImGui::Text(title);
         ImGui::ShowHelp("Guild Wars only shows skills learned for the current primary/secondary profession.\n\n"
             "GWToolbox remembers skills learned for other professions,\nbut is only able to update this info when you switch to that profession.");
-        ImGui::SameLine(checkbox_offset - 100.f);
+        const float skills_checkbox_offset = ImGui::GetContentRegionAvail().x - 280.f * ImGui::FontScale();
+        ImGui::SameLine(skills_checkbox_offset - 100.f * ImGui::FontScale());
         if (ImGui::Button("Check Now")) {
             GW::GameThread::Enqueue(CheckAllSkills);
         }
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Will cycle through your available secondary professions to detect all unlocked skills");
         }
-        ImGui::SameLine(checkbox_offset);
+        ImGui::SameLine(skills_checkbox_offset);
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, {0, 0});
         ImGui::Checkbox("Hide learnt skills", &hide_unlocked_skills);
         ImGui::SameLine();

--- a/GWToolboxdll/Windows/CompletionWindow.h
+++ b/GWToolboxdll/Windows/CompletionWindow.h
@@ -65,6 +65,7 @@ namespace Missions {
 
     public:
         GW::Constants::ProfessionByte profession = (GW::Constants::ProfessionByte)0;
+        bool is_account_unlocked = false;
         PvESkill(GW::Constants::SkillID _skill_id);
         bool IsDaily() override { return false; }
         bool HasQuest() override { return false; }


### PR DESCRIPTION
Adds a new "Hide unlocked skills" checkbox alongside "Hide learnt skills" in the skill completion tracker.

The new checkbox hides skills already unlocked account-wide via `GW::SkillbarMgr::GetIsSkillUnlocked`, which reflects whether any hero on the account can use the skill — distinct from the per-character "learnt" status tracked in completion.ini.

Fixes #1408

Generated with [Claude Code](https://claude.ai/code)