### PR TITLE
feat(launcher): offer to restart into the updated exe

### DIFF
--- a/GWToolbox/Download.cpp
+++ b/GWToolbox/Download.cpp
@@ -9,6 +9,7 @@
 #include "Download.h"
 
 #include "Install.h"
+#include "Settings.h"
 
 class AsyncFileDownloader : public AsyncRestClient {
 public:
@@ -370,11 +371,16 @@ void CheckForExeUpdate()
         return;
 
     std::wstring error;
-    if (!UpdateExe(exe_path, exe_asset->browser_download_url, error))
+    if (!UpdateExe(exe_path, exe_asset->browser_download_url, error)) {
         MessageBoxW(nullptr, error.c_str(), L"GWToolbox - Update failed", MB_OK | MB_ICONERROR | MB_TOPMOST);
-    else
-        MessageBoxW(nullptr, L"GWToolbox.exe was updated. The new version will be used next time you start GWToolbox.",
-                    L"GWToolbox - Update complete", MB_OK | MB_ICONINFORMATION | MB_TOPMOST);
+        return;
+    }
+
+    // Relaunch into the new exe (e.g. to retry an injection the old one failed). The single OK button is the
+    // restart; we re-run from the original path, which now holds the new file.
+    MessageBoxW(nullptr, L"GWToolbox.exe was updated.\n\nClick the button below to restart the launcher and start using the new version.",
+                L"GWToolbox - Update complete", MB_OK | MB_ICONINFORMATION | MB_TOPMOST);
+    RestartWithSameArgs();
 }
 
 bool DownloadWindow::Create()


### PR DESCRIPTION
Follow-up to #2291 (the self-update was merged before this last commit landed on the branch, so it needs its own PR).

## What this does

After a successful exe self-update, shows a plain `MB_OK` box whose text — *"Click the button below to restart the launcher and start using the new version"* — implies that the OK button restarts. Since it's a single-button dialog, dismissing it always calls the existing **`RestartWithSameArgs()`**, which re-runs from the original path (now holding the freshly-installed file), so the new exe takes effect immediately.

This pairs with the RVA bug from the support thread: old exe fails to inject → background check finds the new exe → user updates → clicks OK → new exe injects correctly, in one flow.

## Notes

- Reuses `RestartWithSameArgs()` rather than re-implementing the relaunch. After the in-place swap, `GetModuleFileNameW` (inside `Restart()`) still returns the original image path, which now points at the new file, so the new exe is what gets launched.
- No new libs / no TaskDialog — just `MessageBoxW`.
- Could not compile here (Windows-only, 32-bit MSVC/clang-cl toolchain) — please verify the build in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)