### PR TITLE
fix(overhead): suppress zero combined floater as noise

### DIFF
--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -982,6 +982,8 @@ namespace {
                         const auto context = (int*)GW::UI::GetFrameContext(existing);
                         packet->amount += context[0x10];
                         GW::UI::DestroyUIComponent(existing);
+                        // A combined total of zero (e.g. damage cancelled out by a heal) is just noise
+                        status->blocked |= packet->amount == 0 && packet->h0004 != 2;
                     }
                 }
             } break;


### PR DESCRIPTION
When combining overhead numbers (the *Combine floating numbers above character* setting), a damage hit cancelled out by a heal — or overkill adjustments — can sum to **0**, leaving a meaningless `0` floater above the agent. As Jon put it, "showing zero on the damage monitor is just extra noise."

This blocks the combined message when the total comes to zero for damage/heal/energy numbers (`h0004 != 2`, so XP/faction gain floaters are unaffected). The already-rendered floater was destroyed during the combine step, so blocking the new one leaves nothing on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)