### PR TITLE
Add Tunnels of the Forsaken to ObjectiveTimerWindow

### DIFF
--- a/GWToolboxdll/Windows/ObjectiveTimerWindow.cpp
+++ b/GWToolboxdll/Windows/ObjectiveTimerWindow.cpp
@@ -539,6 +539,11 @@ void ObjectiveTimerWindow::AddObjectiveSet(const GW::Constants::MapID map_id)
                                     MapID::Heart_of_the_Shiverpeaks_Level_2,
                                     MapID::Heart_of_the_Shiverpeaks_Level_3});
             break;
+        case MapID::Forsaken_Tunnels_Level1:
+            AddDungeonObjectiveSet({MapID::Forsaken_Tunnels_Level1,
+                                    MapID::Forsaken_Tunnels_Level2,
+                                    MapID::Forsaken_Tunnels_Level3});
+            break;
 
         // dungeons - 5 levels:
         case MapID::Frostmaws_Burrows_Level_1:


### PR DESCRIPTION
Adds post-Searing Tunnels of the Forsaken dungeon (3 levels) to the Objectives window. The run completes when the DungeonReward event fires after Varny the Zealot dies.

Closes #2243

Generated with [Claude Code](https://claude.ai/code)