### PR TITLE
feat(pathing): embed portal_connections.json in the DLL as a resource

### DIFF
--- a/GWToolboxdll/CMakeLists.txt
+++ b/GWToolboxdll/CMakeLists.txt
@@ -151,14 +151,3 @@ add_custom_command(TARGET GWToolboxdll POST_BUILD
     COMMENT "Compressing PDB for distribution (RelWithDebInfo only)"
     VERBATIM
 )
-
-# Stage portal_connections.json next to the built DLL. PathfindingWindow.cpp
-# resolves the path via GetModuleFileName + sibling lookup, so the JSON has to
-# live in the same directory as GWToolboxdll.dll at runtime.
-add_custom_command(TARGET GWToolboxdll POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${CMAKE_CURRENT_SOURCE_DIR}/Windows/Pathfinding/portal_connections.json"
-            "$<TARGET_FILE_DIR:GWToolboxdll>/portal_connections.json"
-    COMMENT "Staging portal_connections.json next to GWToolboxdll.dll"
-    VERBATIM
-)

--- a/GWToolboxdll/GWToolbox.rc
+++ b/GWToolboxdll/GWToolbox.rc
@@ -97,6 +97,7 @@ END
 //
 
 IDR_GWCA_DLL            RCDATA                  "..\\Dependencies\\GWCA\\bin\\gwca.dll"
+IDR_PORTAL_CONNECTIONS_JSON RCDATA              "Windows\\Pathfinding\\portal_connections.json"
 
 #endif    // English (United Kingdom) resources
 /////////////////////////////////////////////////////////////////////////////

--- a/GWToolboxdll/Windows/Pathfinding/PathfindingWindow.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/PathfindingWindow.cpp
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <numeric>
 
+#include <EmbeddedResource.h>
 #include <GWToolbox.h>
 #include <ImGuiAddons.h>
 #include <Utils/EncString.h>
@@ -41,6 +42,7 @@
 #include "PathingMapDataLoader.h"
 #include "PortalConnections.h"
 #include "maps_constant_data.h"
+#include "resource.h"
 
 #include <GWCA/Context/WorldContext.h>
 #include <Utils/ToolboxUtils.h>
@@ -298,7 +300,6 @@ namespace {
 
     // Portal connection editor
     Pathing::PortalConnections portal_connections;
-    std::string portal_connections_path;
 
     struct EditorEndpoint {
         GW::Constants::MapID map_id = GW::Constants::MapID::None;
@@ -431,23 +432,6 @@ namespace {
             saved_connection_lines.push_back(line);
         }
     }
-
-    void InitPortalConnectionsPath()
-    {
-        if (!portal_connections_path.empty()) return;
-        // Resolve the path next to GWToolboxdll.dll. The portal_connections.json
-        // resource is committed in the repo at
-        //   GWToolboxdll/Windows/Pathfinding/portal_connections.json
-        // and copied next to the built DLL by a CMake POST_BUILD step.
-        wchar_t dll_path[MAX_PATH];
-        if (GetModuleFileNameW(GWToolbox::GetDLLModule(), dll_path, _countof(dll_path)) == 0) {
-            return;
-        }
-        std::filesystem::path p(dll_path);
-        p.replace_filename(L"portal_connections.json");
-        portal_connections_path = p.string();
-    }
-
 
     // LoadAndShowMapsAtWorldPos defined after anonymous namespace
 
@@ -3072,8 +3056,16 @@ void PathfindingWindow::Initialize()
     BuildMapFileHashLookup();
     RegisterUIMessageCallback(&gw_ui_hookentry, GW::UI::UIMessage::kLoadMapContext, OnUIMessage, 0x4000);
 
-    // Load saved portal connections (drawing deferred until map is ready)
-    InitPortalConnectionsPath();
-    portal_connections.Load(portal_connections_path);
+    // Load portal connections from the JSON embedded in the DLL as an RCDATA
+    // resource (drawing deferred until map is ready). Shipping it inside the DLL
+    // avoids the file having to sit next to GWToolboxdll.dll at runtime.
+    const EmbeddedResource portal_json(IDR_PORTAL_CONNECTIONS_JSON, RT_RCDATA, GWToolbox::GetDLLModule());
+    if (portal_json.data() && portal_json.size()) {
+        portal_connections.LoadFromMemory(
+            static_cast<const char*>(portal_json.data()), portal_json.size(), "<embedded resource>");
+    }
+    else {
+        Log::Error("Failed to load embedded portal connections resource");
+    }
     pending_connection_lines_update = true;
 }

--- a/GWToolboxdll/Windows/Pathfinding/PortalConnections.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/PortalConnections.cpp
@@ -145,25 +145,31 @@ namespace Pathing {
 
     bool PortalConnections::Load(const std::string& path)
     {
+        std::ifstream f(path);
+        if (!f.is_open()) {
+            Log::Error("Could not open portal connections file (%s)",
+                path.empty() ? "<empty path>" : path.c_str());
+            return false;
+        }
+        std::ostringstream oss;
+        oss << f.rdbuf();
+        const std::string buf = oss.str();
+        return LoadFromMemory(buf.data(), buf.size(), path);
+    }
+
+    bool PortalConnections::LoadFromMemory(const char* data, size_t size, const std::string& source)
+    {
         try {
-            std::ifstream f(path);
-            if (!f.is_open()) {
-                Log::Error("Could not open portal connections file (%s)",
-                    path.empty() ? "<empty path>" : path.c_str());
-                return false;
-            }
-            std::ostringstream oss;
-            oss << f.rdbuf();
-            const std::string buf = oss.str();
+            const std::string buf(data, size);
 
             glz::generic j;
             if (auto ec = glz::read_json(j, buf); ec) {
-                Log::Error("Failed to parse portal connections JSON (%s)", path.c_str());
+                Log::Error("Failed to parse portal connections JSON (%s)", source.c_str());
                 return false;
             }
             if (!j.contains("connections") || !j.at("connections").is_array()) {
                 connections.clear();
-                Log::Info("Portal connections file has no \"connections\" array (%s)", path.c_str());
+                Log::Info("Portal connections file has no \"connections\" array (%s)", source.c_str());
                 return true;
             }
 
@@ -234,11 +240,11 @@ namespace Pathing {
                 }
                 if (!has_reverse) connections.push_back(MakeReverse(connections[i]));
             }
-            Log::Info("Loaded %d portal connections from %s", (int)connections.size(), path.c_str());
+            Log::Info("Loaded %d portal connections from %s", (int)connections.size(), source.c_str());
             return true;
         }
         catch (...) {
-            Log::Error("Failed to load portal connections from %s", path.c_str());
+            Log::Error("Failed to load portal connections from %s", source.c_str());
             return false;
         }
     }

--- a/GWToolboxdll/Windows/Pathfinding/PortalConnections.h
+++ b/GWToolboxdll/Windows/Pathfinding/PortalConnections.h
@@ -66,6 +66,8 @@ namespace Pathing {
         void Remove(size_t index);
         bool Save(const std::string& path) const;
         bool Load(const std::string& path);
+        // Parse connections from an in-memory JSON buffer (e.g. an embedded resource).
+        bool LoadFromMemory(const char* data, size_t size, const std::string& source = "<memory>");
         void Clear();
 
         const std::vector<PortalConnection>& GetAll() const { return connections; }

--- a/GWToolboxdll/resource.h
+++ b/GWToolboxdll/resource.h
@@ -4,12 +4,13 @@
 //
 
 #define IDR_GWCA_DLL                                        154
+#define IDR_PORTAL_CONNECTIONS_JSON                         155
 
 // Next default values for new objects
 //
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        155
+#define _APS_NEXT_RESOURCE_VALUE        156
 #define _APS_NEXT_COMMAND_VALUE         40001
 #define _APS_NEXT_CONTROL_VALUE         1001
 #define _APS_NEXT_SYMED_VALUE           101


### PR DESCRIPTION
## What

Ships the portal connection data **inside GWToolboxdll.dll** as an `RCDATA` resource instead of staging it as a sibling file next to the DLL.

## Why

In 8.26, users were seeing **"Could not open portal connections file (…)"** on startup whenever `portal_connections.json` wasn't deployed next to `GWToolboxdll.dll` (stale/partial installs, manually-updated DLL, etc.). The file was only copied alongside the DLL by a CMake POST_BUILD step, so any install that delivered just the DLL hit the error and lost the map-travel routing data. Embedding it in the DLL makes the data always available and removes the failure mode.

## Changes

- `resource.h` / `GWToolbox.rc`: add `IDR_PORTAL_CONNECTIONS_JSON` RCDATA entry pointing at `Windows\Pathfinding\portal_connections.json`.
- `PortalConnections`: new `LoadFromMemory(data, size, source)` that parses from an in-memory buffer; `Load(path)` now reads the file and delegates to it (shared parse/logging).
- `PathfindingWindow::Initialize`: load the embedded resource via `EmbeddedResource` (mirrors how the bundled `gwca.dll` is loaded), dropping the `GetModuleFileName` sibling-path lookup and `InitPortalConnectionsPath`.
- `CMakeLists.txt`: remove the POST_BUILD step that copied the JSON next to the DLL — no longer needed.

The JSON stays committed at `GWToolboxdll/Windows/Pathfinding/portal_connections.json` as the resource source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)