### PR TITLE
Fix salvage auto-accept: chase child frame id to 0x6f

### DIFF
--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -1498,7 +1498,7 @@ namespace {
                 pending_salvage_at = TIMER_INIT();
             }
             // Auto accept "you can only salvage materials with a lesser salvage kit"
-            GW::UI::ButtonClick(GW::UI::GetChildFrame(GW::UI::GetFrameByLabel(L"Game"), 0x6, 0x6e, 0x6));
+            GW::UI::ButtonClick(GW::UI::GetChildFrame(GW::UI::GetFrameByLabel(L"Game"), 0x6, 0x6f, 0x6));
             return;
         }
         is_salvaging = false;


### PR DESCRIPTION
## What

The "Salvage All" flow auto-accepts the *"you can only salvage materials with a lesser salvage kit"* confirmation prompt by clicking a child frame addressed positionally off the `Game` frame (`0x6 → 0x6e → 0x6`).

A recent GW UI update shifted the layout, so the middle id moved from `0x6e` → `0x6f`. Without this, salvage all hangs on the confirmation prompt for items that trigger it (e.g. basic salvage kit on purple/gold).

## Change

`GWToolboxdll/Modules/InventoryManager.cpp`, `ContinueSalvage()`:

```diff
-GW::UI::ButtonClick(GW::UI::GetChildFrame(GW::UI::GetFrameByLabel(L"Game"), 0x6, 0x6e, 0x6));
+GW::UI::ButtonClick(GW::UI::GetChildFrame(GW::UI::GetFrameByLabel(L"Game"), 0x6, 0x6f, 0x6));
```

This is the same positional-id re-chase done previously (`0x64` → `0x6d` → `0x6e` → `0x6f`). Worth considering a more robust lookup (frame label / template hash) so it stops breaking on each UI patch, but this PR is the minimal fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)