### PR TITLE
docs: add Quality of Life Fixes page

### DIFF
--- a/site/src/content/docs/qol_fixes.md
+++ b/site/src/content/docs/qol_fixes.md
@@ -1,0 +1,24 @@
+---
+title: "Quality of Life Fixes"
+section: features
+---
+
+Alongside its bigger windows and widgets, GWToolbox++ quietly fixes a number of small base-game bugs and annoyances. These are enabled by default, and most players never realise that Toolbox is the reason things "just work". This page collects them in one place.
+
+Each can be toggled in its own section of the [Settings](/docs/settings/) panel.
+
+## Fixes
+
+- **Hero command panel positions** — Remembers where you place each hero's skill-bar / command panel and restores it when the panel reappears, so they stop scattering across the screen after you reorder your party or swap characters. The position is tied to the hero, so it follows them regardless of party slot.
+
+- **Experience bar shows XP progress** — Replaces the experience bar text so it shows your progress toward the next level (current XP / XP needed) instead of just repeating your current level number.
+
+- **Keyboard Language Fix** — Stops Guild Wars from silently switching your Windows keyboard layout to en-US on startup, which would otherwise trigger the Win+Space language switcher and persist until you change it back in Windows. See [Input Modules](/docs/input_modules/).
+
+- **Mouse Fix** — Fixes an occasional camera glitch when looking around with the mouse, and optionally lets you resize the in-game cursor. See [Input Modules](/docs/input_modules/).
+
+- **Vendor Fix** — Fixes a base-game bug where collectable items sitting beyond the 56th inventory slot aren't recognised by collectors and crafters, so trade-ins work no matter where the item sits in your bags.
+
+- **Code Optimiser** — Swaps Guild Wars' internal checksum (CRC32) routine for a much faster one, cutting the time the game spends validating large chunks of data and the stutter that can come with it.
+
+- **FPS Fix** — Removes Guild Wars' hard-coded 90 FPS cap so the frame rate can match your monitor's refresh rate.

--- a/site/src/lib/nav.ts
+++ b/site/src/lib/nav.ts
@@ -71,6 +71,7 @@ export const navGroups: NavGroup[] = [
       { slug: 'reroll', label: 'Reroll' },
       { slug: 'integrations', label: 'Integrations' },
       { slug: 'input_modules', label: 'Input' },
+      { slug: 'qol_fixes', label: 'Quality of Life Fixes' },
       { slug: 'plugins', label: 'Plugins' },
     ],
   },


### PR DESCRIPTION
Adds a docs page collecting the smaller base-game fixes and tweaks Toolbox makes — the kind players often don't realise are Toolbox doing the work, rather than big new windows/widgets.

Short bullets for each, with cross-links to existing pages where they already have fuller docs:

- Hero command panel positions
- Experience bar shows XP progress (instead of current level)
- Keyboard Language Fix
- Mouse Fix
- Vendor Fix
- Code Optimiser
- FPS Fix

Added to the **Features** group in the sidebar (`nav.ts`). Page is plain Markdown under `site/src/content/docs/qol_fixes.md`.

Verified locally with `npm run build` — page renders at `/docs/qol_fixes/` and is picked up by the Pagefind search index.

Note: the site deploys on push to `master`, so this goes live once `dev` is merged up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)