### PR TITLE
Add GW::UI::GetButtonFrameByEncodedString (button frame lookup by encoded label)

### DIFF
--- a/GWToolboxdll/Utils/UIFrameLookup.cpp
+++ b/GWToolboxdll/Utils/UIFrameLookup.cpp
@@ -33,7 +33,7 @@ namespace {
     }
 
     // Shared lifecycle for a frame-type cache: created/destroyed frames are tracked by their
-    // encoded label, and relabel_message reassigns the cache key (wparam = new encoded string).
+    // encoded label, and relabel_message re-reads the frame's label to reassign the cache key.
     template <typename FrameT>
     void UpdateCache(std::unordered_map<std::wstring, FrameT*>& cache, GW::UI::UIInteractionCallback original,
                      GW::UI::UIMessage relabel_message, GW::UI::InteractionMessage* message, void* wparam, void* lparam)
@@ -46,20 +46,14 @@ namespace {
             }
         }
         original(message, wparam, lparam);
-        if (message->message_id == GW::UI::UIMessage::kInitFrame) {
-            const auto frame = static_cast<FrameT*>(GW::UI::GetFrameById(message->frame_id));
-            const auto label = ReadEncodedLabel(frame);
-            if (label && label[0]) {
-                cache[label] = frame;
-            }
-        }
-        else if (message->message_id == relabel_message) {
+        // Frame created or relabelled; re-key it under its current encoded label.
+        if (message->message_id == GW::UI::UIMessage::kInitFrame || message->message_id == relabel_message) {
             const auto frame = static_cast<FrameT*>(GW::UI::GetFrameById(message->frame_id));
             if (frame) {
                 ForgetFrame(cache, frame);
-                const auto new_label = static_cast<const wchar_t*>(wparam);
-                if (new_label && new_label[0]) {
-                    cache[new_label] = frame;
+                const auto label = ReadEncodedLabel(frame);
+                if (label && label[0]) {
+                    cache[label] = frame;
                 }
             }
         }

--- a/GWToolboxdll/Utils/UIFrameLookup.cpp
+++ b/GWToolboxdll/Utils/UIFrameLookup.cpp
@@ -7,88 +7,137 @@
 #include <Logger.h>
 
 namespace {
-    // encoded label -> live multiline text frame, kept current by the callback below.
+    // encoded label -> live frame, kept current by the callbacks below.
     std::unordered_map<std::wstring, GW::MultiLineTextLabelFrame*> multiline_frames;
+    std::unordered_map<std::wstring, GW::ButtonFrame*> button_frames;
 
     GW::UI::UIInteractionCallback TextMultiline_UICallback_Func = nullptr;
     GW::UI::UIInteractionCallback TextMultiline_UICallback_Ret = nullptr;
+    GW::UI::UIInteractionCallback CtlButton_UICallback_Func = nullptr;
+    GW::UI::UIInteractionCallback CtlButton_UICallback_Ret = nullptr;
 
-    void ForgetFrame(const GW::UI::Frame* frame)
+    const wchar_t* ReadEncodedLabel(GW::MultiLineTextLabelFrame* frame)
     {
-        std::erase_if(multiline_frames, [frame](const auto& entry) { return entry.second == frame; });
+        return frame ? frame->GetEncodedLabel() : nullptr;
+    }
+    const wchar_t* ReadEncodedLabel(GW::ButtonFrame* frame)
+    {
+        const wchar_t* label = nullptr;
+        return frame && frame->GetLabel(&label) ? label : nullptr;
     }
 
-    void OnTextMultilineUICallback(GW::UI::InteractionMessage* message, void* wparam, void* lparam)
+    template <typename FrameT>
+    void ForgetFrame(std::unordered_map<std::wstring, FrameT*>& cache, const GW::UI::Frame* frame)
+    {
+        std::erase_if(cache, [frame](const auto& entry) { return entry.second == frame; });
+    }
+
+    // Shared lifecycle for a frame-type cache: created/destroyed frames are tracked by their
+    // encoded label, and relabel_message reassigns the cache key (wparam = new encoded string).
+    template <typename FrameT>
+    void UpdateCache(std::unordered_map<std::wstring, FrameT*>& cache, GW::UI::UIInteractionCallback original,
+                     GW::UI::UIMessage relabel_message, GW::UI::InteractionMessage* message, void* wparam, void* lparam)
     {
         GW::Hook::EnterHook();
         // Drop the entry before the original handler tears the frame down.
         if (message->message_id == GW::UI::UIMessage::kDestroyFrame) {
             if (const auto frame = GW::UI::GetFrameById(message->frame_id)) {
-                ForgetFrame(frame);
+                ForgetFrame(cache, frame);
             }
         }
-        TextMultiline_UICallback_Ret(message, wparam, lparam);
-        switch (message->message_id) {
-            // Frame created; cache its initial encoded label.
-            case GW::UI::UIMessage::kInitFrame: {
-                const auto frame = static_cast<GW::MultiLineTextLabelFrame*>(GW::UI::GetFrameById(message->frame_id));
-                const auto label = frame ? frame->GetEncodedLabel() : nullptr;
-                if (label && label[0]) {
-                    multiline_frames[label] = frame;
+        original(message, wparam, lparam);
+        if (message->message_id == GW::UI::UIMessage::kInitFrame) {
+            const auto frame = static_cast<FrameT*>(GW::UI::GetFrameById(message->frame_id));
+            const auto label = ReadEncodedLabel(frame);
+            if (label && label[0]) {
+                cache[label] = frame;
+            }
+        }
+        else if (message->message_id == relabel_message) {
+            const auto frame = static_cast<FrameT*>(GW::UI::GetFrameById(message->frame_id));
+            if (frame) {
+                ForgetFrame(cache, frame);
+                const auto new_label = static_cast<const wchar_t*>(wparam);
+                if (new_label && new_label[0]) {
+                    cache[new_label] = frame;
                 }
-            } break;
-            // Encoded label is being reassigned; wparam is the new encoded string.
-            case GW::UI::UIMessage::kFrameMessage_0x52: {
-                const auto frame = static_cast<GW::MultiLineTextLabelFrame*>(GW::UI::GetFrameById(message->frame_id));
-                if (frame) {
-                    ForgetFrame(frame);
-                    const auto new_label = static_cast<const wchar_t*>(wparam);
-                    if (new_label && new_label[0]) {
-                        multiline_frames[new_label] = frame;
-                    }
-                }
-            } break;
-            default:
-                break;
+            }
         }
         GW::Hook::LeaveHook();
     }
 
-    bool EnsureInitialised()
+    void OnTextMultilineUICallback(GW::UI::InteractionMessage* message, void* wparam, void* lparam)
     {
-        static bool initialised = false;
-        if (initialised) {
-            return TextMultiline_UICallback_Func != nullptr;
-        }
-        initialised = true;
-        TextMultiline_UICallback_Func = reinterpret_cast<GW::UI::UIInteractionCallback>(
-            GW::Scanner::ToFunctionStart(GW::Scanner::Find("\x83\xc0\xf8\x83\xf8\x5b", "xxxxxx")));
-        if (!TextMultiline_UICallback_Func) {
-            Log::Error("Failed to find TextMultiline_UICallback");
+        UpdateCache(multiline_frames, TextMultiline_UICallback_Ret, GW::UI::UIMessage::kFrameMessage_0x52, message, wparam, lparam);
+    }
+    void OnCtlButtonUICallback(GW::UI::InteractionMessage* message, void* wparam, void* lparam)
+    {
+        UpdateCache(button_frames, CtlButton_UICallback_Ret, GW::UI::UIMessage::kFrameMessage_0x4c, message, wparam, lparam);
+    }
+
+    bool InstallHook(GW::UI::UIInteractionCallback& func, GW::UI::UIInteractionCallback detour, GW::UI::UIInteractionCallback& ret, uintptr_t address, const char* name)
+    {
+        func = reinterpret_cast<GW::UI::UIInteractionCallback>(address);
+        if (!func) {
+            Log::Error("Failed to find %s", name);
             return false;
         }
-        GW::Hook::CreateHook(reinterpret_cast<void**>(&TextMultiline_UICallback_Func), OnTextMultilineUICallback,
-                             reinterpret_cast<void**>(&TextMultiline_UICallback_Ret));
-        GW::Hook::EnableHooks(TextMultiline_UICallback_Func);
+        GW::Hook::CreateHook(reinterpret_cast<void**>(&func), detour, reinterpret_cast<void**>(&ret));
+        GW::Hook::EnableHooks(func);
         return true;
+    }
+
+    bool EnsureMultilineInitialised()
+    {
+        static bool initialised = false;
+        if (!initialised) {
+            initialised = true;
+            InstallHook(TextMultiline_UICallback_Func, OnTextMultilineUICallback, TextMultiline_UICallback_Ret,
+                        GW::Scanner::ToFunctionStart(GW::Scanner::Find("\x83\xc0\xf8\x83\xf8\x5b", "xxxxxx")), "TextMultiline_UICallback");
+        }
+        return TextMultiline_UICallback_Func != nullptr;
+    }
+    bool EnsureButtonInitialised()
+    {
+        static bool initialised = false;
+        if (!initialised) {
+            initialised = true;
+            InstallHook(CtlButton_UICallback_Func, OnCtlButtonUICallback, CtlButton_UICallback_Ret,
+                        GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("CtlBtn.cpp", "checked", 0, 0)), "CtlButton_UICallback");
+        }
+        return CtlButton_UICallback_Func != nullptr;
+    }
+
+    template <typename FrameT>
+    FrameT* FindByEncodedString(std::unordered_map<std::wstring, FrameT*>& cache, const wchar_t* encoded_string, bool partial_match)
+    {
+        if (!partial_match) {
+            const auto found = cache.find(encoded_string);
+            return found == cache.end() ? nullptr : found->second;
+        }
+        for (const auto& [label, frame] : cache) {
+            if (label.starts_with(encoded_string)) {
+                return frame;
+            }
+        }
+        return nullptr;
     }
 }
 
 namespace GW::UI {
     GW::MultiLineTextLabelFrame* GetMultilineTextFrameByEncodedString(const wchar_t* encoded_string, const bool partial_match)
     {
-        if (!encoded_string || !EnsureInitialised()) {
+        if (!encoded_string || !EnsureMultilineInitialised()) {
             return nullptr;
         }
-        if (!partial_match) {
-            const auto found = multiline_frames.find(encoded_string);
-            return found == multiline_frames.end() ? nullptr : found->second;
+        return FindByEncodedString(multiline_frames, encoded_string, partial_match);
+    }
+
+    GW::ButtonFrame* GetButtonFrameByEncodedString(const wchar_t* encoded_string, const bool partial_match)
+    {
+        if (!encoded_string || !EnsureButtonInitialised()) {
+            return nullptr;
         }
-        for (const auto& [label, frame] : multiline_frames) {
-            if (label.starts_with(encoded_string)) {
-                return frame;
-            }
-        }
-        return nullptr;
+        return FindByEncodedString(button_frames, encoded_string, partial_match);
     }
 }

--- a/GWToolboxdll/Utils/UIFrameLookup.h
+++ b/GWToolboxdll/Utils/UIFrameLookup.h
@@ -9,4 +9,7 @@ namespace GW::UI {
     // chasing positional child frame ids that drift every time the GW UI changes.
     // With partial_match, returns the first frame whose encoded label starts with encoded_string.
     GW::MultiLineTextLabelFrame* GetMultilineTextFrameByEncodedString(const wchar_t* encoded_string, bool partial_match = false);
+
+    // As above, but for button frames matched on their encoded button label.
+    GW::ButtonFrame* GetButtonFrameByEncodedString(const wchar_t* encoded_string, bool partial_match = false);
 }


### PR DESCRIPTION
## Why

Follow-up to the multiline text frame cache. Extends the same encoded-label lookup to `GW::ButtonFrame`, so button-targeting code can stop chasing positional child frame ids that drift on every GW UI update.

## What

`GWToolboxdll/Utils/UIFrameLookup.{h,cpp}` now exposes:

```cpp
GW::ButtonFrame* GW::UI::GetButtonFrameByEncodedString(
    const wchar_t* encoded_string, bool partial_match = false);
```

alongside the existing `GetMultilineTextFrameByEncodedString`. Same semantics (exact match, or `partial_match` = first frame whose encoded label starts with the string).

### How it works

The create/destroy/relabel lifecycle is now shared between both caches via a template (`UpdateCache`), so the two differ only in:

| | Multiline text | Button |
|---|---|---|
| hooked callback | `TextMultiline_UICallback` (`Find("83 c0 f8 83 f8 5b")`) | `CtlButton_UICallback` (`FindAssertion("CtlBtn.cpp", "checked")`) |
| label read | `MultiLineTextLabelFrame::GetEncodedLabel()` | `ButtonFrame::GetLabel(&out)` |
| relabel message | `kFrameMessage_0x52` | `kFrameMessage_0x4c` |

Create (`kInitFrame`) and destroy (`kDestroyFrame`) handling is identical. Both hooks install lazily on first use of their respective getter and are cleaned up by GWCA's global `Hook::Deinitialize()` on shutdown.

## Notes

- Cache keyed by encoded label, so two live frames sharing a label collapse to one entry — fine for the dialog/button labels this targets.
- No call sites converted yet; this just adds the button getter. The natural first users are the `GameSettings` donation-dialog sign button and the `Party` button click, which currently use hardcoded child-frame paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)