### PR TITLE
fix: enforce 100ms minimum between quote requests in MaterialsWindow

### DIFF
--- a/GWToolboxdll/Windows/MaterialsWindow.cpp
+++ b/GWToolboxdll/Windows/MaterialsWindow.cpp
@@ -52,6 +52,7 @@ namespace {
 
 
     clock_t last_transaction = 0;
+    clock_t last_dequeue_time = 0;
 
     const std::unordered_map<GW::Constants::MaterialSlot, const wchar_t*> material_enc_strings = {
         {GW::Constants::MaterialSlot::BoltofCloth, GW::EncStrings::BoltofCloth},
@@ -166,6 +167,7 @@ namespace {
     {
         trans_done++;
         transactions.pop_front();
+        last_dequeue_time = TIMER_INIT();
     }
 
     void Enqueue(Transaction::Type type, GW::Constants::MaterialSlot mat)
@@ -334,6 +336,8 @@ void MaterialsWindow::Update(const float)
     }
     switch (trans->state) {
     case Transaction::State::Idle: {
+        if (TIMER_DIFF(last_dequeue_time) < 100)
+            return;
         const auto item_id = trans->type == Transaction::Sell ? RequestSellQuote(trans->material) : RequestPurchaseQuote(trans->material);
         if (!item_id) {
             Cancel("Failed to quote for item");


### PR DESCRIPTION
Fixes #2131

Enforces a 100ms minimum delay between quote requests to prevent the server flood/throttle triggered at low ping (<30ms). Caps throughput at 10 trades/second by waiting in `State::Idle` until 100ms has passed since the last dequeue.

Generated with [Claude Code](https://claude.ai/code)