### PR TITLE
Add gwmarket purchase analytics when whispering a seller/buyer

### DIFF
--- a/GWToolboxdll/Windows/GWMarketWindow.cpp
+++ b/GWToolboxdll/Windows/GWMarketWindow.cpp
@@ -33,7 +33,6 @@
 #include <Timer.h>
 #include <Utils/TextUtils.h>
 #include <algorithm>
-#include <chrono>
 #include <sstream>
 #include <unordered_set>
 
@@ -351,7 +350,7 @@ namespace {
         bool IsActive() const
         {
             return !player_name.empty() && timestamp &&
-                   (clock() - timestamp) < (60 * CLOCKS_PER_SEC);
+                   TIMER_DIFF(timestamp) < (60 * CLOCKS_PER_SEC);
         }
 
         void Clear() { player_name.clear(); timestamp = 0; }
@@ -1167,7 +1166,7 @@ namespace {
                     pending_purchase_analytic.item_name = order.name;
                     pending_purchase_analytic.order_type = order.orderType;
                     pending_purchase_analytic.price = order.prices[0];
-                    pending_purchase_analytic.timestamp = clock();
+                    pending_purchase_analytic.timestamp = TIMER_INIT();
                 }
                 auto cpy = new MarketItem();
                 *cpy = order;

--- a/GWToolboxdll/Windows/GWMarketWindow.cpp
+++ b/GWToolboxdll/Windows/GWMarketWindow.cpp
@@ -8,6 +8,7 @@
 #include <GWCA/GameEntities/Item.h>
 #include <GWCA/GameEntities/Map.h>
 
+#include <GWCA/Managers/ChatMgr.h>
 #include <GWCA/Managers/GameThreadMgr.h>
 #include <GWCA/Managers/ItemMgr.h>
 #include <GWCA/Managers/MapMgr.h>
@@ -15,6 +16,7 @@
 #include <GWCA/Managers/UIMgr.h>
 
 #include <Logger.h>
+#include <RestClient.h>
 #include <Utils/GuiUtils.h>
 
 #include <Utils/ThreadedWebSocket.h>
@@ -24,6 +26,7 @@
 #include <Modules/GwDatTextureModule.h>
 #include <Modules/InventoryManager.h>
 #include <Modules/Resources.h>
+#include <Modules/ToolboxSettings.h>
 
 #include <GWCA/Context/CharContext.h>
 #include <GWCA/GameEntities/Frame.h>
@@ -337,6 +340,22 @@ namespace {
     std::vector<MarketItem> edit_window_matching_orders;
     std::string edit_window_matching_item_name;
     bool edit_window_orders_needs_sort = true;
+
+    struct PendingPurchaseAnalytic {
+        std::string player_name;
+        std::string item_name;
+        OrderType order_type = OrderType::Sell;
+        Price price;
+        clock_t timestamp = 0;
+
+        bool IsActive() const
+        {
+            return !player_name.empty() && timestamp &&
+                   (clock() - timestamp) < (60 * CLOCKS_PER_SEC);
+        }
+
+        void Clear() { player_name.clear(); timestamp = 0; }
+    } pending_purchase_analytic;
 
     struct ShopItem : MarketItem {
         bool hidden = false;
@@ -1143,6 +1162,13 @@ namespace {
 
             ImGui::SetCursorPos({ImGui::GetContentRegionAvail().x - 100.f, top + 5.f});
             if (ImGui::Button("Whisper##seller", {100.f, 0.f})) {
+                if (!order.prices.empty()) {
+                    pending_purchase_analytic.player_name = order.player;
+                    pending_purchase_analytic.item_name = order.name;
+                    pending_purchase_analytic.order_type = order.orderType;
+                    pending_purchase_analytic.price = order.prices[0];
+                    pending_purchase_analytic.timestamp = clock();
+                }
                 auto cpy = new MarketItem();
                 *cpy = order;
                 GW::GameThread::Enqueue([cpy] {
@@ -1578,6 +1604,57 @@ namespace {
         //
     }
 
+    AsyncRestClient purchase_analytics_client;
+
+    void SendPurchaseAnalytics(const std::string& item_name, OrderType order_type, const Price& price)
+    {
+        if (!ToolboxSettings::send_anonymous_gameplay_info) return;
+        if (purchase_analytics_client.IsPending()) return;
+        purchase_analytics_client.Clear();
+
+        json price_json;
+        price_json["type"] = static_cast<int>(price.type);
+        price_json["price"] = price.price;
+        price_json["quantity"] = price.quantity;
+
+        json payload;
+        payload["name"] = item_name;
+        payload["orderType"] = static_cast<int>(order_type);
+        payload["price"] = price_json;
+
+        const auto json_str = glz::write_json(payload).value_or(std::string{});
+
+        purchase_analytics_client.SetUrl(std::format("https://{}/api/shop/purchase/", market_host).c_str());
+        purchase_analytics_client.SetMethod(HttpMethod::Post);
+        purchase_analytics_client.SetHeader("Content-Type", "application/json");
+        purchase_analytics_client.SetPostContent(json_str, ContentFlag::Copy);
+        purchase_analytics_client.SetTimeoutSec(5);
+        purchase_analytics_client.SetConnectTimeoutSec(3);
+        purchase_analytics_client.SetVerifyPeer(false);
+        purchase_analytics_client.SetVerifyHost(false);
+        purchase_analytics_client.ExecuteAsync();
+    }
+
+    GW::HookEntry OnSendChatMessage_HookEntry;
+    void OnSendChatMessage(GW::HookStatus*, GW::UI::UIMessage, void* wparam, void*)
+    {
+        if (!pending_purchase_analytic.IsActive()) return;
+
+        const auto message = static_cast<GW::UI::UIPacket::kSendChatMessage*>(wparam)->message;
+        if (!(message && *message)) return;
+        if (GW::Chat::GetChannel(*message) != GW::Chat::Channel::CHANNEL_WHISPER) return;
+
+        const wchar_t* name_start = message + 1; // skip channel opcode
+        const wchar_t* sep = wcschr(name_start, L',');
+        if (!sep) return;
+
+        const std::string recipient = TextUtils::WStringToString(std::wstring(name_start, sep - name_start));
+        if (recipient != pending_purchase_analytic.player_name) return;
+
+        SendPurchaseAnalytics(pending_purchase_analytic.item_name, pending_purchase_analytic.order_type, pending_purchase_analytic.price);
+        pending_purchase_analytic.Clear();
+    }
+
     struct PendingAddToSell {
         uint32_t item_id;
         std::unique_ptr<GuiUtils::EncString> decoded_complete_name;
@@ -1667,6 +1744,7 @@ void GWMarketWindow::Initialize()
         RegisterUIMessageCallback(&OnPostUIMessage_HookEntry, ui_message, OnPostUIMessage, 0x4000);
     }
     OnPostUIMessage(0, GW::UI::UIMessage::kMapLoaded, 0, 0);
+    RegisterUIMessageCallback(&OnSendChatMessage_HookEntry, GW::UI::UIMessage::kSendChatMessage, OnSendChatMessage);
 }
 
 void GWMarketWindow::Terminate()
@@ -1674,6 +1752,8 @@ void GWMarketWindow::Terminate()
     Disconnect(true);
     ToolboxWindow::Terminate();
     GW::UI::RemoveUIMessageCallback(&OnPostUIMessage_HookEntry);
+    GW::UI::RemoveUIMessageCallback(&OnSendChatMessage_HookEntry);
+    purchase_analytics_client.Abort();
 }
 
 void GWMarketWindow::Update(float delta)

--- a/GWToolboxdll/Windows/SettingsWindow.cpp
+++ b/GWToolboxdll/Windows/SettingsWindow.cpp
@@ -358,7 +358,8 @@ void SettingsWindow::Draw(IDirect3DDevice9*)
         ImGui::Checkbox("Hide Settings when entering explorable area", &hide_when_entering_explorable);
         ImGui::CheckboxWithHelp("Send anonymous gameplay stats", &ToolboxSettings::send_anonymous_gameplay_info, "Some features of toolbox allow you to contribute to the community\nby sending in-game data to remote websites.\
         \n\nFeatures that use this info:\
-        \n\t- Sending outpost party information to https://party.gwtoolbox.com");
+        \n\t- Sending outpost party information to https://party.gwtoolbox.com\
+        \n\t- Sending purchase analytics to https://gwmarket.net when whispering a seller/buyer from the Market Browser");
         ImGui::Text("General:");
 
         if (ImGui::CollapsingHeader("Help")) {

--- a/site/src/content/docs/analytics.md
+++ b/site/src/content/docs/analytics.md
@@ -1,0 +1,39 @@
+---
+title: "Anonymous Analytics"
+section: meta
+description: "What anonymous gameplay data GWToolbox++ sends, to whom, and how to opt out."
+---
+
+GWToolbox++ can send anonymous gameplay data to third-party services to help improve those services for the Guild Wars community. This is **opt-in by default via the "Send anonymous gameplay stats" checkbox** in [Settings](/docs/settings/#toolbox-settings) and can be disabled at any time.
+
+No account name, character name, IP address, or any other personally identifying information is ever included in these transmissions.
+
+## Opting out
+
+Open **Settings → Toolbox Settings** and uncheck **Send anonymous gameplay stats**. All analytics transmissions described below will stop immediately.
+
+## Data sent and when
+
+### gwmarket.net — purchase analytics
+
+**When it happens:** You click the **Whisper** button on a listing in the [Market Browser](/docs/market_browser/) and then send a whisper to that same player within 60 seconds.
+
+**What is sent:** A single HTTP POST to `https://gwmarket.net/api/shop/purchase/` containing:
+
+| Field | Value |
+|-------|-------|
+| `name` | Item name (e.g. `"Glob of Ectoplasm"`) |
+| `orderType` | `0` for a sell order, `1` for a buy order |
+| `price.type` | Currency: `0` = Platinum, `1` = Ecto, `2` = Zkeys, `3` = Arms |
+| `price.price` | Quoted price |
+| `price.quantity` | Quoted quantity |
+
+**Why it is useful:** gwmarket.net uses this to track which listings result in completed trades, helping it surface more accurate pricing data for the community.
+
+### party.gwtoolbox.com — outpost party information
+
+**When it happens:** While you are in an outpost, Toolbox periodically shares your party composition with party.gwtoolbox.com.
+
+**What is sent:** Party size and outpost location — no character or account names.
+
+**Why it is useful:** This powers the cross-client "party search" feature so players can find groups in the same outpost.

--- a/site/src/content/docs/analytics.md
+++ b/site/src/content/docs/analytics.md
@@ -6,7 +6,7 @@ description: "What anonymous gameplay data GWToolbox++ sends, to whom, and how t
 
 GWToolbox++ can send anonymous gameplay data to third-party services to help improve those services for the Guild Wars community. This is **opt-in by default via the "Send anonymous gameplay stats" checkbox** in [Settings](/docs/settings/#toolbox-settings) and can be disabled at any time.
 
-No account name, character name, IP address, or any other personally identifying information is ever included in these transmissions.
+No account name or IP address is ever included in these transmissions. Some transmissions include character names or an account UUID as described below.
 
 ## Opting out
 
@@ -32,8 +32,28 @@ Open **Settings → Toolbox Settings** and uncheck **Send anonymous gameplay sta
 
 ### party.gwtoolbox.com — outpost party information
 
-**When it happens:** While you are in an outpost, Toolbox periodically shares your party composition with party.gwtoolbox.com.
+**When it happens:** While you are in an outpost, Toolbox periodically sends party search listings visible to you (and parties of nearby players) to party.gwtoolbox.com via a WebSocket connection.
 
-**What is sent:** Party size and outpost location — no character or account names.
+**What is sent:**
+
+The WebSocket connection headers include your **account UUID** (`X-Account-Uuid`) and the current Toolbox version as an API key. Your account UUID is a persistent identifier derived from your Guild Wars account; it is not your account name or email address.
+
+Each party listing payload contains:
+
+| Field | Value |
+|-------|-------|
+| `s` | **Character name** of the party leader |
+| `ms` | Party search message (the text the player typed) |
+| `t` | Search type (hunting, mission, quest, trade, guild) |
+| `p` / `sc` | Primary and secondary profession |
+| `ps` | Party size (omitted if 1) |
+| `hc` | Hero count |
+| `hm` | Hard mode flag |
+| `dl` / `dn` | District language and number |
+| `l` | Level (omitted if 20) |
+| `map_id` | Current map (outpost) |
+| `district_region` | Server region |
+
+Character names sent here are the same names publicly visible to all players in the outpost via the in-game party search panel.
 
 **Why it is useful:** This powers the cross-client "party search" feature so players can find groups in the same outpost.

--- a/site/src/content/docs/market_browser.mdx
+++ b/site/src/content/docs/market_browser.mdx
@@ -50,7 +50,7 @@ When you click an item, the right pane fills with:
 - A **★ Favorite / Unfavorite** button to toggle the item in your Favorites pane.
 - A **gwmarket.net** button to open the item's page in the website.
 - A **Guild Wars Wiki** button to open the item's wiki page.
-- Two grouped lists below: **SELL ORDERS** (green) and **BUY ORDERS** (orange). Each row shows the seller name, when it was posted, the quoted quantity, the asking price, the per-unit price and a **Whisper** button that opens an in-game whisper pre-filled with that player's name.
+- Two grouped lists below: **SELL ORDERS** (green) and **BUY ORDERS** (orange). Each row shows the seller name, when it was posted, the quoted quantity, the asking price, the per-unit price and a **Whisper** button that opens an in-game whisper pre-filled with that player's name. If you then send a whisper to that player within 60 seconds, anonymous purchase data is sent to gwmarket.net (see [Anonymous Analytics](/docs/analytics/)).
 
 ## Settings
 

--- a/site/src/lib/nav.ts
+++ b/site/src/lib/nav.ts
@@ -15,6 +15,7 @@ export const navGroups: NavGroup[] = [
       { slug: 'faq', label: 'FAQ' },
       { slug: 'launch_options', label: 'Launcher Arguments' },
       { slug: 'linux', label: 'Linux Install Guide' },
+      { slug: 'analytics', label: 'Anonymous Analytics' },
       { slug: 'history', label: 'Version History' },
       { slug: 'credits', label: 'Credits' },
       { slug: 'donate', label: 'Donate' },


### PR DESCRIPTION
Closes #2249

When the player clicks Whisper on a market listing, start a 1-minute timer. If the player then sends a whisper to that same recipient within the window, POST the item name, price, and order type to gwmarket.net/api/shop/purchase/ as anonymous gameplay analytics. Honors the Send anonymous gameplay stats setting, and updates the help tooltip to mention this feature.

Generated with [Claude Code](https://claude.ai/code)