### PR TITLE
feat(hero-panel): toggle panel position memory between party slot and hero

### DIFF
--- a/GWToolboxdll/Modules/HeroPanelPositionModule.cpp
+++ b/GWToolboxdll/Modules/HeroPanelPositionModule.cpp
@@ -24,24 +24,17 @@ namespace {
     static_assert(sizeof(GW::UI::FramePosition) % sizeof(uint32_t) == 0);
     using FramePosWords = std::array<uint32_t, frame_pos_words>;
 
-    // Last known panel positions, kept separately per keying mode so switching modes (or upgrading
-    // from the original by-hero-id-only version) never reinterprets one mode's keys as the other's.
+    // How a remembered position is keyed; persisted, defaults to by party slot.
+    enum PositionKeyMode : int { ByHeroIndex, ByHeroId };
+    int position_key_mode = ByHeroIndex;
+
+    // Kept separate per keying so switching modes never reinterprets one mode's keys as the other's.
     std::map<uint32_t, GW::UI::FramePosition> saved_positions_by_id;
     std::map<uint32_t, GW::UI::FramePosition> saved_positions_by_index;
 
     GW::HookEntry ui_message_entry;
 
-    bool KeyByHeroId()
-    {
-        return HeroPanelPositionModule::Instance().position_key_mode == HeroPanelPositionModule::ByHeroId;
-    }
-
-    std::map<uint32_t, GW::UI::FramePosition>& ActivePositions()
-    {
-        return KeyByHeroId() ? saved_positions_by_id : saved_positions_by_index;
-    }
-
-    // Visible hero command panel for the given index. Fills the panel's hero id (0 if unknown).
+    // Visible hero command panel for the given index; fills the panel's hero id (0 if unknown).
     GW::UI::Frame* GetCommanderFrame(uint32_t commander_index, uint32_t* hero_id_out)
     {
         wchar_t label[] = L"AgentCommander0";
@@ -54,8 +47,7 @@ namespace {
         return frame;
     }
 
-    // Record a placement into both maps regardless of the active mode, so that toggling the mode
-    // restores from whichever keying was kept current right up to the switch.
+    // Record into both maps regardless of mode, so toggling restores from the keying kept current.
     void RememberPosition(uint32_t commander_index, uint32_t hero_id, const GW::UI::FramePosition& position)
     {
         saved_positions_by_index[commander_index] = position;
@@ -72,16 +64,15 @@ namespace {
         }
     }
 
-    // Restore (or, the first time we see it, learn) a hero panel's position.
+    // Restore each hero panel, or learn its current placement the first time we see it.
     void RestorePanelPositions()
     {
-        const auto& positions = ActivePositions();
-        const bool by_id = KeyByHeroId();
+        const bool by_id = position_key_mode == ByHeroId;
+        auto& positions = by_id ? saved_positions_by_id : saved_positions_by_index;
         uint32_t hero_id = 0;
         for (uint32_t i = 0; i < hero_panel_count; i++) {
             const auto frame = GetCommanderFrame(i, &hero_id);
-            if (!frame) continue;
-            if (by_id && !hero_id) continue;
+            if (!frame || (by_id && !hero_id)) continue;
             const auto found = positions.find(by_id ? hero_id : i);
             if (found == positions.end()) {
                 RememberPosition(i, hero_id, frame->position);

--- a/GWToolboxdll/Modules/HeroPanelPositionModule.cpp
+++ b/GWToolboxdll/Modules/HeroPanelPositionModule.cpp
@@ -144,14 +144,20 @@ void HeroPanelPositionModule::SignalTerminate()
     GW::UI::RemoveUIMessageCallback(&ui_message_entry);
 }
 
-void HeroPanelPositionModule::DrawPositionKeySetting()
+void HeroPanelPositionModule::RegisterSettingsContent()
 {
-    ImGui::Text("Remember hero command panel positions by:");
-    ImGui::RadioButton("Party slot", &position_key_mode, ByHeroIndex);
-    ImGui::ShowHelp("Each party position keeps its panel placement, regardless of which hero is in that slot. Matches the base game's intended behaviour.");
-    ImGui::SameLine();
-    ImGui::RadioButton("Hero", &position_key_mode, ByHeroId);
-    ImGui::ShowHelp("Each hero keeps its panel placement, so it follows the hero across party slots and characters.");
+    RegisterSettingsContent(
+        "Party Settings", nullptr,
+        [](const std::string&, const bool is_showing) {
+            if (!is_showing) return;
+            ImGui::Text("Remember hero command panel positions by:");
+            ImGui::RadioButton("Party slot", &position_key_mode, ByHeroIndex);
+            ImGui::ShowHelp("Each party position keeps its panel placement, regardless of which hero is in that slot. Matches the base game's intended behaviour.");
+            ImGui::SameLine();
+            ImGui::RadioButton("Hero", &position_key_mode, ByHeroId);
+            ImGui::ShowHelp("Each hero keeps its panel placement, so it follows the hero across party slots and characters.");
+        },
+        1.1f);
 }
 
 void HeroPanelPositionModule::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)

--- a/GWToolboxdll/Modules/HeroPanelPositionModule.cpp
+++ b/GWToolboxdll/Modules/HeroPanelPositionModule.cpp
@@ -41,45 +41,50 @@ namespace {
         return KeyByHeroId() ? saved_positions_by_id : saved_positions_by_index;
     }
 
-    GW::UI::Frame* GetCommanderFrame(uint32_t commander_index, uint32_t* key_out)
+    // Visible hero command panel for the given index. Fills the panel's hero id (0 if unknown).
+    GW::UI::Frame* GetCommanderFrame(uint32_t commander_index, uint32_t* hero_id_out)
     {
         wchar_t label[] = L"AgentCommander0";
         label[_countof(label) - 2] = static_cast<wchar_t>(L'0' + commander_index);
         const auto frame = GW::UI::GetFrameByLabel(label);
         if (!(frame && frame->IsCreated() && frame->IsVisible())) return nullptr;
-        if (!KeyByHeroId()) {
-            *key_out = commander_index;
-            return frame;
-        }
         const auto context = (uint32_t*)GW::UI::GetFrameContext(frame);
         const auto* hero = context ? ToolboxUtils::GetHeroPartyMember(context[1]) : 0;
-        return hero ? (*key_out = static_cast<uint32_t>(hero->hero_id), frame) : nullptr;
+        *hero_id_out = hero ? static_cast<uint32_t>(hero->hero_id) : 0;
+        return frame;
+    }
+
+    // Record a placement into both maps regardless of the active mode, so that toggling the mode
+    // restores from whichever keying was kept current right up to the switch.
+    void RememberPosition(uint32_t commander_index, uint32_t hero_id, const GW::UI::FramePosition& position)
+    {
+        saved_positions_by_index[commander_index] = position;
+        if (hero_id) saved_positions_by_id[hero_id] = position;
     }
 
     // User dragged a floating window; if it's a hero command panel, remember where.
     void SavePanelPositions()
     {
-        auto& positions = ActivePositions();
-        uint32_t key = 0;
+        uint32_t hero_id = 0;
         for (uint32_t i = 0; i < hero_panel_count; i++) {
-            const auto frame = GetCommanderFrame(i, &key);
-            if (!frame) continue;
-            positions[key] = frame->position;
+            const auto frame = GetCommanderFrame(i, &hero_id);
+            if (frame) RememberPosition(i, hero_id, frame->position);
         }
     }
 
     // Restore (or, the first time we see it, learn) a hero panel's position.
-    // Returns true once the frame exists and has been handled; false while it's not created yet.
     void RestorePanelPositions()
     {
-        auto& positions = ActivePositions();
-        uint32_t key = 0;
+        const auto& positions = ActivePositions();
+        const bool by_id = KeyByHeroId();
+        uint32_t hero_id = 0;
         for (uint32_t i = 0; i < hero_panel_count; i++) {
-            const auto frame = GetCommanderFrame(i, &key);
+            const auto frame = GetCommanderFrame(i, &hero_id);
             if (!frame) continue;
-            const auto found = positions.find(key);
+            if (by_id && !hero_id) continue;
+            const auto found = positions.find(by_id ? hero_id : i);
             if (found == positions.end()) {
-                positions[key] = frame->position;
+                RememberPosition(i, hero_id, frame->position);
             }
             else {
                 frame->position = found->second;

--- a/GWToolboxdll/Modules/HeroPanelPositionModule.cpp
+++ b/GWToolboxdll/Modules/HeroPanelPositionModule.cpp
@@ -10,6 +10,7 @@
 #include <GWCA/Utilities/Hook.h>
 
 #include <GWCA/Managers/GameThreadMgr.h>
+#include <ImGuiAddons.h>
 #include <Modules/HeroPanelPositionModule.h>
 #include <Timer.h>
 #include <Utils/SettingsDoc.h>
@@ -23,30 +24,47 @@ namespace {
     static_assert(sizeof(GW::UI::FramePosition) % sizeof(uint32_t) == 0);
     using FramePosWords = std::array<uint32_t, frame_pos_words>;
 
-    // hero id -> last known panel position. Keyed by hero id so it survives party reordering.
-    std::map<uint32_t, GW::UI::FramePosition> saved_positions;
+    // Last known panel positions, kept separately per keying mode so switching modes (or upgrading
+    // from the original by-hero-id-only version) never reinterprets one mode's keys as the other's.
+    std::map<uint32_t, GW::UI::FramePosition> saved_positions_by_id;
+    std::map<uint32_t, GW::UI::FramePosition> saved_positions_by_index;
 
     GW::HookEntry ui_message_entry;
 
-    GW::UI::Frame* GetCommanderFrame(uint32_t commander_index, GW::Constants::HeroID* hero_id_out)
+    bool KeyByHeroId()
+    {
+        return HeroPanelPositionModule::Instance().position_key_mode == HeroPanelPositionModule::ByHeroId;
+    }
+
+    std::map<uint32_t, GW::UI::FramePosition>& ActivePositions()
+    {
+        return KeyByHeroId() ? saved_positions_by_id : saved_positions_by_index;
+    }
+
+    GW::UI::Frame* GetCommanderFrame(uint32_t commander_index, uint32_t* key_out)
     {
         wchar_t label[] = L"AgentCommander0";
         label[_countof(label) - 2] = static_cast<wchar_t>(L'0' + commander_index);
         const auto frame = GW::UI::GetFrameByLabel(label);
         if (!(frame && frame->IsCreated() && frame->IsVisible())) return nullptr;
+        if (!KeyByHeroId()) {
+            *key_out = commander_index;
+            return frame;
+        }
         const auto context = (uint32_t*)GW::UI::GetFrameContext(frame);
         const auto* hero = context ? ToolboxUtils::GetHeroPartyMember(context[1]) : 0;
-        return hero ? (*hero_id_out = hero->hero_id, frame) : nullptr;
+        return hero ? (*key_out = static_cast<uint32_t>(hero->hero_id), frame) : nullptr;
     }
 
     // User dragged a floating window; if it's a hero command panel, remember where.
     void SavePanelPositions()
     {
-        GW::Constants::HeroID hero_id = GW::Constants::HeroID::NoHero;
+        auto& positions = ActivePositions();
+        uint32_t key = 0;
         for (uint32_t i = 0; i < hero_panel_count; i++) {
-            const auto frame = GetCommanderFrame(i, &hero_id);
+            const auto frame = GetCommanderFrame(i, &key);
             if (!frame) continue;
-            saved_positions[static_cast<uint32_t>(hero_id)] = frame->position;
+            positions[key] = frame->position;
         }
     }
 
@@ -54,19 +72,47 @@ namespace {
     // Returns true once the frame exists and has been handled; false while it's not created yet.
     void RestorePanelPositions()
     {
-        GW::Constants::HeroID hero_id = GW::Constants::HeroID::NoHero;
+        auto& positions = ActivePositions();
+        uint32_t key = 0;
         for (uint32_t i = 0; i < hero_panel_count; i++) {
-            const auto frame = GetCommanderFrame(i, &hero_id);
+            const auto frame = GetCommanderFrame(i, &key);
             if (!frame) continue;
-            const auto found = saved_positions.find(static_cast<uint32_t>(hero_id));
-            if (found == saved_positions.end()) {
-                saved_positions[static_cast<uint32_t>(hero_id)] = frame->position;
+            const auto found = positions.find(key);
+            if (found == positions.end()) {
+                positions[key] = frame->position;
             }
             else {
                 frame->position = found->second;
                 GW::UI::TriggerFrameRedraw(frame);
             }
         }
+    }
+
+    void LoadPositions(const SettingsDoc& doc, const char* section, const char* key, std::map<uint32_t, GW::UI::FramePosition>& out)
+    {
+        std::map<std::string, FramePosWords> serialized;
+        if (!doc.Get(section, key, serialized)) return;
+        out.clear();
+        for (const auto& [id_str, words] : serialized) {
+            uint32_t id = 0;
+            const auto* first = id_str.data();
+            const auto* last = first + id_str.size();
+            if (std::from_chars(first, last, id).ec != std::errc{}) continue;
+            GW::UI::FramePosition position{};
+            memcpy(&position, words.data(), sizeof(position));
+            out[id] = position;
+        }
+    }
+
+    void SavePositions(SettingsDoc& doc, const char* section, const char* key, const std::map<uint32_t, GW::UI::FramePosition>& in)
+    {
+        std::map<std::string, FramePosWords> serialized;
+        for (const auto& [id, position] : in) {
+            FramePosWords words{};
+            memcpy(words.data(), &position, sizeof(position));
+            serialized[std::to_string(id)] = words;
+        }
+        doc.Set(section, key, serialized);
     }
 
     void OnPostUIMessage(GW::HookStatus*, GW::UI::UIMessage message_id, void*, void*)
@@ -102,31 +148,29 @@ void HeroPanelPositionModule::SignalTerminate()
     GW::UI::RemoveUIMessageCallback(&ui_message_entry);
 }
 
+void HeroPanelPositionModule::DrawPositionKeySetting()
+{
+    ImGui::Text("Remember hero command panel positions by:");
+    ImGui::RadioButton("Party slot", &position_key_mode, ByHeroIndex);
+    ImGui::ShowHelp("Each party position keeps its panel placement, regardless of which hero is in that slot. Matches the base game's intended behaviour.");
+    ImGui::SameLine();
+    ImGui::RadioButton("Hero", &position_key_mode, ByHeroId);
+    ImGui::ShowHelp("Each hero keeps its panel placement, so it follows the hero across party slots and characters.");
+}
+
 void HeroPanelPositionModule::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
 {
     ToolboxModule::LoadSettings(doc, legacy);
-    std::map<std::string, FramePosWords> serialized;
-    if (!doc.Get(Name(), "positions", serialized)) return;
-    saved_positions.clear();
-    for (const auto& [key, words] : serialized) {
-        uint32_t hero_id = 0;
-        const auto* first = key.data();
-        const auto* last = first + key.size();
-        if (std::from_chars(first, last, hero_id).ec != std::errc{}) continue;
-        GW::UI::FramePosition position{};
-        memcpy(&position, words.data(), sizeof(position));
-        saved_positions[hero_id] = position;
-    }
+    // "positions" predates the keying mode and was always by hero id.
+    LoadPositions(doc, Name(), "positions", saved_positions_by_id);
+    LoadPositions(doc, Name(), "positions_by_index", saved_positions_by_index);
+    doc.Get(Name(), "position_key_mode", position_key_mode);
 }
 
 void HeroPanelPositionModule::SaveSettings(SettingsDoc& doc)
 {
     ToolboxModule::SaveSettings(doc);
-    std::map<std::string, FramePosWords> serialized;
-    for (const auto& [hero_id, position] : saved_positions) {
-        FramePosWords words{};
-        memcpy(words.data(), &position, sizeof(position));
-        serialized[std::to_string(hero_id)] = words;
-    }
-    doc.Set(Name(), "positions", serialized);
+    SavePositions(doc, Name(), "positions", saved_positions_by_id);
+    SavePositions(doc, Name(), "positions_by_index", saved_positions_by_index);
+    doc.Set(Name(), "position_key_mode", position_key_mode);
 }

--- a/GWToolboxdll/Modules/HeroPanelPositionModule.h
+++ b/GWToolboxdll/Modules/HeroPanelPositionModule.h
@@ -2,11 +2,7 @@
 
 #include <ToolboxModule.h>
 
-// Remembers where each hero's command panel (skill bar) was last placed and restores it
-// whenever that panel is recreated - e.g. after reordering the party or swapping characters,
-// which otherwise reshuffles the panels around the screen. Positions are keyed either by party
-// slot or by hero id (user setting); the game's own per-slot memory is unreliable, so we override
-// it in both modes.
+// Remembers each hero command panel's position (keyed by party slot or hero id) and restores it when the panel reappears, since the game's own per-slot memory is unreliable.
 class HeroPanelPositionModule : public ToolboxModule {
     HeroPanelPositionModule() = default;
     ~HeroPanelPositionModule() override = default;

--- a/GWToolboxdll/Modules/HeroPanelPositionModule.h
+++ b/GWToolboxdll/Modules/HeroPanelPositionModule.h
@@ -5,8 +5,8 @@
 // Remembers where each hero's command panel (skill bar) was last placed and restores it
 // whenever that panel is recreated - e.g. after reordering the party or swapping characters,
 // which otherwise reshuffles the panels around the screen. Positions are keyed either by party
-// slot or by hero id (see PositionKeyMode); the game's own per-slot memory is unreliable, so we
-// override it in both modes.
+// slot or by hero id (user setting); the game's own per-slot memory is unreliable, so we override
+// it in both modes.
 class HeroPanelPositionModule : public ToolboxModule {
     HeroPanelPositionModule() = default;
     ~HeroPanelPositionModule() override = default;
@@ -22,8 +22,8 @@ public:
     [[nodiscard]] const char* Description() const override { return "Remembers the on-screen position of each hero's command panel and restores it when the panel reappears."; }
     [[nodiscard]] bool HasSettings() override { return false; }
 
-    // Radio buttons for the keying mode, drawn from the Party Settings section.
-    void DrawPositionKeySetting();
+    // Registers the keying-mode radio buttons into the existing Party Settings section.
+    void RegisterSettingsContent() override;
 
     void Initialize() override;
     void SignalTerminate() override;

--- a/GWToolboxdll/Modules/HeroPanelPositionModule.h
+++ b/GWToolboxdll/Modules/HeroPanelPositionModule.h
@@ -22,14 +22,7 @@ public:
     [[nodiscard]] const char* Description() const override { return "Remembers the on-screen position of each hero's command panel and restores it when the panel reappears."; }
     [[nodiscard]] bool HasSettings() override { return false; }
 
-    // How a remembered panel position is keyed.
-    enum PositionKeyMode : int {
-        ByHeroIndex = 0, // by party slot - matches the base game's per-slot memory (default)
-        ByHeroId = 1,    // by the specific hero, so it follows the hero across party slots
-    };
-    int position_key_mode = ByHeroIndex;
-
-    // Radio buttons for position_key_mode, drawn from the Party Settings section.
+    // Radio buttons for the keying mode, drawn from the Party Settings section.
     void DrawPositionKeySetting();
 
     void Initialize() override;

--- a/GWToolboxdll/Modules/HeroPanelPositionModule.h
+++ b/GWToolboxdll/Modules/HeroPanelPositionModule.h
@@ -4,8 +4,9 @@
 
 // Remembers where each hero's command panel (skill bar) was last placed and restores it
 // whenever that panel is recreated - e.g. after reordering the party or swapping characters,
-// which otherwise reshuffles the panels around the screen. Position is keyed by hero id so it
-// follows the hero regardless of its current party slot.
+// which otherwise reshuffles the panels around the screen. Positions are keyed either by party
+// slot or by hero id (see PositionKeyMode); the game's own per-slot memory is unreliable, so we
+// override it in both modes.
 class HeroPanelPositionModule : public ToolboxModule {
     HeroPanelPositionModule() = default;
     ~HeroPanelPositionModule() override = default;
@@ -20,6 +21,16 @@ public:
     [[nodiscard]] const char* Name() const override { return "Hero Panel Positions"; }
     [[nodiscard]] const char* Description() const override { return "Remembers the on-screen position of each hero's command panel and restores it when the panel reappears."; }
     [[nodiscard]] bool HasSettings() override { return false; }
+
+    // How a remembered panel position is keyed.
+    enum PositionKeyMode : int {
+        ByHeroIndex = 0, // by party slot - matches the base game's per-slot memory (default)
+        ByHeroId = 1,    // by the specific hero, so it follows the hero across party slots
+    };
+    int position_key_mode = ByHeroIndex;
+
+    // Radio buttons for position_key_mode, drawn from the Party Settings section.
+    void DrawPositionKeySetting();
 
     void Initialize() override;
     void SignalTerminate() override;

--- a/GWToolboxdll/Modules/PartyWindowModule.cpp
+++ b/GWToolboxdll/Modules/PartyWindowModule.cpp
@@ -29,6 +29,7 @@
 #include <Logger.h>
 #include <Timer.h>
 #include <Defines.h>
+#include <Modules/HeroPanelPositionModule.h>
 #include <Modules/PartyWindowModule.h>
 #include <Windows/FriendListWindow.h>
 #include "Resources.h"
@@ -1073,6 +1074,9 @@ void PartyWindowModule::DrawSettingsInternal()
         DrawCustomPartySortingSettings();
         ImGui::Unindent();
     }
+    ImGui::Separator();
+
+    HeroPanelPositionModule::Instance().DrawPositionKeySetting();
 }
 void PartyWindowModule::SaveSettings(SettingsDoc& doc)
 {

--- a/GWToolboxdll/Modules/PartyWindowModule.cpp
+++ b/GWToolboxdll/Modules/PartyWindowModule.cpp
@@ -29,7 +29,6 @@
 #include <Logger.h>
 #include <Timer.h>
 #include <Defines.h>
-#include <Modules/HeroPanelPositionModule.h>
 #include <Modules/PartyWindowModule.h>
 #include <Windows/FriendListWindow.h>
 #include "Resources.h"
@@ -1074,9 +1073,6 @@ void PartyWindowModule::DrawSettingsInternal()
         DrawCustomPartySortingSettings();
         ImGui::Unindent();
     }
-    ImGui::Separator();
-
-    HeroPanelPositionModule::Instance().DrawPositionKeySetting();
 }
 void PartyWindowModule::SaveSettings(SettingsDoc& doc)
 {

--- a/site/src/content/docs/qol_fixes.md
+++ b/site/src/content/docs/qol_fixes.md
@@ -9,7 +9,7 @@ Each can be toggled in its own section of the [Settings](/docs/settings/) panel.
 
 ## Fixes
 
-- **Hero command panel positions** — Remembers where you place each hero's skill-bar / command panel and restores it when the panel reappears, so they stop scattering across the screen after you reorder your party or swap characters. The position is tied to the hero, so it follows them regardless of party slot.
+- **Hero command panel positions** — Remembers where you place each hero's skill-bar / command panel and restores it when the panel reappears, so they stop scattering across the screen after you reorder your party or swap characters. In the Party Settings section you can choose whether positions are remembered by **party slot** (the default — each slot keeps its placement no matter which hero is in it) or by **hero** (the placement follows the specific hero across slots and characters).
 
 - **Experience bar shows XP progress** — Replaces the experience bar text so it shows your progress toward the next level (current XP / XP needed) instead of just repeating your current level number.
 


### PR DESCRIPTION
## What

Adds radio buttons (under **Party Settings**) to choose how hero command panel positions are remembered:

- **Party slot** — *new default.* Each party position keeps its panel placement regardless of which hero occupies it. This matches the base game's intended per-slot memory (the behaviour several users expect: place 7 panels once, never have them overlap).
- **Hero** — placement follows the specific hero across party slots and characters (the previous, only behaviour).

## Why

The "Hero command panel positions are now remembered and restored on map load" change shipped keyed solely by hero id, with no setting to turn it off or switch it. As raised on Discord, keying by party slot is what most players are used to (there are 31 heroes but only 7 slots, so by-hero placements can overlap). GW's own per-slot memory is unreliable, so Toolbox keeps overriding it in both modes.

## Notes

- Positions are persisted in separate maps per mode (`positions` = by hero id, `positions_by_index` = by party slot), so switching modes — or upgrading from the by-hero-id-only version — never reinterprets one mode's keys as the other's. Existing saved by-hero positions are preserved for users who pick the Hero option.
- The setting (`position_key_mode`) defaults to party slot.
- Docs (`qol_fixes.md`) updated to describe the new choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)