### PR TITLE
fix(damage): don't render zero damage/heal on party monitor

### DIFF
--- a/GWToolboxdll/Widgets/PartyDamage.cpp
+++ b/GWToolboxdll/Widgets/PartyDamage.cpp
@@ -684,7 +684,7 @@ void PartyDamage::Draw(IDirect3DDevice9*)
             const auto text_height = ImGui::GetTextLineHeight();
             const auto text_y = damage_top_left.y + (row_height - text_height) / 2;
 
-            if (settings.show_damage) {
+            if (settings.show_damage && entry->damage > 0) {
                 // Damage text
                 if (damage_float < 1000.f) {
                     snprintf(buffer, buffer_size, "%.0f", damage_float);
@@ -709,7 +709,7 @@ void PartyDamage::Draw(IDirect3DDevice9*)
                 }
             }
 
-            if (settings.show_healing) {
+            if (settings.show_healing && entry->healing > 0) {
                 // Healing text
                 const float healing_float = static_cast<float>(entry->healing);
                 if (healing_float < 1000.f) {


### PR DESCRIPTION
On the **Damage** widget (the numbers overlaid on party health bars), a member who has dealt no damage — or done no healing — still showed a bare `0` on their row. As discussed, that zero is just extra noise.

This skips rendering the damage/heal number (and its percentage) when the value is zero. The row background and bars are unaffected; a zero-width bar already drew nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)