### PR TITLE
feat(site): auto-focus search input when the dialog opens

### DIFF
--- a/site/src/components/Search.tsx
+++ b/site/src/components/Search.tsx
@@ -64,6 +64,20 @@ export default function Search({ variant = 'button', placeholder = 'Search…' }
     })();
   }, [open]);
 
+  useEffect(() => {
+    if (!open) return;
+    // Pagefind builds its input asynchronously on first open, so poll a frame
+    // at a time until it exists before focusing.
+    let raf = 0;
+    const focus = () => {
+      const input = mountRef.current?.querySelector<HTMLInputElement>('input.pagefind-ui__search-input');
+      if (input) input.focus();
+      else raf = requestAnimationFrame(focus);
+    };
+    raf = requestAnimationFrame(focus);
+    return () => cancelAnimationFrame(raf);
+  }, [open]);
+
   const searchIcon = (
     <svg viewBox="0 0 16 16" className="fill-current" aria-hidden="true">
       <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z" />


### PR DESCRIPTION
## What

Auto-focus Pagefind's search input each time the docs-site search dialog opens (via the header/hero button, `/`, or `⌘K`), so users can type their query immediately without an extra click into the field.

## How

Added a small effect keyed on `open` in `Search.tsx`. Because Pagefind builds its input asynchronously on the first open, it polls a frame at a time with `requestAnimationFrame` until `input.pagefind-ui__search-input` exists, then focuses it. Cleans up the pending frame on close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)