### PR TITLE
feat(launcher): self-update GWToolbox.exe from Github

### DIFF
--- a/GWToolbox/CMakeLists.txt
+++ b/GWToolbox/CMakeLists.txt
@@ -24,4 +24,5 @@ target_link_libraries(GWToolbox PRIVATE
     glaze::glaze
 
     version.lib # for GetFileVersionInfo
+    bcrypt.lib # for sha256 of the launcher exe
     )

--- a/GWToolbox/Download.cpp
+++ b/GWToolbox/Download.cpp
@@ -1,5 +1,7 @@
 #include "stdafx.h"
 
+#include <bcrypt.h>
+
 #include <File.h>
 #include <Path.h>
 
@@ -63,6 +65,7 @@ struct Asset {
     std::string name{};
     size_t size = 0;
     std::string browser_download_url{};
+    std::string digest{}; // e.g. "sha256:<hex>"; absent on older releases
 };
 
 struct Release {
@@ -275,8 +278,55 @@ static bool UpdateExe(const std::filesystem::path& exe_path, const std::string& 
     return true;
 }
 
+// Lowercase hex sha256 of a file, streamed so we don't hold the whole exe in memory; empty on failure.
+static std::string Sha256Hex(const std::filesystem::path& path)
+{
+    BCRYPT_ALG_HANDLE alg = nullptr;
+    if (BCryptOpenAlgorithmProvider(&alg, BCRYPT_SHA256_ALGORITHM, nullptr, 0) != 0)
+        return {};
+
+    std::string result;
+    BCRYPT_HASH_HANDLE hash = nullptr;
+    if (BCryptCreateHash(alg, &hash, nullptr, 0, nullptr, 0, 0) == 0) {
+        std::ifstream file(path, std::ios::binary);
+        bool ok = file.is_open();
+        char buffer[64 * 1024];
+        while (ok) {
+            file.read(buffer, sizeof(buffer));
+            const std::streamsize n = file.gcount();
+            if (n <= 0)
+                break;
+            ok = BCryptHashData(hash, reinterpret_cast<PUCHAR>(buffer), static_cast<ULONG>(n), 0) == 0;
+        }
+
+        unsigned char digest[32];
+        if (ok && BCryptFinishHash(hash, digest, sizeof(digest), 0) == 0) {
+            char hex[2 * sizeof(digest) + 1];
+            for (size_t i = 0; i < sizeof(digest); ++i)
+                sprintf_s(hex + i * 2, 3, "%02x", digest[i]);
+            result = hex;
+        }
+        BCryptDestroyHash(hash);
+    }
+    BCryptCloseAlgorithmProvider(alg, 0);
+    return result;
+}
+
+// True if the installed exe already matches the release asset. Prefers Github's sha256 digest (exact identity)
+// and falls back to file size when the digest is absent or the local file can't be hashed.
+static bool ExeMatchesAsset(const std::filesystem::path& exe_path, const Asset& asset, size_t exe_size)
+{
+    constexpr std::string_view sha_prefix = "sha256:";
+    if (asset.digest.starts_with(sha_prefix)) {
+        const std::string local = Sha256Hex(exe_path);
+        if (!local.empty())
+            return local == asset.digest.substr(sha_prefix.size());
+    }
+    return exe_size == asset.size;
+}
+
 // Runs on a background thread so it never delays injection. Not every release ships a GWToolbox.exe, so we scan
-// the release list newest-first for the most recent one that does, and offer it if its size differs from ours.
+// the release list newest-first for the most recent one that does, and offer it if it differs from ours.
 void CheckForExeUpdate()
 {
     std::filesystem::path exe_path;
@@ -309,8 +359,8 @@ void CheckForExeUpdate()
 
     std::error_code ec;
     const auto current_size = std::filesystem::file_size(exe_path, ec);
-    if (ec || current_size == exe_asset->size)
-        return; // size is the only signal Github gives us without downloading; same size means up to date
+    if (ec || ExeMatchesAsset(exe_path, *exe_asset, current_size))
+        return; // already running the released exe
 
     const std::wstring tag_w(tag_name.begin(), tag_name.end());
     const std::wstring prompt = std::format(

--- a/GWToolbox/Download.cpp
+++ b/GWToolbox/Download.cpp
@@ -30,13 +30,13 @@ private: // From AsyncRestClient
     std::atomic<size_t> m_DownloadLength;
 };
 
-bool Download(std::string& content, const char* url)
+bool Download(std::string& content, const char* url, int timeout_sec = 5)
 {
     RestClient client;
     client.SetUrl(url);
     client.SetFollowLocation(true);
     client.SetVerifyPeer(false);
-    client.SetTimeoutSec(5);
+    client.SetTimeoutSec(timeout_sec);
     client.SetUserAgent("curl/7.71.1");
     client.Execute();
 
@@ -80,6 +80,16 @@ static bool ParseRelease(const std::string& json_text, Release* release)
     }
     if (release->tag_name.empty() || release->assets.empty()) {
         fprintf(stderr, "Required fields missing in '%s'\n", json_text.c_str());
+        return false;
+    }
+    return true;
+}
+
+static bool ParseReleases(const std::string& json_text, std::vector<Release>& releases)
+{
+    constexpr glz::opts opts{.error_on_unknown_keys = false};
+    if (auto ec = glz::read<opts>(releases, json_text); ec) {
+        fprintf(stderr, "Failed to parse releases list\n");
         return false;
     }
     return true;
@@ -224,6 +234,97 @@ bool DownloadWindow::DownloadAllFiles(std::wstring& error)
     }
 
     return true;
+}
+
+static constexpr wchar_t kReleasesPage[] = L"https://github.com/gwdevhub/GWToolboxpp/releases";
+
+// Windows locks a running exe against being overwritten, but still allows it to be renamed; so we move
+// the running file aside and drop the new one in its place. The new exe takes effect on the next launch.
+static bool UpdateExe(const std::filesystem::path& exe_path, const std::string& url, std::wstring& error)
+{
+    std::string data;
+    if (!Download(data, url.c_str(), 30) || data.empty())
+        return error = std::format(L"Couldn't download the update.\n\nAnti-virus software may be blocking it. "
+                                   L"Download the latest GWToolbox.exe manually from {}.", kReleasesPage), false;
+
+    auto new_path = exe_path;
+    new_path += L".new";
+    auto old_path = exe_path;
+    old_path += L".old";
+
+    if (!WriteEntireFile(new_path.wstring().c_str(), data.c_str(), data.size()))
+        return error = std::format(L"Couldn't write the update to {}.\n\nThe folder may be read-only, or anti-virus may "
+                                   L"have quarantined the file. Run GWToolbox from a writable folder, or download the "
+                                   L"latest version manually from {}.", new_path.wstring(), kReleasesPage), false;
+
+    DeleteFileW(old_path.wstring().c_str()); // leftover from a previous update, if any
+
+    if (!MoveFileW(exe_path.wstring().c_str(), old_path.wstring().c_str())) {
+        const DWORD err = GetLastError();
+        DeleteFileW(new_path.wstring().c_str());
+        return error = std::format(L"Couldn't replace GWToolbox.exe (error {}).\n\nIf it lives in a protected folder such "
+                                   L"as Program Files, run GWToolbox as administrator or move it to a normal folder. You "
+                                   L"can also download the latest version manually from {}.", err, kReleasesPage), false;
+    }
+    if (!MoveFileW(new_path.wstring().c_str(), exe_path.wstring().c_str())) {
+        const DWORD err = GetLastError();
+        MoveFileW(old_path.wstring().c_str(), exe_path.wstring().c_str()); // roll back the rename
+        return error = std::format(L"Couldn't move the update into place (error {}).\n\nDownload the latest GWToolbox.exe "
+                                   L"manually from {}.", err, kReleasesPage), false;
+    }
+    return true;
+}
+
+// Runs on a background thread so it never delays injection. Not every release ships a GWToolbox.exe, so we scan
+// the release list newest-first for the most recent one that does, and offer it if its size differs from ours.
+void CheckForExeUpdate()
+{
+    std::filesystem::path exe_path;
+    if (!PathGetExeFullPath(exe_path))
+        return;
+
+    std::string content;
+    if (!Download(content, "https://api.github.com/repos/gwdevhub/GWToolboxpp/releases?per_page=30"))
+        return; // GitHub unreachable or rate-limited; never block a launch over an update check
+
+    std::vector<Release> releases;
+    if (!ParseReleases(content, releases))
+        return;
+
+    const Asset* exe_asset = nullptr;
+    std::string tag_name;
+    for (const auto& release : releases) {
+        for (const auto& asset : release.assets) {
+            if (asset.name == "GWToolbox.exe") {
+                exe_asset = &asset;
+                tag_name = release.tag_name;
+                break;
+            }
+        }
+        if (exe_asset)
+            break;
+    }
+    if (!exe_asset || exe_asset->browser_download_url.empty())
+        return;
+
+    std::error_code ec;
+    const auto current_size = std::filesystem::file_size(exe_path, ec);
+    if (ec || current_size == exe_asset->size)
+        return; // size is the only signal Github gives us without downloading; same size means up to date
+
+    const std::wstring tag_w(tag_name.begin(), tag_name.end());
+    const std::wstring prompt = std::format(
+        L"A newer version of GWToolbox.exe ({}) is available.\n\n"
+        L"Update now? GWToolbox will replace its own program file; the new version takes effect next launch.", tag_w);
+    if (MessageBoxW(nullptr, prompt.c_str(), L"GWToolbox - Update available", MB_YESNO | MB_ICONINFORMATION | MB_TOPMOST) != IDYES)
+        return;
+
+    std::wstring error;
+    if (!UpdateExe(exe_path, exe_asset->browser_download_url, error))
+        MessageBoxW(nullptr, error.c_str(), L"GWToolbox - Update failed", MB_OK | MB_ICONERROR | MB_TOPMOST);
+    else
+        MessageBoxW(nullptr, L"GWToolbox.exe was updated. The new version will be used next time you start GWToolbox.",
+                    L"GWToolbox - Update complete", MB_OK | MB_ICONINFORMATION | MB_TOPMOST);
 }
 
 bool DownloadWindow::Create()

--- a/GWToolbox/Download.h
+++ b/GWToolbox/Download.h
@@ -5,6 +5,9 @@
 bool Download(std::string& content, const wchar_t* url);
 bool Download(const wchar_t* path_to_file, const wchar_t* url);
 
+// Checks Github for a newer GWToolbox.exe and offers to self-update. Meant to run on a background thread.
+void CheckForExeUpdate();
+
 class DownloadWindow : public Window {
 public:
     DownloadWindow() = default;

--- a/GWToolbox/Settings.cpp
+++ b/GWToolbox/Settings.cpp
@@ -19,6 +19,7 @@ void PrintUsage(const bool terminate)
 
             "    /asadmin                   GWToolbox will try to run as admin\n"
             "    /noupdate                  Won't try to update\n"
+            "    /noexecheck                Won't check Github for a newer GWToolbox.exe\n"
             "    /noinstall                 Won't try to install if missing\n"
             "    /localdll                  Check launcher directory for toolbox dll, won't try to install or update\n\n"
 
@@ -89,6 +90,9 @@ void ParseCommandLine()
         }
         else if (wcscmp(arg, L"/noupdate") == 0) {
             settings.noupdate = true;
+        }
+        else if (wcscmp(arg, L"/noexecheck") == 0) {
+            settings.noexecheck = true;
         }
         else if (wcscmp(arg, L"/help") == 0) {
             settings.help = true;

--- a/GWToolbox/Settings.h
+++ b/GWToolbox/Settings.h
@@ -11,6 +11,7 @@ struct Settings {
     bool reinstall = false;
     bool asadmin = false;
     bool noupdate = false;
+    bool noexecheck = false;
     bool noinstall = false;
     bool localdll = false;
     uint32_t pid;

--- a/GWToolbox/main.cpp
+++ b/GWToolbox/main.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 
 #include <cstdio>
+#include <thread>
 
 #include <Path.h>
 #include <RestClient.h>
@@ -120,6 +121,12 @@ static bool InjectInstalledDllInProcess(const Process* process, std::wstring& er
     return true;
 }
 
+// Joins the exe-update worker when WinMain returns, so any open update prompt is honoured before we exit.
+struct ExeUpdateChecker {
+    std::thread thread;
+    ~ExeUpdateChecker() { if (thread.joinable()) thread.join(); }
+};
+
 static bool SetProcessForeground(const Process* process)
 {
     HWND hWndIt = GetTopWindow(nullptr);
@@ -161,6 +168,11 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int n
         MessageBoxW(nullptr, L"Failed to get qualified path for logs file.", L"GWToolbox", MB_OK | MB_TOPMOST);
         return 0;
     }
+    // A previous self-update renames the old exe aside; clean it up now that it's no longer locked.
+    std::filesystem::path stale_exe = log_file_path;
+    stale_exe += L".old";
+    DeleteFileW(stale_exe.wstring().c_str());
+
     log_file_path = log_file_path.parent_path() / L"GWToolbox.error.log";
     static FILE* stream;
     if (freopen_s(&stream, log_file_path.string().c_str(), "w", stderr) != 0) {
@@ -239,6 +251,11 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int n
             return 1;
         }
     }
+
+    // Check Github for a newer launcher exe in parallel; it only ever prompts, never blocks the injection below.
+    ExeUpdateChecker exe_update_checker;
+    if (!settings.noexecheck && !settings.noupdate && !settings.localdll && !settings.quiet && !settings.pid)
+        exe_update_checker.thread = std::thread(CheckForExeUpdate);
 
     if (settings.pid) {
         if (!proc.Open(settings.pid)) {


### PR DESCRIPTION
## Problem

The launcher updates `GWToolboxdll.dll` from Github but never updates **itself**. When a release ships a new `GWToolbox.exe` (e.g. a changed character-name RVA pattern), users on an old exe get the *"Couldn't find character name RVA"* error and have to manually re-download the exe from the website. This is the root cause of the current support thread.

## What this does

- On a **background thread** (never blocks injection), checks Github for a newer `GWToolbox.exe`.
- Not every release contains an exe, so it scans the release list **newest-first** for the most recent release that ships a `GWToolbox.exe`, rather than assuming the latest release has one.
- Decides "am I up to date" by comparing the running exe to the asset. The primary signal is Github's per-asset **`sha256:` digest** (exact byte identity) — the running exe is hashed with BCrypt and compared. Falls back to **file size** when the digest is absent (older releases) or the local file can't be hashed.
- If the exe differs, it shows a **Yes/No popup** offering to update.
- On accept, it self-updates: a running exe can't overwrite itself, so it renames the running file aside (`.old`) and drops the new one in place. The new exe takes effect on the **next launch**. The `.old` file is cleaned up on the next startup.
- `/noexecheck` disables the check. It's also skipped under `/noupdate`, `/localdll`, `/quiet`, and `/pid` (the elevated re-launch).

## Failure handling

The exe self-updating is the fragile part, so each step has a targeted message with concrete help and a manual-download fallback link:

- **Download blocked** → mentions anti-virus, links the releases page.
- **Write fails** → read-only folder / AV quarantine guidance.
- **Rename fails** → protected folder (Program Files) / run-as-admin guidance; rolls back the rename if the second move fails.

## Notes / review questions

- Neither digest nor size tells us *newer* vs merely *different* — a locally-built exe will mismatch the released one and get prompted. `/noexecheck` is the escape hatch for devs. Github gives no exe version without downloading the binary, and the version isn't encoded in the release tag.
- Adds `bcrypt.lib` to the GWToolbox link libraries for the sha256.
- Could not compile here (Windows-only, 32-bit MSVC/clang-cl toolchain) — please verify the build in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)