### PR TITLE
docs: note DLL has its own update setting independent of /noupdate

### DIFF
--- a/site/src/content/docs/launch_options.md
+++ b/site/src/content/docs/launch_options.md
@@ -44,6 +44,8 @@ Run without ever checking for updates (e.g. to stay on a specific release):
 GWToolbox.exe /noupdate
 ```
 
+> **Note:** `/noupdate` only stops the *launcher* from updating the DLL at startup. The Toolbox DLL has its own update setting (Toolbox **Settings → Updater → Update mode**) which may be set to check for and apply updates on its own. To stay on a specific release, also set that to **Do not check for updates**.
+
 Inject into a specific Guild Wars process:
 
 ```text


### PR DESCRIPTION
Adds a note to the `/noupdate` example on the Launcher Arguments page clarifying that `/noupdate` only stops the **launcher** from updating the DLL at startup. The Toolbox DLL has its own update setting (**Settings → Updater → Update mode**, including "Check and automatically update") that can still update on its own — so to pin a specific release you need to set that to "Do not check for updates" as well.

Verified against `GWToolboxdll/Modules/Updater.cpp`.

This re-introduces the note through a proper PR (the earlier direct-to-master commit was reverted in 6ff0bd2b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)