### PR TITLE
feat(chatfilter): block chat messages from a list of player names

### DIFF
--- a/GWToolboxdll/Modules/ChatFilter.cpp
+++ b/GWToolboxdll/Modules/ChatFilter.cpp
@@ -52,15 +52,13 @@ namespace {
     std::vector<std::wregex> bycontent_regex;
     char bycontent_regex_buf[FILTER_BUF_SIZE] = "";
 
-#ifdef EXTENDED_IGNORE_LIST
-    bool messagebyauthor = false;
-    std::set<std::string> byauthor_words;
+    std::vector<std::wstring> byauthor_words;
     char byauthor_buf[FILTER_BUF_SIZE] = "";
     bool byauthor_filedirty = false;
-#endif
 
     uint32_t timer_parse_filters = 0;
     uint32_t timer_parse_regexes = 0;
+    uint32_t timer_parse_authors = 0;
 
     //void ByContent_ParseBuf() {
     //      ParseBuffer(bycontent_buf, bycontent_regex);
@@ -69,11 +67,6 @@ namespace {
     //  }
     //}
 
-#ifdef EXTENDED_IGNORE_LIST
-    void ByAuthor_ParseBuf() {
-        ParseBuffer(byauthor_buf, byauthor_words);
-    }
-#endif
     GW::HookEntry BlockIfApplicable_Entry;
 
 
@@ -292,10 +285,27 @@ namespace {
         return player_name && wcsncmp(player_name, _player_name, wcslen(player_name)) == 0;
     }
 
+    // Matches a sender against the user-defined "Hide messages from" block list.
+    bool IsAuthorBlocked(const std::wstring& sender)
+    {
+        using namespace TextUtils;
+        if (!settings.messagebyauthor || byauthor_words.empty()) {
+            return false;
+        }
+        // Normalise the same way ParseBuffer normalises the stored names.
+        const auto normalised = RemoveDiacritics(ToLower(SanitizePlayerName(sender)));
+        for (const auto& blocked : byauthor_words) {
+            if (blocked == normalised) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     bool ShouldIgnoreBySender(const std::wstring& sender)
     {
         const auto sanitised = TextUtils::SanitizePlayerName(sender);
-        return FriendListWindow::GetIsPlayerIgnored(sanitised) || GW::FriendListMgr::GetFriend(nullptr, sanitised.c_str(), GW::FriendType::Ignore) != nullptr;
+        return IsAuthorBlocked(sender) || FriendListWindow::GetIsPlayerIgnored(sanitised) || GW::FriendListMgr::GetFriend(nullptr, sanitised.c_str(), GW::FriendType::Ignore) != nullptr;
     }
 
     // Should this message be ignored by encoded string?
@@ -826,6 +836,10 @@ void ChatFilter::BlockMessageForMs(const wchar_t* message_contains, clock_t ms) 
     suppressed_messages.push_back({message_contains, TIMER_INIT() + ms});
 }
 
+bool ChatFilter::IsSenderBlocked(const std::wstring& sender) {
+    return IsAuthorBlocked(sender);
+}
+
 void ChatFilter::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
 {
     ToolboxModule::LoadSettings(doc, legacy);
@@ -849,15 +863,14 @@ void ChatFilter::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
         ParseBuffer(bycontent_regex_buf, bycontent_regex);
     }
 
-#ifdef EXTENDED_IGNORE_LIST
+    strcpy_s(byauthor_buf, "");
     std::ifstream byauthor_file;
     byauthor_file.open(Resources::GetSettingFileOrLegacy(L"FilterByAuthor.txt"));
     if (byauthor_file.is_open()) {
         byauthor_file.get(byauthor_buf, FILTER_BUF_SIZE, '\0');
         byauthor_file.close();
-        ByAuthor_ParseBuf();
+        ParseBuffer(byauthor_buf, byauthor_words);
     }
-#endif
 }
 
 void ChatFilter::SaveSettings(SettingsDoc& doc)
@@ -877,6 +890,12 @@ void ChatFilter::SaveSettings(SettingsDoc& doc)
         bycontent_filedirty = true;
     }
 
+    if (timer_parse_authors) {
+        timer_parse_authors = 0;
+        ParseBuffer(byauthor_buf, byauthor_words);
+        byauthor_filedirty = true;
+    }
+
     if (bycontent_filedirty || GWToolbox::SettingsFolderChanged()) {
         std::ofstream file1;
         file1.open(Resources::GetSettingFile(L"FilterByContent.txt"));
@@ -893,8 +912,7 @@ void ChatFilter::SaveSettings(SettingsDoc& doc)
         bycontent_filedirty = false;
     }
 
-#ifdef EXTENDED_IGNORE_LIST
-    if (byauthor_filedirty) {
+    if (byauthor_filedirty || GWToolbox::SettingsFolderChanged()) {
         std::ofstream byauthor_file;
         byauthor_file.open(Resources::GetSettingFile(L"FilterByAuthor.txt"));
         if (byauthor_file.is_open()) {
@@ -903,7 +921,6 @@ void ChatFilter::SaveSettings(SettingsDoc& doc)
             byauthor_filedirty = false;
         }
     }
-#endif
 }
 
 void ChatFilter::DrawSettingsInternal()
@@ -1050,18 +1067,14 @@ void ChatFilter::DrawSettingsInternal()
     }
     ImGui::Unindent();
 
-#ifdef EXTENDED_IGNORE_LIST
     ImGui::Separator();
-    ImGui::Checkbox("Hide any messages from: ", &messagebyauthor);
+    ImGui::Checkbox("Hide any messages from these players:", &settings.messagebyauthor);
     ImGui::Indent();
-    ImGui::TextDisabled("(Each in a separate line)");
-    ImGui::TextDisabled("(Not implemented)");
+    ImGui::TextDisabled("(One player name per line. Not case sensitive. Also hides their Kamadan/Ascalon trade chat.)");
     if (ImGui::InputTextMultiline("##byauthorfilter", byauthor_buf, FILTER_BUF_SIZE, ImVec2(-1.0f, 0.0f))) {
-        ByAuthor_ParseBuf();
-        byauthor_filedirty = true;
+        timer_parse_authors = GetTickCount() + NOISE_REDUCTION_DELAY_MS;
     }
     ImGui::Unindent();
-#endif // EXTENDED_IGNORE_LIST
 }
 
 void ChatFilter::Update(const float)
@@ -1077,5 +1090,11 @@ void ChatFilter::Update(const float)
         timer_parse_regexes = 0;
         ParseBuffer(bycontent_regex_buf, bycontent_regex);
         bycontent_filedirty = true;
+    }
+
+    if (timer_parse_authors && timer_parse_authors < timestamp) {
+        timer_parse_authors = 0;
+        ParseBuffer(byauthor_buf, byauthor_words);
+        byauthor_filedirty = true;
     }
 }

--- a/GWToolboxdll/Modules/ChatFilter.h
+++ b/GWToolboxdll/Modules/ChatFilter.h
@@ -57,6 +57,7 @@ public:
         bool item_already_identified = false;
 
         bool messagebycontent = false;
+        bool messagebyauthor = false;
         // Which channels to filter.
         bool filter_channel_local = true;
         bool filter_channel_guild = false;
@@ -69,6 +70,8 @@ public:
     void Initialize() override;
     void Terminate() override;
     static void BlockMessageForMs(const wchar_t* message_contains, clock_t ms);
+    // True if the user has added this player to the "Hide messages from" block list.
+    static bool IsSenderBlocked(const std::wstring& sender);
     void LoadSettings(SettingsDoc& doc, ToolboxIni* legacy) override;
     void SaveSettings(SettingsDoc& doc) override;
     void DrawSettingsInternal() override;

--- a/GWToolboxdll/Windows/TradeWindow.cpp
+++ b/GWToolboxdll/Windows/TradeWindow.cpp
@@ -22,6 +22,7 @@
 #include <Utils/RateLimiter.h>
 #include <CircurlarBuffer.h>
 
+#include <Modules/ChatFilter.h>
 #include <Modules/Resources.h>
 #include <Windows/FriendListWindow.h>
 #include <Windows/TradeWindow.h>
@@ -394,6 +395,9 @@ void TradeWindow::fetch()
                 messages.add(msg);
                 if (print_search_results && i < 12) {
                     std::wstring name_ws = TextUtils::StringToWString(msg.name);
+                    if (ChatFilter::IsSenderBlocked(name_ws)) {
+                        continue; // Skip search results from blocked players
+                    }
                     std::wstring msg_ws = TextUtils::StringToWString(msg.message);
                     time_t ts = msg.timestamp;
                     tm* local_tm = localtime(&ts);
@@ -440,8 +444,8 @@ void TradeWindow::fetch()
 
         if (print_message) {
             std::wstring name_ws = TextUtils::StringToWString(msg.name);
-            if (FriendListWindow::GetIsPlayerIgnored(name_ws)) {
-                return; // Skip messages from ignored players
+            if (FriendListWindow::GetIsPlayerIgnored(name_ws) || ChatFilter::IsSenderBlocked(name_ws)) {
+                return; // Skip messages from ignored or blocked players
             }
             std::wstring msg_ws = std::format(L"<c=#f96677><quote>{}",TextUtils::StringToWString(msg.message));
             external_trade_message = true;


### PR DESCRIPTION
## What

Adds a **"Hide any messages from these players"** block list to **Chat Settings** — one player name per line, case- and diacritic-insensitive. Asked for in Discord (filtering specific Kamadan trade sellers, since the in-game ignore list is capped at 20).

## How

- **`ChatFilter`** now owns a user-editable name list (`byauthor_words`), persisted to `FilterByAuthor.txt` and parsed with the same noise-reduction/normalisation pipeline as the existing by-content filter.
- It's folded into `ShouldIgnoreBySender()`, so **all normal in-game chat** that already runs through that check (local/whisper/trade via `kPlayerChatMessage`, etc.) is covered automatically — no new packet parsing.
- The **Kamadan/Ascalon trade feed** is injected by `TradeWindow` from an external websocket, so it never flows through the in-game sender path and can't be caught by the `ChatFilter` hook. `TradeWindow` already self-filters by the ignore list before writing to chat, so a new public `ChatFilter::IsSenderBlocked()` check is added at the same two write sites (streamed alerts + printed search results).
- Revives the previously dormant `EXTENDED_IGNORE_LIST` scaffold (was `#ifdef`'d out and marked "Not implemented").

## Notes / limitations

- The block list only applies to **named** senders — same limitation as the existing ignore-by-sender path. Anonymous/system-channel lines have no sender to match.
- Matching is **exact name** (case/diacritic-insensitive), not substring, so blocking `Bob` won't catch `Bobby`.
- I deliberately did **not** refactor GWCA's `WriteChat` routing; mirroring `TradeWindow`'s existing ignore-list check at the source is lower-risk and keeps a single list/UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)