### PR TITLE
fix(pathing): only show pathing/portal errors in chat on debug builds

### DIFF
--- a/GWToolboxdll/Windows/Pathfinding/PathfindingWindow.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/PathfindingWindow.cpp
@@ -38,6 +38,7 @@
 #include <Windows/Pathfinding/Pathing.h>
 
 #include "OpenTyriaPathfinder.h"
+#include "PathingLog.h"
 #include "PathingMapData.h"
 #include "PathingMapDataLoader.h"
 #include "PortalConnections.h"
@@ -50,8 +51,9 @@
 #include <Widgets/WorldMapWidget.h>
 
 // Define PATHING_VERBOSE to re-enable pathfinding's per-frame Log::Info chatter
-// ([GetAdj]/[Dijkstra]/[CacheTrace]/[AStar:los|ok]/etc.). Errors and warnings
-// always log; only Log::Info inside this file is silenced when not defined.
+// ([GetAdj]/[Dijkstra]/[CacheTrace]/[AStar:los|ok]/etc.). PATH_LOG_ERROR/WARNING
+// (see PathingLog.h) only reach chat in debug; only Log::Info inside this file is
+// silenced when PATHING_VERBOSE is not defined.
 // #define PATHING_VERBOSE 1
 #ifdef PATHING_VERBOSE
 #define PATH_LOG_INFO(...) Log::Info(__VA_ARGS__)
@@ -61,14 +63,6 @@
 // `caller` arg of EnsureLightweightMapInfo exist only to be formatted into
 // PATH_LOG_INFO; with logging compiled out they're unused.
 #pragma warning(disable : 4189 4100)
-#endif
-
-// Pathing errors are expected for unreachable markers etc. — only surface them in chat
-// in debug; in release they still go to the log file.
-#ifdef _DEBUG
-#define PATH_LOG_ERROR(...) Log::Error(__VA_ARGS__)
-#else
-#define PATH_LOG_ERROR(...) Log::Log(__VA_ARGS__)
 #endif
 
 namespace {
@@ -1758,14 +1752,14 @@ namespace {
         }
         if (!mp) {
             float fb = euclidean_min();
-            Log::Warning("[Trapezoid] map %d->%d: no MilePath → Euclidean=%.0f", (int)owner_map, (int)other_map, fb);
+            PATH_LOG_WARNING("[Trapezoid] map %d->%d: no MilePath → Euclidean=%.0f", (int)owner_map, (int)other_map, fb);
             portal_walk_cache[key] = fb;
             return fb;
         }
         const Pathing::PathingMapData* data = mp->GetMapData();
         if (!data || !data->IsValid()) {
             float fb = euclidean_min();
-            Log::Warning("[Trapezoid] map %d->%d: PathingMapData missing/invalid → Euclidean=%.0f", (int)owner_map, (int)other_map, fb);
+            PATH_LOG_WARNING("[Trapezoid] map %d->%d: PathingMapData missing/invalid → Euclidean=%.0f", (int)owner_map, (int)other_map, fb);
             portal_walk_cache[key] = fb;
             return fb;
         }
@@ -1774,7 +1768,7 @@ namespace {
         const uint32_t fh = GetMapFileId(owner_map);
         if (!fh) {
             float fb = euclidean_min();
-            Log::Warning("[Trapezoid] map %d->%d: no file_hash → Euclidean=%.0f", (int)owner_map, (int)other_map, fb);
+            PATH_LOG_WARNING("[Trapezoid] map %d->%d: no file_hash → Euclidean=%.0f", (int)owner_map, (int)other_map, fb);
             portal_walk_cache[key] = fb;
             return fb;
         }
@@ -2307,7 +2301,7 @@ namespace {
                         auto map_g = resolve_graph(map_id);
                         if (seg > 0) {
                             auto prev_g = resolve_graph(route[seg - 1]);
-                            Log::Warning("AStar failed on map %d, blacklisting edge %d->%d (graph %d->%d)", (int)map_id, (int)route[seg - 1], (int)map_id, (int)prev_g, (int)map_g);
+                            PATH_LOG_WARNING("AStar failed on map %d, blacklisting edge %d->%d (graph %d->%d)", (int)map_id, (int)route[seg - 1], (int)map_id, (int)prev_g, (int)map_g);
                             blacklisted_edges.insert(EdgeKey(prev_g, map_g));
                             blacklisted_edges.insert(EdgeKey(map_g, prev_g));
                         }
@@ -2530,15 +2524,15 @@ namespace {
             }
             if (runtime_fid && constant_fid && runtime_fid != constant_fid) {
                 file_id_mismatch_warned.insert((uint32_t)map_id);
-                Log::Warning("[FileId] map %d: runtime=0x%X constant=0x%X MISMATCH", (int)map_id, runtime_fid, constant_fid);
+                PATH_LOG_WARNING("[FileId] map %d: runtime=0x%X constant=0x%X MISMATCH", (int)map_id, runtime_fid, constant_fid);
             }
             else if (runtime_fid && !constant_fid) {
                 file_id_mismatch_warned.insert((uint32_t)map_id);
-                Log::Warning("[FileId] map %d: runtime=0x%X but MISSING from maps_constant_data.h", (int)map_id, runtime_fid);
+                PATH_LOG_WARNING("[FileId] map %d: runtime=0x%X but MISSING from maps_constant_data.h", (int)map_id, runtime_fid);
             }
             else if (!runtime_fid && !constant_fid) {
                 file_id_mismatch_warned.insert((uint32_t)map_id);
-                Log::Warning("[FileId] map %d: no file_id from runtime or constant data", (int)map_id);
+                PATH_LOG_WARNING("[FileId] map %d: no file_id from runtime or constant data", (int)map_id);
             }
         }
 
@@ -3065,7 +3059,7 @@ void PathfindingWindow::Initialize()
             static_cast<const char*>(portal_json.data()), portal_json.size(), "<embedded resource>");
     }
     else {
-        Log::Error("Failed to load embedded portal connections resource");
+        PATH_LOG_ERROR("Failed to load embedded portal connections resource");
     }
     pending_connection_lines_update = true;
 }

--- a/GWToolboxdll/Windows/Pathfinding/Pathing.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/Pathing.cpp
@@ -7,6 +7,7 @@
 #include <Logger.h>
 #include "MathUtility.h"
 #include "Pathing.h"
+#include "PathingLog.h"
 #include "PathingMapDataLoader.h"
 
 // Define PATHING_VERBOSE to re-enable per-stage Log::Info chatter
@@ -19,13 +20,6 @@
 #define PATH_LOG_INFO(...) ((void)0)
 // log_timings(tag) and similar take args only used by the logger.
 #pragma warning(disable: 4189 4100)
-#endif
-
-// Pathing errors only reach chat in debug; in release they go to the log file.
-#ifdef _DEBUG
-#define PATH_LOG_ERROR(...) Log::Error(__VA_ARGS__)
-#else
-#define PATH_LOG_ERROR(...) Log::Log(__VA_ARGS__)
 #endif
 
 namespace {

--- a/GWToolboxdll/Windows/Pathfinding/PathingLog.h
+++ b/GWToolboxdll/Windows/Pathfinding/PathingLog.h
@@ -3,13 +3,19 @@
 #include <Logger.h>
 
 // Pathing failures (unreachable markers, missing/mismatched DAT data, malformed
-// portal connection data, etc.) are expected during normal play and must not
-// spam the in-game chat. In debug builds they surface via Log::Error/Log::Warning
-// so developers see them; in release they go to the log file only.
+// portal connection data, etc.) and one-shot notices (e.g. "loaded N portal
+// connections") are expected during normal play and must not spam the in-game
+// chat. In debug builds they surface via Log::Error/Warning/Info so developers
+// see them; in release they go to the log file only.
+//
+// Note: this is distinct from PATH_LOG_INFO, which guards high-volume per-frame
+// pathfinding chatter and is compiled out entirely unless PATHING_VERBOSE is set.
 #ifdef _DEBUG
 #define PATH_LOG_ERROR(...) Log::Error(__VA_ARGS__)
 #define PATH_LOG_WARNING(...) Log::Warning(__VA_ARGS__)
+#define PATH_LOG_NOTICE(...) Log::Info(__VA_ARGS__)
 #else
 #define PATH_LOG_ERROR(...) Log::Log(__VA_ARGS__)
 #define PATH_LOG_WARNING(...) Log::Log(__VA_ARGS__)
+#define PATH_LOG_NOTICE(...) Log::Log(__VA_ARGS__)
 #endif

--- a/GWToolboxdll/Windows/Pathfinding/PathingLog.h
+++ b/GWToolboxdll/Windows/Pathfinding/PathingLog.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <Logger.h>
+
+// Pathing failures (unreachable markers, missing/mismatched DAT data, malformed
+// portal connection data, etc.) are expected during normal play and must not
+// spam the in-game chat. In debug builds they surface via Log::Error/Log::Warning
+// so developers see them; in release they go to the log file only.
+#ifdef _DEBUG
+#define PATH_LOG_ERROR(...) Log::Error(__VA_ARGS__)
+#define PATH_LOG_WARNING(...) Log::Warning(__VA_ARGS__)
+#else
+#define PATH_LOG_ERROR(...) Log::Log(__VA_ARGS__)
+#define PATH_LOG_WARNING(...) Log::Log(__VA_ARGS__)
+#endif

--- a/GWToolboxdll/Windows/Pathfinding/PortalConnections.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/PortalConnections.cpp
@@ -135,7 +135,7 @@ namespace Pathing {
             std::ofstream f(path);
             if (!f.is_open()) return false;
             f << str;
-            Log::Info("Saved %d portal connections to %s", (int)written, path.c_str());
+            PATH_LOG_NOTICE("Saved %d portal connections to %s", (int)written, path.c_str());
             return true;
         }
         catch (...) {
@@ -170,7 +170,7 @@ namespace Pathing {
             }
             if (!j.contains("connections") || !j.at("connections").is_array()) {
                 connections.clear();
-                Log::Info("Portal connections file has no \"connections\" array (%s)", source.c_str());
+                PATH_LOG_NOTICE("Portal connections file has no \"connections\" array (%s)", source.c_str());
                 return true;
             }
 
@@ -241,7 +241,7 @@ namespace Pathing {
                 }
                 if (!has_reverse) connections.push_back(MakeReverse(connections[i]));
             }
-            Log::Info("Loaded %d portal connections from %s", (int)connections.size(), source.c_str());
+            PATH_LOG_NOTICE("Loaded %d portal connections from %s", (int)connections.size(), source.c_str());
             return true;
         }
         catch (...) {

--- a/GWToolboxdll/Windows/Pathfinding/PortalConnections.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/PortalConnections.cpp
@@ -8,6 +8,7 @@
 
 #include <Logger.h>
 #include <Utils/TextUtils.h>
+#include "PathingLog.h"
 
 namespace Pathing {
 
@@ -138,7 +139,7 @@ namespace Pathing {
             return true;
         }
         catch (...) {
-            Log::Error("Failed to save portal connections");
+            PATH_LOG_ERROR("Failed to save portal connections");
             return false;
         }
     }
@@ -147,7 +148,7 @@ namespace Pathing {
     {
         std::ifstream f(path);
         if (!f.is_open()) {
-            Log::Error("Could not open portal connections file (%s)",
+            PATH_LOG_ERROR("Could not open portal connections file (%s)",
                 path.empty() ? "<empty path>" : path.c_str());
             return false;
         }
@@ -164,7 +165,7 @@ namespace Pathing {
 
             glz::generic j;
             if (auto ec = glz::read_json(j, buf); ec) {
-                Log::Error("Failed to parse portal connections JSON (%s)", source.c_str());
+                PATH_LOG_ERROR("Failed to parse portal connections JSON (%s)", source.c_str());
                 return false;
             }
             if (!j.contains("connections") || !j.at("connections").is_array()) {
@@ -244,7 +245,7 @@ namespace Pathing {
             return true;
         }
         catch (...) {
-            Log::Error("Failed to load portal connections from %s", source.c_str());
+            PATH_LOG_ERROR("Failed to load portal connections from %s", source.c_str());
             return false;
         }
     }


### PR DESCRIPTION
## What

A user reported the new build showing **"can not open portal connections file"** in-game on startup. Pathing/portal-connection failures were logged via `Log::Error`/`Log::Warning`, which render as transient **in-game chat** messages in release builds. These failures are expected during normal play (unreachable markers, missing/mismatched DAT data, portal data that can't be parsed) and are just noise to end users.

## Change

- Route all pathing/portal error & warning logging through the debug-gated `PATH_LOG_ERROR` / `PATH_LOG_WARNING` macros — they reach chat only on `_DEBUG` builds and otherwise go to the log file.
- Consolidate the macro definition (previously duplicated in `Pathing.cpp` and `PathfindingWindow.cpp`) into a shared `PathingLog.h`, and add `PATH_LOG_WARNING`.
- Convert the remaining direct `Log::Error`/`Log::Warning` calls in `PortalConnections.cpp` and `PathfindingWindow.cpp` (`[Trapezoid]`/`[FileId]`/AStar diagnostics, embedded-resource load failure).

## Graceful handling

All affected failure paths already degrade safely — `Initialize()` continues with empty portal connections, parse failures return `false` without partial corruption, and the trapezoid/file-id paths fall back to a Euclidean estimate. No behavioural change other than where the messages go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)