### PR TITLE
docs: document launcher command-line arguments

### DIFF
--- a/site/src/content/docs/launch_options.md
+++ b/site/src/content/docs/launch_options.md
@@ -1,0 +1,51 @@
+---
+title: "Launcher Command-Line Arguments"
+section: meta
+description: "Command-line arguments accepted by GWToolbox.exe, the launcher that injects Toolbox into Guild Wars."
+---
+
+`GWToolbox.exe` is the small launcher that installs, updates, and injects the Toolbox DLL into a running copy of Guild Wars. It accepts a handful of command-line arguments, which are useful when scripting startup, running from a third-party launcher, or working with a local build.
+
+You can pass these by editing your shortcut's **Target** field, calling the exe from a batch/PowerShell script, or running it from a terminal. On Linux/Wine, append them after the exe path in your `wine start` command.
+
+## Arguments
+
+| Argument | Effect |
+| --- | --- |
+| `/?`, `/help` | Print the list of arguments and exit. |
+| `/version` | Print the launcher version and exit. |
+| `/quiet` | Run without any user interaction — no prompts or dialogs. Useful for scripted/silent launches. |
+| `/install` | Create the necessary folders and download `GWToolboxdll.dll`, then exit. |
+| `/uninstall` | Remove all data used by GWToolbox, then exit. |
+| `/reinstall` | Do a fresh installation (uninstall, then install), then exit. |
+| `/asadmin` | Relaunch as administrator if not already elevated. |
+| `/noupdate` | Don't check for or download an updated DLL on launch. |
+| `/noinstall` | Don't offer to install the DLL if it's missing. |
+| `/localdll` | Inject the `GWToolboxdll.dll` sitting next to `GWToolbox.exe` instead of the installed copy. Implies `/noupdate` and `/noinstall`. |
+| `/pid <process id>` | Inject into the Guild Wars process with the given PID instead of searching for one. |
+
+## Notes
+
+- `/install`, `/uninstall`, and `/reinstall` are mutually exclusive — pass at most one.
+- `/quiet` requires Toolbox to already be installed; it will error out rather than prompt you to install.
+- `/localdll` is mainly for developers running a local build — it loads the DLL from the launcher's own directory and skips updating and installing entirely.
+
+## Examples
+
+Launch silently using a locally-built DLL, without updating or installing:
+
+```text
+GWToolbox.exe /noupdate /noinstall /quiet /localdll
+```
+
+Run without ever checking for updates (e.g. to stay on a specific release):
+
+```text
+GWToolbox.exe /noupdate
+```
+
+Inject into a specific Guild Wars process:
+
+```text
+GWToolbox.exe /pid 12345
+```

--- a/site/src/lib/nav.ts
+++ b/site/src/lib/nav.ts
@@ -13,6 +13,7 @@ export const navGroups: NavGroup[] = [
     label: 'Getting Started',
     items: [
       { slug: 'faq', label: 'FAQ' },
+      { slug: 'launch_options', label: 'Launcher Arguments' },
       { slug: 'linux', label: 'Linux Install Guide' },
       { slug: 'history', label: 'Version History' },
       { slug: 'credits', label: 'Credits' },


### PR DESCRIPTION
Adds a docs page covering the command-line arguments accepted by `GWToolbox.exe` (the launcher), since there was nothing on the site about them.

Source of truth is `PrintUsage()` / `ParseCommandLine()` in `GWToolbox/Settings.cpp`:
- `/?` `/help`, `/version`, `/quiet`
- `/install`, `/uninstall`, `/reinstall`
- `/asadmin`, `/noupdate`, `/noinstall`, `/localdll`
- `/pid <process id>`

Includes notes on mutual exclusivity and `/localdll` implying `/noupdate` + `/noinstall`, plus usage examples (including the `/noupdate /noinstall /quiet /localdll` dev combo). Linked in the sidebar under **Getting Started**. Site builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)