### PR TITLE
perf(minimap): throttle custom-line buffer rebuilds

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/CustomRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/CustomRenderer.cpp
@@ -1014,6 +1014,10 @@ void CustomRenderer::DrawCustomMarkers(IDirect3DDevice9* device)
 
 void CustomRenderer::DrawCustomLines(const IDirect3DDevice9*)
 {
+    // Rebuild at 30fps, not every frame: a rebuild marks the buffer dirty and forces a Lock/memcpy re-upload.
+    static clock_t last_check = 0;
+    if (!ToolboxUtils::FrameRateCheck(last_check, 30)) return;
+
     const auto doa_outpost = GW::Map::GetInstanceType() != GW::Constants::InstanceType::Explorable && GW::Map::GetMapID() == GW::Constants::MapID::Domain_of_Anguish;
     const auto my_pos = GW::PlayerMgr::GetPlayerPosition();
     vertices.clear();


### PR DESCRIPTION
## What
`CustomRenderer::DrawCustomLines` cleared and repopulated its vertex buffer **every frame**. Because `clear()`/`push_back` set `dirty`, this forced a `Lock`/`memcpy` re-upload of the line geometry on every frame the minimap is drawn (and the mission map, when lines are present) — even when nothing changed.

This throttles the rebuild to 30fps using the same `ToolboxUtils::FrameRateCheck` pattern `AgentRenderer` already uses. Throttled frames keep the existing buffer and skip the upload (`dirty` stays false → `D3DVertexBuffer::Render` just draws). Player-anchored lines (`from_player_pos`, e.g. the quest path) still update at 30/sec, which is smooth and matches agent markers.

Marker/settings edits go through `CustomRenderer::Invalidate`, which re-uploads the current buffer immediately; the throttle only affects how often the line list is *rebuilt*, so an edit is reflected within ≤33ms — imperceptible.

## Scope
Independent of the mission-map-overlay PR (#2247) — this benefits the minimap widget on its own.

## Considered but NOT included: the per-frame `CreateStateBlock(D3DSBT_ALL)`
`Minimap::Render` captures a full device state block (`CreateStateBlock(D3DSBT_ALL)` + `Apply` + `Release`) every call. It's real overhead, but I'm deliberately leaving it for now because neither fix is safe to ship without dedicated in-game testing and/or extra infrastructure:
- **Manual minimal save/restore** (the big win) requires enumerating *every* state each sub-renderer touches across multiple files; miss one and the game's own rendering corrupts. The full block is a deliberate catch-all.
- **Cache one block and reuse via `Capture`/`Apply`** (smaller win — saves the per-frame alloc, not the capture) is fragile across D3D9 device resets: state blocks don't survive a `Reset`, and there's no device-reset hook here to release/recreate it, so fullscreen alt-tab could crash.

Recommend tackling it separately, with profiling to confirm it's worth it and an in-game pass (including a device reset) to validate.

## Notes
Not compiled here (Windows/D3D9 build); needs an in-game smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)