### PR TITLE
refactor(launcher): single Github fetch for exe + dll update checks

### DIFF
--- a/GWToolbox/Download.cpp
+++ b/GWToolbox/Download.cpp
@@ -75,20 +75,6 @@ struct Release {
     std::vector<Asset> assets{};
 };
 
-static bool ParseRelease(const std::string& json_text, Release* release)
-{
-    constexpr glz::opts opts{.error_on_unknown_keys = false};
-    if (auto ec = glz::read<opts>(*release, json_text); ec) {
-        fprintf(stderr, "Json::parse failed\n");
-        return false;
-    }
-    if (release->tag_name.empty() || release->assets.empty()) {
-        fprintf(stderr, "Required fields missing in '%s'\n", json_text.c_str());
-        return false;
-    }
-    return true;
-}
-
 static bool ParseReleases(const std::string& json_text, std::vector<Release>& releases)
 {
     constexpr glz::opts opts{.error_on_unknown_keys = false};
@@ -97,6 +83,15 @@ static bool ParseReleases(const std::string& json_text, std::vector<Release>& re
         return false;
     }
     return true;
+}
+
+// One Github request shared by the exe and dll checks, so we only tap the (rate-limited) API once per launch.
+static bool DownloadReleases(std::vector<Release>& releases)
+{
+    std::string content;
+    if (!Download(content, "https://api.github.com/repos/gwdevhub/GWToolboxpp/releases?per_page=30"))
+        return false;
+    return ParseReleases(content, releases);
 }
 
 std::string GetDllRelease(const std::filesystem::path& dllpath)
@@ -179,30 +174,26 @@ static bool FileMatchesAsset(const std::filesystem::path& file_path, const Asset
     return file_size == asset.size;
 }
 
-bool DownloadWindow::DownloadAllFiles(std::wstring& error)
+bool DownloadWindow::DownloadDll(const std::vector<Release>& releases, std::wstring& error)
 {
     std::filesystem::path dllpath = GetInstallationDir();
     if (dllpath.empty())
         return error = L"GetInstallPath failed", false;
     dllpath = dllpath.parent_path() / "GWToolboxdll.dll";
 
-    std::string content;
-    if (!Download(content, "https://api.github.com/repos/gwdevhub/GWToolboxpp/releases/latest")) {
-        // @Remark:
-        // We may not be able to grep Github api. (For instance, if we spam it)
-        return error = L"Couldn't download the latest release of GWToolboxpp", true;
-    }
-
-    Release release;
-    if (!ParseRelease(content, &release))
-        return error = L"ParseRelease failed", false;
-
-    Asset* release_dll_asset = nullptr;
-    for (auto& asset : release.assets) {
-        if (asset.name == "GWToolbox.dll" || asset.name == "GWToolboxdll.dll") {
-            release_dll_asset = &asset;
-            break;
+    // Most recent release that ships the dll (normally the latest; scan to be safe).
+    const Release* release = nullptr;
+    const Asset* release_dll_asset = nullptr;
+    for (const auto& candidate : releases) {
+        for (const auto& asset : candidate.assets) {
+            if (asset.name == "GWToolbox.dll" || asset.name == "GWToolboxdll.dll") {
+                release = &candidate;
+                release_dll_asset = &asset;
+                break;
+            }
         }
+        if (release_dll_asset)
+            break;
     }
     if (!release_dll_asset) {
         return error = L"Failed to find dll in latest release", false;
@@ -214,7 +205,7 @@ bool DownloadWindow::DownloadAllFiles(std::wstring& error)
             return true;
         }
         const auto current_version = GetDllRelease(dllpath);
-        const auto available_version = std::regex_replace(release.tag_name, std::regex(R"([^0-9.])"), "");
+        const auto available_version = std::regex_replace(release->tag_name, std::regex(R"([^0-9.])"), "");
         if (current_version.starts_with(available_version)) {
             // NB: keeps locally-built betas (8.6 Beta1, 8.6 Beta123, ...) from being overwritten by the release.
             return true;
@@ -222,7 +213,7 @@ bool DownloadWindow::DownloadAllFiles(std::wstring& error)
     }
 
     // Convert tag_name to wstring for MessageBox
-    std::wstring tag_name_w(release.tag_name.begin(), release.tag_name.end());
+    std::wstring tag_name_w(release->tag_name.begin(), release->tag_name.end());
     std::wstring buffer = std::format(L"Downloading version '{}'", tag_name_w);
     MessageBoxW(nullptr, buffer.c_str(), L"Downloading...", 0);
 
@@ -235,7 +226,7 @@ bool DownloadWindow::DownloadAllFiles(std::wstring& error)
 
     DownloadWindow window;
     window.Create();
-    window.SetChangelog(release.body.c_str(), release.body.size());
+    window.SetChangelog(release->body.c_str(), release->body.size());
 
     AsyncFileDownloader downloader;
     AsyncDownload(url.c_str(), &downloader);
@@ -324,20 +315,12 @@ static bool UpdateExe(const std::filesystem::path& exe_path, const std::string& 
     return true;
 }
 
-// Runs on a background thread so it never delays injection. Not every release ships a GWToolbox.exe, so we scan
-// the release list newest-first for the most recent one that does, and offer it if it differs from ours.
-void CheckForExeUpdate()
+// Not every release ships a GWToolbox.exe, so we scan the release list newest-first for the most recent one
+// that does, and offer it if it differs from ours.
+static void CheckForExeUpdate(const std::vector<Release>& releases)
 {
     std::filesystem::path exe_path;
     if (!PathGetExeFullPath(exe_path))
-        return;
-
-    std::string content;
-    if (!Download(content, "https://api.github.com/repos/gwdevhub/GWToolboxpp/releases?per_page=30"))
-        return; // GitHub unreachable or rate-limited; never block a launch over an update check
-
-    std::vector<Release> releases;
-    if (!ParseReleases(content, releases))
         return;
 
     const Asset* exe_asset = nullptr;
@@ -379,6 +362,31 @@ void CheckForExeUpdate()
     MessageBoxW(nullptr, L"GWToolbox.exe was updated.\n\nClick the button below to restart the launcher and start using the new version.",
                 L"GWToolbox - Update complete", MB_OK | MB_ICONINFORMATION | MB_TOPMOST);
     RestartWithSameArgs();
+}
+
+bool DownloadWindow::CheckForUpdates(std::wstring& error)
+{
+    // Fetch the release list once and run both checks off it, rather than tapping Github twice.
+    std::vector<Release> releases;
+    if (!DownloadReleases(releases))
+        return error = L"Couldn't download the latest releases of GWToolboxpp", true; // non-fatal: don't block the launch
+
+    // Exe first: if it's out of date its dialog wins and may relaunch before we ever touch the dll.
+    if (!settings.noexecheck)
+        CheckForExeUpdate(releases);
+
+    if (settings.noupdate)
+        return true;
+    return DownloadDll(releases, error);
+}
+
+// dll-only entry (used by the installer); fetches its own release list since there's no exe check to share it with.
+bool DownloadWindow::DownloadDll(std::wstring& error)
+{
+    std::vector<Release> releases;
+    if (!DownloadReleases(releases))
+        return error = L"Couldn't download the latest releases of GWToolboxpp", true;
+    return DownloadDll(releases, error);
 }
 
 bool DownloadWindow::Create()

--- a/GWToolbox/Download.cpp
+++ b/GWToolbox/Download.cpp
@@ -75,23 +75,19 @@ struct Release {
     std::vector<Asset> assets{};
 };
 
-static bool ParseReleases(const std::string& json_text, std::vector<Release>& releases)
-{
-    constexpr glz::opts opts{.error_on_unknown_keys = false};
-    if (auto ec = glz::read<opts>(releases, json_text); ec) {
-        fprintf(stderr, "Failed to parse releases list\n");
-        return false;
-    }
-    return true;
-}
-
 // One Github request shared by the exe and dll checks, so we only tap the (rate-limited) API once per launch.
 static bool DownloadReleases(std::vector<Release>& releases)
 {
     std::string content;
     if (!Download(content, "https://api.github.com/repos/gwdevhub/GWToolboxpp/releases?per_page=30"))
         return false;
-    return ParseReleases(content, releases);
+    // Parse the JSON array, tolerating unknown keys so Github can add response fields without breaking us.
+    constexpr glz::opts opts{.error_on_unknown_keys = false};
+    if (auto ec = glz::read<opts>(releases, content); ec) {
+        fprintf(stderr, "Failed to parse releases list\n");
+        return false;
+    }
+    return true;
 }
 
 std::string GetDllRelease(const std::filesystem::path& dllpath)

--- a/GWToolbox/Download.h
+++ b/GWToolbox/Download.h
@@ -5,8 +5,7 @@
 bool Download(std::string& content, const wchar_t* url);
 bool Download(const wchar_t* path_to_file, const wchar_t* url);
 
-// Checks Github for a newer GWToolbox.exe and offers to self-update. Meant to run on a background thread.
-void CheckForExeUpdate();
+struct Release;
 
 class DownloadWindow : public Window {
 public:
@@ -17,10 +16,15 @@ public:
     DownloadWindow& operator=(const DownloadWindow&) = delete;
 
     bool Create() override;
-    static bool DownloadAllFiles(std::wstring& error);
+    // Single Github fetch feeding the exe self-update check then the dll update; replaces two separate API calls.
+    static bool CheckForUpdates(std::wstring& error);
+    // dll-only update, fetching its own release list; used by the installer.
+    static bool DownloadDll(std::wstring& error);
     void SetChangelog(const char* str, size_t length) const;
 
 private:
+    static bool DownloadDll(const std::vector<Release>& releases, std::wstring& error);
+
     LRESULT WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
     void OnCreate(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);

--- a/GWToolbox/Install.cpp
+++ b/GWToolbox/Install.cpp
@@ -121,7 +121,7 @@ bool Install(const bool quiet, std::wstring& error)
     if (!CopyInstaller())
         return error = L"CopyInstaller failed", false;
 
-    if (!DownloadWindow::DownloadAllFiles(error))
+    if (!DownloadWindow::DownloadDll(error))
         return false;
     const auto dll_path = install_path.parent_path() / "GWToolboxdll.dll";
     if (!fs::exists(dll_path)) {

--- a/GWToolbox/main.cpp
+++ b/GWToolbox/main.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
 
 #include <cstdio>
-#include <thread>
 
 #include <Path.h>
 #include <RestClient.h>
@@ -114,15 +113,6 @@ static bool InjectInstalledDllInProcess(const Process* process, std::wstring& er
     return true;
 }
 
-// Joins the exe-update worker when WinMain returns, so any open update prompt is honoured before we exit.
-struct ExeUpdateChecker {
-    std::thread thread;
-    ~ExeUpdateChecker()
-    {
-        if (thread.joinable()) thread.join();
-    }
-};
-
 static bool SetProcessForeground(const Process* process)
 {
     HWND hWndIt = GetTopWindow(nullptr);
@@ -233,20 +223,16 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int n
             }
         }
     }
-    else if (!settings.noupdate) {
+    else if (!settings.noupdate || !settings.noexecheck) {
+        // One Github fetch drives both the exe self-update prompt and the dll update.
         std::wstring error;
-        if (!DownloadWindow::DownloadAllFiles(error)) {
+        if (!DownloadWindow::CheckForUpdates(error)) {
             ShowError(std::format(L"Failed to download GWToolbox DLL: {}", error).c_str());
-            fprintf(stderr, "DownloadWindow::DownloadAllFiles failed\n");
+            fprintf(stderr, "DownloadWindow::CheckForUpdates failed\n");
             return 1;
         }
     }
 
-    // Check Github for a newer launcher exe in parallel; it only ever prompts, never blocks the injection below.
-    ExeUpdateChecker exe_update_checker;
-    if (!settings.noexecheck) {
-        exe_update_checker.thread = std::thread(CheckForExeUpdate);
-    }
     if (settings.pid) {
         if (!proc.Open(settings.pid)) {
             fprintf(stderr, "Couldn't open process %d\n", settings.pid);


### PR DESCRIPTION
Per Jon's request: the exe self-update and the dll update each tapped the Github API separately (`releases?per_page=30` for the exe, `releases/latest` for the dll), doubling requests against the rate limit. This fetches the release list **once** and runs both checks off it.

## Flow

`DownloadWindow::CheckForUpdates(error)` (called from `WinMain`):
1. One fetch of `releases?per_page=30`.
2. **Exe check first** — if the exe is out of date, its dialog wins and may relaunch the launcher before the dll is touched (on accept it updates + restarts; the relaunched, now-current exe then proceeds to the dll).
3. **Dll check** — if the dll is out of date, download it.

If the user declines the exe update, the dll check still runs in the same session.

## Changes

- `CheckForExeUpdate` and the dll downloader now take the shared `const std::vector<Release>&` instead of fetching their own. **The exe check is no longer threaded** — it runs synchronously before the dll logic, so the old `ExeUpdateChecker` thread/join is removed (along with `#include <thread>`).
- `DownloadAllFiles` is replaced by `CheckForUpdates` (exe + dll) plus a `DownloadDll(error)` dll-only entry that keeps its own fetch for the installer (`Install.cpp`), which shouldn't trigger an exe-update prompt.
- The dll check now locates the newest release that ships the dll from the fetched list, where it previously used `releases/latest`. In practice both resolve to the same newest release.
- Removed the now-unused single-release JSON parser.

## Notes

- Behavior change worth a look: the exe update check no longer runs on the fresh-install path (only on the normal already-installed launch). A fresh install just pulled the latest exe from the site, so it's current; if somehow stale, the next launch prompts. This avoids a second API fetch right after install.
- Could not compile here (Windows-only, 32-bit MSVC/clang-cl toolchain) — please verify the build in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)