### PR TITLE
Diagnose write/load failures and surface antivirus blocks

### DIFF
--- a/Core/Defender.cpp
+++ b/Core/Defender.cpp
@@ -1,0 +1,109 @@
+#include "stdafx.h"
+
+#include "Defender.h"
+
+#include <fstream>
+#include <sstream>
+#include <vector>
+
+namespace {
+    std::wstring ReadFileToWString(const std::filesystem::path& path)
+    {
+        std::wifstream file(path);
+        if (!file.is_open()) {
+            return L"";
+        }
+        std::wstringstream buffer;
+        buffer << file.rdbuf();
+        return buffer.str();
+    }
+
+    void TrimWhitespace(std::wstring& s)
+    {
+        const auto first = s.find_first_not_of(L" \t\r\n");
+        if (first == std::wstring::npos) {
+            s.clear();
+            return;
+        }
+        s.erase(0, first);
+        s.erase(s.find_last_not_of(L" \t\r\n") + 1);
+    }
+}
+
+bool RunPowerShellCommand(const std::wstring& command, std::wstring& output)
+{
+    wchar_t temp_path[MAX_PATH];
+    wchar_t temp_file[MAX_PATH];
+
+    if (GetTempPathW(MAX_PATH, temp_path) == 0) {
+        fwprintf(stderr, L"%S: GetTempPathW failed (%lu)\n", __func__, GetLastError());
+        return false;
+    }
+    if (GetTempFileNameW(temp_path, L"GWT", 0, temp_file) == 0) {
+        fwprintf(stderr, L"%S: GetTempFileNameW failed (%lu)\n", __func__, GetLastError());
+        return false;
+    }
+
+    std::wstring full_command = L"powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"";
+    full_command += command;
+    full_command += L" | Out-File -FilePath '";
+    full_command += temp_file;
+    full_command += L"' -Encoding UTF8\"";
+
+    STARTUPINFOW si = {sizeof(STARTUPINFOW)};
+    PROCESS_INFORMATION pi = {nullptr};
+    si.dwFlags = STARTF_USESHOWWINDOW;
+    si.wShowWindow = SW_HIDE;
+
+    std::vector<wchar_t> cmd_buffer(full_command.begin(), full_command.end());
+    cmd_buffer.push_back(L'\0');
+
+    const BOOL success = CreateProcessW(nullptr, cmd_buffer.data(), nullptr, nullptr, FALSE, CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi);
+    if (!success) {
+        fwprintf(stderr, L"%S: CreateProcessW failed (%lu)\n", __func__, GetLastError());
+        DeleteFileW(temp_file);
+        return false;
+    }
+
+    DWORD exit_code = STILL_ACTIVE;
+    for (DWORD elapsed = 0; exit_code == STILL_ACTIVE && elapsed < 5000; elapsed += 10) {
+        Sleep(10);
+        GetExitCodeProcess(pi.hProcess, &exit_code);
+    }
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+
+    output = ReadFileToWString(temp_file);
+    DeleteFileW(temp_file);
+
+    return exit_code == 0;
+}
+
+bool FindRecentDefenderBlock(const std::wstring& needle, const unsigned seconds, std::wstring& detail)
+{
+    // Double up single quotes so the needle is safe inside the PowerShell single-quoted string.
+    std::wstring escaped;
+    for (const wchar_t c : needle) {
+        escaped += c;
+        if (c == L'\'') escaped += c;
+    }
+
+    // 1116-1119 malware detection/remediation, 1121 ASR block, 1123 Controlled Folder Access block.
+    const std::wstring command =
+        L"Get-WinEvent -FilterHashtable @{LogName='Microsoft-Windows-Windows Defender/Operational';"
+        L"Id=1116,1117,1118,1119,1121,1123;StartTime=(Get-Date).AddSeconds(-" + std::to_wstring(seconds) + L")} -ErrorAction SilentlyContinue|"
+        L"Where-Object{$_.Message -like '*" + escaped + L"*'}|"
+        L"Select-Object -First 1 -ExpandProperty Message";
+
+    std::wstring output;
+    if (!RunPowerShellCommand(command, output))
+        return false;
+
+    TrimWhitespace(output);
+    if (output.empty())
+        return false;
+
+    detail = output;
+    return true;
+}

--- a/Core/Defender.h
+++ b/Core/Defender.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+// Runs a PowerShell command, capturing its stdout into `output`. Returns true on exit code 0.
+bool RunPowerShellCommand(const std::wstring& command, std::wstring& output);
+
+// Searches the Windows Defender Operational log for a recent malware/ASR/Controlled-Folder-Access block whose message mentions `needle`, within the last `seconds`; on a hit returns true and sets `detail` to the event message.
+bool FindRecentDefenderBlock(const std::wstring& needle, unsigned seconds, std::wstring& detail);

--- a/Core/Path.cpp
+++ b/Core/Path.cpp
@@ -268,8 +268,7 @@ std::wstring PathDiagnoseWritability(const fs::path& folder)
         out += buf;
     }
 
-    // Probe whether we can write a file into the folder right now; this distinguishes a
-    // folder-wide permission/lock problem from something blocking only a specific file.
+    // A real write probe tells a folder-wide permission/lock problem from a block on one file.
     const fs::path probe = folder / L"gwtoolbox_write_test.tmp";
     fs::remove(probe, ec);
     bool wrote = false;

--- a/Core/Path.cpp
+++ b/Core/Path.cpp
@@ -229,3 +229,66 @@ bool PathIsDirectorySafe(const fs::path& path, bool* out)
     }
     return true;
 }
+
+std::wstring FormatWindowsError(const unsigned long error_code)
+{
+    LPWSTR buffer = nullptr;
+    const DWORD len = FormatMessageW(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        nullptr, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        reinterpret_cast<LPWSTR>(&buffer), 0, nullptr);
+
+    std::wstring message = len && buffer ? std::wstring(buffer, len) : L"no description available";
+    if (buffer) {
+        LocalFree(buffer);
+    }
+    while (!message.empty() && (message.back() == L'\n' || message.back() == L'\r' || message.back() == L' ')) {
+        message.pop_back();
+    }
+    return message;
+}
+
+std::wstring PathDiagnoseWritability(const fs::path& folder)
+{
+    if (folder.empty()) {
+        return L"No folder path was provided.";
+    }
+
+    std::error_code ec;
+    if (!fs::exists(folder, ec)) {
+        return ec
+            ? L"Could not access the folder: " + FormatWindowsError(ec.value())
+            : L"The folder no longer exists (" + folder.wstring() + L") - something deleted or moved it.";
+    }
+
+    std::wstring out;
+    if (const auto space = fs::space(folder, ec); !ec && space.available < 16ull * 1024 * 1024) {
+        wchar_t buf[128];
+        swprintf(buf, 128, L"Only %llu KB free on this drive - it may be full.\n", static_cast<unsigned long long>(space.available / 1024));
+        out += buf;
+    }
+
+    // Probe whether we can write a file into the folder right now; this distinguishes a
+    // folder-wide permission/lock problem from something blocking only a specific file.
+    const fs::path probe = folder / L"gwtoolbox_write_test.tmp";
+    fs::remove(probe, ec);
+    bool wrote = false;
+    const HANDLE h = CreateFileW(probe.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_TEMPORARY, nullptr);
+    if (h != INVALID_HANDLE_VALUE) {
+        DWORD written = 0;
+        const char byte = 'x';
+        wrote = WriteFile(h, &byte, 1, &written, nullptr) && written == 1;
+        CloseHandle(h);
+    }
+    else {
+        out += L"A test file could not be created in the folder either: " + FormatWindowsError(GetLastError()) + L"\n";
+    }
+    fs::remove(probe, ec);
+
+    out += wrote
+        ? L"A test file could be written to the folder, so the folder itself is writable - "
+          L"something is blocking this specific file. Antivirus quarantine is the most common cause."
+        : L"Writing to the folder is being blocked entirely - check folder permissions, a "
+          L"read-only drive, or antivirus exclusions for your Guild Wars / GWToolbox folder.";
+    return out;
+}

--- a/Core/Path.h
+++ b/Core/Path.h
@@ -34,8 +34,5 @@ bool PathGetComputerName(std::filesystem::path& out);
 // Human-readable description for a Win32 error code (e.g. from GetLastError()), via FormatMessage.
 std::wstring FormatWindowsError(unsigned long error_code);
 
-// Best-effort, non-throwing diagnosis of why writes to `folder` might be failing: reports a
-// missing/inaccessible folder, a (nearly) full disk, and whether a test file can actually be
-// written - distinguishing a folder-wide permission/lock problem from antivirus blocking a
-// single file. Returns a user-facing, possibly multi-line message.
+// Non-throwing, user-facing diagnosis of why writes to `folder` may be failing (missing folder, full disk, permission/lock, or antivirus blocking a single file).
 std::wstring PathDiagnoseWritability(const std::filesystem::path& folder);

--- a/Core/Path.h
+++ b/Core/Path.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <string>
 
 // is_directory without catch; returns false on failure
 bool PathIsDirectorySafe(const std::filesystem::path& path, bool* out);
@@ -29,3 +30,12 @@ bool PathSafeCopy(const std::filesystem::path& from, const std::filesystem::path
 bool PathRecursiveRemove(const std::filesystem::path& from);
 
 bool PathGetComputerName(std::filesystem::path& out);
+
+// Human-readable description for a Win32 error code (e.g. from GetLastError()), via FormatMessage.
+std::wstring FormatWindowsError(unsigned long error_code);
+
+// Best-effort, non-throwing diagnosis of why writes to `folder` might be failing: reports a
+// missing/inaccessible folder, a (nearly) full disk, and whether a test file can actually be
+// written - distinguishing a folder-wide permission/lock problem from antivirus blocking a
+// single file. Returns a user-facing, possibly multi-line message.
+std::wstring PathDiagnoseWritability(const std::filesystem::path& folder);

--- a/GWToolbox/WindowsDefender.cpp
+++ b/GWToolbox/WindowsDefender.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 
+#include <Defender.h>
 #include <Path.h>
 #include "WindowsDefender.h"
 
@@ -8,86 +9,6 @@
 namespace fs = std::filesystem;
 
 namespace {
-    std::wstring ReadFile(const std::filesystem::path& path)
-    {
-        std::wifstream file(path);
-        if (!file.is_open()) {
-            return L"";
-        }
-
-        std::wstringstream buffer;
-        buffer << file.rdbuf();
-        return buffer.str();
-    }
-
-
-    bool ExecutePowerShellCommand(const std::wstring& command, std::wstring& output)
-    {
-        // Create a temporary file for output
-        wchar_t temp_path[MAX_PATH];
-        wchar_t temp_file[MAX_PATH];
-
-        if (GetTempPathW(MAX_PATH, temp_path) == 0) {
-            fprintf(stderr, "GetTempPathW failed (%lu)\n", GetLastError());
-            return false;
-        }
-
-        if (GetTempFileNameW(temp_path, L"GWT", 0, temp_file) == 0) {
-            fprintf(stderr, "GetTempFileNameW failed (%lu)\n", GetLastError());
-            return false;
-        }
-
-        std::wstring full_command = L"powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"";
-        full_command += command;
-        full_command += L" | Out-File -FilePath '";
-        full_command += temp_file;
-        full_command += L"' -Encoding UTF8\"";
-
-        STARTUPINFOW si = {sizeof(STARTUPINFOW)};
-        PROCESS_INFORMATION pi = {nullptr};
-
-        si.dwFlags = STARTF_USESHOWWINDOW;
-        si.wShowWindow = SW_HIDE;
-
-        // Create a modifiable copy of the command string
-        std::vector cmd_buffer(full_command.begin(), full_command.end());
-        cmd_buffer.push_back(L'\0');
-
-        BOOL success = CreateProcessW(
-            nullptr,
-            cmd_buffer.data(),
-            nullptr,
-            nullptr,
-            FALSE,
-            CREATE_NO_WINDOW,
-            nullptr,
-            nullptr,
-            &si,
-            &pi);
-
-        if (!success) {
-            fprintf(stderr, "CreateProcessW failed (%lu)\n", GetLastError());
-            DeleteFileW(temp_file);
-            return false;
-        }
-
-        DWORD exit_code = STILL_ACTIVE;
-        DWORD elapsed = 0;
-        for (elapsed = 0; exit_code == STILL_ACTIVE && elapsed < 5000; elapsed += 10) {
-            Sleep(10);
-            GetExitCodeProcess(pi.hProcess, &exit_code);
-        }
-
-        CloseHandle(pi.hProcess);
-        CloseHandle(pi.hThread);
-
-        output = ReadFile(temp_file);
-
-        DeleteFileW(temp_file);
-
-        return exit_code == 0;
-    }
-
     bool ExecutePowerShellCommandElevated(const std::wstring& command, std::wstring& error)
     {
         std::wstring ps_command = L"-NoProfile -ExecutionPolicy Bypass -Command \"";
@@ -127,7 +48,7 @@ bool IsPathExcludedFromDefender(const std::filesystem::path& path)
     std::wstring output;
     const std::wstring command = L"Get-MpPreference | Select-Object -ExpandProperty ExclusionPath";
 
-    if (!ExecutePowerShellCommand(command, output)) {
+    if (!RunPowerShellCommand(command, output)) {
         // If we're not admin, this will fail, treat it as if it wasn't excluded but check registry later
         return false;
     }
@@ -167,29 +88,6 @@ bool IsPathExcludedFromDefender(const std::filesystem::path& path)
     return false;
 }
 
-
-bool FindRecentDefenderBlock(const std::wstring& dll_name, std::wstring& detail)
-{
-    // Ids 1116-1119 = malware detected / action taken, 1121 = ASR rule blocked.
-    const std::wstring command =
-        L"Get-WinEvent -FilterHashtable @{LogName='Microsoft-Windows-Windows Defender/Operational';"
-        L"Id=1116,1117,1118,1119,1121;StartTime=(Get-Date).AddSeconds(-30)} -ErrorAction SilentlyContinue|"
-        L"Where-Object{$_.Message -like '*" + dll_name + L"*'}|"
-        L"Select-Object -First 1 -ExpandProperty Message";
-
-    std::wstring output;
-    if (!ExecutePowerShellCommand(command, output))
-        return false;
-
-    output.erase(0, output.find_first_not_of(L" \t\r\n"));
-    output.erase(output.find_last_not_of(L" \t\r\n") + 1);
-    if (output.empty())
-        return false;
-
-    detail = output;
-    return true;
-}
-
 bool AddDefenderExclusion(const std::filesystem::path& path, const bool quiet, std::wstring& error)
 {
     if (IsPathExcludedFromDefender(path)) {
@@ -224,7 +122,7 @@ bool AddDefenderExclusion(const std::filesystem::path& path, const bool quiet, s
     bool success;
     if (is_admin) {
         std::wstring output;
-        success = ExecutePowerShellCommand(command, output);
+        success = RunPowerShellCommand(command, output);
     }
     else {
         success = ExecutePowerShellCommandElevated(command, error);

--- a/GWToolbox/WindowsDefender.h
+++ b/GWToolbox/WindowsDefender.h
@@ -3,7 +3,3 @@
 bool IsPathExcludedFromDefender(const std::filesystem::path& path);
 
 bool AddDefenderExclusion(const std::filesystem::path& path, const bool quiet, std::wstring& error);
-
-// Looks for a recent Defender detection/ASR-block event naming dll_name.
-// Returns true and sets `detail` to the matching event message when found.
-bool FindRecentDefenderBlock(const std::wstring& dll_name, std::wstring& detail);

--- a/GWToolbox/main.cpp
+++ b/GWToolbox/main.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdio>
 
+#include <Defender.h>
 #include <Path.h>
 #include <RestClient.h>
 
@@ -102,7 +103,7 @@ static bool InjectInstalledDllInProcess(const Process* process, std::wstring& er
                false;
     if (!process->GetModule(&module, L"GWToolboxdll.dll")) {
         std::wstring detail;
-        if (FindRecentDefenderBlock(L"GWToolboxdll.dll", detail))
+        if (FindRecentDefenderBlock(L"GWToolboxdll.dll", 30, detail))
             return error = std::format(L"Windows Defender blocked GWToolbox from loading:\n\n{}\n\nAdd an exclusion for the {} directory in Windows Security and re-launch {}.", detail, dllpath.parent_path().wstring(), exe_filename), false;
         return error = std::format(
                    L"Application @ {} failed to inject; it may have been quarantined by anti virus software!\n\nExclude the {} directory in your anti virus settings and re-launch {}.", dllpath.wstring(), dllpath.parent_path().wstring(), exe_filename

--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -19,6 +19,7 @@
 #include <GWCA/Managers/MemoryMgr.h>
 #include <GWCA/Managers/RenderMgr.h>
 
+#include <Defender.h>
 #include <Defines.h>
 #include <GWToolbox.h>
 #include <Logger.h>
@@ -361,10 +362,13 @@ namespace {
         // Defender returns these from CreateFile/LoadLibrary when it blocks or quarantines a file.
         const auto warn_if_antivirus = [](const DWORD err) {
             if (err != ERROR_VIRUS_INFECTED && err != ERROR_VIRUS_DELETED) return;
-            MessageBoxW(nullptr,
-                        L"Windows Defender (or another anti-virus) blocked gwca.dll, which GWToolbox needs to run.\n\n"
-                        L"Add an exclusion for your GWToolbox folder in Windows Security and re-launch.",
-                        L"GWToolbox", MB_OK | MB_ICONERROR | MB_TOPMOST);
+            std::wstring message =
+                L"Windows Defender (or another anti-virus) blocked gwca.dll, which GWToolbox needs to run.\n\n"
+                L"Add an exclusion for your GWToolbox folder in Windows Security and re-launch.";
+            std::wstring detail;
+            if (FindRecentDefenderBlock(L"gwca.dll", 15, detail))
+                message += L"\n\nWindows Defender reported:\n" + detail;
+            MessageBoxW(nullptr, message.c_str(), L"GWToolbox", MB_OK | MB_ICONERROR | MB_TOPMOST);
         };
 
         if (!IsValidGWCADll(gwca_dll_path, resource)) {

--- a/GWToolboxdll/Modules/CrashHandler.cpp
+++ b/GWToolboxdll/Modules/CrashHandler.cpp
@@ -11,11 +11,21 @@
 #include <Modules/Updater.h>
 #include <GWToolbox.h>
 #include <Defines.h>
+#include <Defender.h>
 #include <Path.h>
 #include <Utils/TextUtils.h>
 
 namespace {
     char* tb_exception_message = nullptr;
+
+    // If Defender quarantined/blocked the crash file in the last few seconds, surface the event text.
+    std::wstring RecentDefenderBlock(const std::wstring& needle)
+    {
+        std::wstring detail;
+        if (FindRecentDefenderBlock(needle, 15, detail))
+            return L"\n\nWindows Defender reported a block moments ago:\n" + detail;
+        return L"";
+    }
 
     struct GWDebugInfo {
         size_t len;
@@ -207,6 +217,7 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
             L"{}",
             last_error, FormatWindowsError(last_error), szFileName, PathDiagnoseWritability(crash_folder)
         );
+        error += RecentDefenderBlock(szFileName);
         MessageBoxW(nullptr, error.c_str(), L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
         TerminateProcess(GetCurrentProcess(), 1);
     }
@@ -274,6 +285,7 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
                 szFileName, PathDiagnoseWritability(crash_folder)
             );
         }
+        error_info += RecentDefenderBlock(szFileName);
     }
     else {
         error_info = L"Guild Wars crashed!\n\n";

--- a/GWToolboxdll/Modules/CrashHandler.cpp
+++ b/GWToolboxdll/Modules/CrashHandler.cpp
@@ -16,6 +16,71 @@
 namespace {
     char* tb_exception_message = nullptr;
 
+    // Turn a GetLastError() code into the human-readable description Windows ships with it.
+    std::wstring FormatWin32Error(const DWORD error_code)
+    {
+        LPWSTR buffer = nullptr;
+        const DWORD len = FormatMessageW(
+            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+            nullptr, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+            reinterpret_cast<LPWSTR>(&buffer), 0, nullptr);
+
+        std::wstring message = len && buffer ? std::wstring(buffer, len) : L"no description available";
+        if (buffer) {
+            LocalFree(buffer);
+        }
+        while (!message.empty() && (message.back() == L'\n' || message.back() == L'\r' || message.back() == L' ')) {
+            message.pop_back();
+        }
+        return message;
+    }
+
+    std::wstring ToWide(const std::error_code& ec)
+    {
+        return std::format(L"{} (category '{}', value {})", TextUtils::StringToWString(ec.message()), TextUtils::StringToWString(ec.category().name()), ec.value());
+    }
+
+    // Best-effort, non-throwing probe of the crashes folder so we report what's actually wrong
+    // (missing folder, full disk, blocked write) instead of guessing at the cause.
+    std::wstring DiagnoseCrashFolder(const std::filesystem::path& file)
+    {
+        std::error_code ec;
+        const std::filesystem::path folder = file.parent_path();
+
+        if (!std::filesystem::exists(folder, ec)) {
+            return ec
+                ? std::format(L"Could not access the crashes folder: {}", ToWide(ec))
+                : std::format(L"The crashes folder no longer exists ({}) - something deleted or moved it.", folder.wstring());
+        }
+
+        std::wstring out;
+        if (const auto space = std::filesystem::space(folder, ec); !ec && space.available < 16ull * 1024 * 1024) {
+            out += std::format(L"Only {} KB free on this drive - it may be full.\n", space.available / 1024);
+        }
+
+        // Probe whether we can write a file into the folder right now; this distinguishes a
+        // folder-wide permission/lock problem from something blocking only the dump file.
+        const std::filesystem::path probe = folder / L"gwtoolbox_write_test.tmp";
+        std::filesystem::remove(probe, ec);
+        bool wrote = false;
+        if (const HANDLE h = CreateFileW(probe.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_TEMPORARY, nullptr); h != INVALID_HANDLE_VALUE) {
+            DWORD written = 0;
+            wrote = WriteFile(h, "x", 1, &written, nullptr) && written == 1;
+            CloseHandle(h);
+        }
+        else {
+            out += std::format(L"A test file could not be created in the folder either: {}\n", FormatWin32Error(GetLastError()));
+        }
+        std::filesystem::remove(probe, ec);
+
+        out += wrote
+            ? L"A test file could be written to the folder, so the folder itself is writable - "
+              L"something is blocking this specific file. Antivirus quarantine is the most common cause."
+            : L"Writing to the folder is being blocked entirely - check folder permissions, a "
+              L"read-only drive, or antivirus exclusions for your Guild Wars / GWToolbox folder.";
+        return out;
+    }
+
     struct GWDebugInfo {
         size_t len;
         uint32_t log_file_name[0x82];
@@ -197,7 +262,15 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
     const HANDLE hFile = CreateFileW(szFileName, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_WRITE | FILE_SHARE_READ, nullptr, CREATE_ALWAYS, 0, nullptr);
 
     if (hFile == INVALID_HANDLE_VALUE) {
-        std::wstring error = std::format(L"Failed to create crash file\nGetLastError: {}", GetLastError());
+        const DWORD last_error = GetLastError();
+        std::wstring error = std::format(
+            L"Guild Wars crashed!\n\n"
+            L"GWToolbox tried to create a crash file, but Windows refused to create it.\n\n"
+            L"GetLastError: {} ({})\n\n"
+            L"File: {}\n\n"
+            L"{}",
+            last_error, FormatWin32Error(last_error), szFileName, DiagnoseCrashFolder(szFileName)
+        );
         MessageBoxW(nullptr, error.c_str(), L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
         TerminateProcess(GetCurrentProcess(), 1);
     }
@@ -230,16 +303,42 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
     DWORD lastError = GetLastError();
     CloseHandle(hFile);
 
+    // Antivirus tools sometimes let the write succeed and then quarantine/delete the file,
+    // so re-open it to confirm it's actually there and non-empty before claiming success.
+    bool file_present = false;
+    {
+        const HANDLE hVerify = CreateFileW(szFileName, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (hVerify != INVALID_HANDLE_VALUE) {
+            LARGE_INTEGER file_size{};
+            file_present = GetFileSizeEx(hVerify, &file_size) && file_size.QuadPart > 0;
+            CloseHandle(hVerify);
+        }
+    }
+
+    const bool dump_ok = success && file_present;
+
     std::wstring error_info;
 
-    if (!success) {
-        error_info = std::format(
-            L"Guild Wars crashed!\n\n"
-            L"GWToolbox tried to create a crash dump, but MiniDumpWriteDump failed\n\n"
-            L"GetLastError: {}\n\n"
-            L"File: {}\n\n",
-            lastError, szFileName
-        );
+    if (!dump_ok) {
+        if (!success) {
+            error_info = std::format(
+                L"Guild Wars crashed!\n\n"
+                L"GWToolbox tried to create a crash dump, but MiniDumpWriteDump failed.\n\n"
+                L"GetLastError: {} ({})\n\n"
+                L"File: {}\n\n"
+                L"{}",
+                lastError, FormatWin32Error(lastError), szFileName, DiagnoseCrashFolder(szFileName)
+            );
+        }
+        else {
+            error_info = std::format(
+                L"Guild Wars crashed!\n\n"
+                L"GWToolbox wrote a crash dump, but the file is now empty or gone.\n\n"
+                L"File: {}\n\n"
+                L"{}",
+                szFileName, DiagnoseCrashFolder(szFileName)
+            );
+        }
     }
     else {
         error_info = L"Guild Wars crashed!\n\n";
@@ -264,7 +363,7 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
     }
     delete ExpParam;
 
-    MessageBoxW(nullptr, error_info.c_str(), success ? L"GWToolbox++ crash dump created!" : L"GWToolbox++ crash dump failed!", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_SETFOREGROUND | MB_TOPMOST);
+    MessageBoxW(nullptr, error_info.c_str(), dump_ok ? L"GWToolbox++ crash dump created!" : L"GWToolbox++ crash dump failed!", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_SETFOREGROUND | MB_TOPMOST);
 
     #ifdef _DEBUG
     if (IsDebuggerPresent()) {

--- a/GWToolboxdll/Modules/CrashHandler.cpp
+++ b/GWToolboxdll/Modules/CrashHandler.cpp
@@ -239,8 +239,7 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
     DWORD lastError = GetLastError();
     CloseHandle(hFile);
 
-    // Antivirus tools sometimes let the write succeed and then quarantine/delete the file,
-    // so re-open it to confirm it's actually there and non-empty before claiming success.
+    // Antivirus can let the write succeed then delete the file, so confirm it's really there and non-empty.
     bool file_present = false;
     {
         const HANDLE hVerify = CreateFileW(szFileName, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);

--- a/GWToolboxdll/Modules/CrashHandler.cpp
+++ b/GWToolboxdll/Modules/CrashHandler.cpp
@@ -11,75 +11,11 @@
 #include <Modules/Updater.h>
 #include <GWToolbox.h>
 #include <Defines.h>
+#include <Path.h>
 #include <Utils/TextUtils.h>
 
 namespace {
     char* tb_exception_message = nullptr;
-
-    // Turn a GetLastError() code into the human-readable description Windows ships with it.
-    std::wstring FormatWin32Error(const DWORD error_code)
-    {
-        LPWSTR buffer = nullptr;
-        const DWORD len = FormatMessageW(
-            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-            nullptr, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-            reinterpret_cast<LPWSTR>(&buffer), 0, nullptr);
-
-        std::wstring message = len && buffer ? std::wstring(buffer, len) : L"no description available";
-        if (buffer) {
-            LocalFree(buffer);
-        }
-        while (!message.empty() && (message.back() == L'\n' || message.back() == L'\r' || message.back() == L' ')) {
-            message.pop_back();
-        }
-        return message;
-    }
-
-    std::wstring ToWide(const std::error_code& ec)
-    {
-        return std::format(L"{} (category '{}', value {})", TextUtils::StringToWString(ec.message()), TextUtils::StringToWString(ec.category().name()), ec.value());
-    }
-
-    // Best-effort, non-throwing probe of the crashes folder so we report what's actually wrong
-    // (missing folder, full disk, blocked write) instead of guessing at the cause.
-    std::wstring DiagnoseCrashFolder(const std::filesystem::path& file)
-    {
-        std::error_code ec;
-        const std::filesystem::path folder = file.parent_path();
-
-        if (!std::filesystem::exists(folder, ec)) {
-            return ec
-                ? std::format(L"Could not access the crashes folder: {}", ToWide(ec))
-                : std::format(L"The crashes folder no longer exists ({}) - something deleted or moved it.", folder.wstring());
-        }
-
-        std::wstring out;
-        if (const auto space = std::filesystem::space(folder, ec); !ec && space.available < 16ull * 1024 * 1024) {
-            out += std::format(L"Only {} KB free on this drive - it may be full.\n", space.available / 1024);
-        }
-
-        // Probe whether we can write a file into the folder right now; this distinguishes a
-        // folder-wide permission/lock problem from something blocking only the dump file.
-        const std::filesystem::path probe = folder / L"gwtoolbox_write_test.tmp";
-        std::filesystem::remove(probe, ec);
-        bool wrote = false;
-        if (const HANDLE h = CreateFileW(probe.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_TEMPORARY, nullptr); h != INVALID_HANDLE_VALUE) {
-            DWORD written = 0;
-            wrote = WriteFile(h, "x", 1, &written, nullptr) && written == 1;
-            CloseHandle(h);
-        }
-        else {
-            out += std::format(L"A test file could not be created in the folder either: {}\n", FormatWin32Error(GetLastError()));
-        }
-        std::filesystem::remove(probe, ec);
-
-        out += wrote
-            ? L"A test file could be written to the folder, so the folder itself is writable - "
-              L"something is blocking this specific file. Antivirus quarantine is the most common cause."
-            : L"Writing to the folder is being blocked entirely - check folder permissions, a "
-              L"read-only drive, or antivirus exclusions for your Guild Wars / GWToolbox folder.";
-        return out;
-    }
 
     struct GWDebugInfo {
         size_t len;
@@ -269,7 +205,7 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
             L"GetLastError: {} ({})\n\n"
             L"File: {}\n\n"
             L"{}",
-            last_error, FormatWin32Error(last_error), szFileName, DiagnoseCrashFolder(szFileName)
+            last_error, FormatWindowsError(last_error), szFileName, PathDiagnoseWritability(crash_folder)
         );
         MessageBoxW(nullptr, error.c_str(), L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
         TerminateProcess(GetCurrentProcess(), 1);
@@ -327,7 +263,7 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
                 L"GetLastError: {} ({})\n\n"
                 L"File: {}\n\n"
                 L"{}",
-                lastError, FormatWin32Error(lastError), szFileName, DiagnoseCrashFolder(szFileName)
+                lastError, FormatWindowsError(lastError), szFileName, PathDiagnoseWritability(crash_folder)
             );
         }
         else {
@@ -336,7 +272,7 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
                 L"GWToolbox wrote a crash dump, but the file is now empty or gone.\n\n"
                 L"File: {}\n\n"
                 L"{}",
-                szFileName, DiagnoseCrashFolder(szFileName)
+                szFileName, PathDiagnoseWritability(crash_folder)
             );
         }
     }

--- a/GWToolboxdll/Modules/PluginModule.cpp
+++ b/GWToolboxdll/Modules/PluginModule.cpp
@@ -62,12 +62,12 @@ namespace {
             const DWORD err = GetLastError();
             const auto filename = plugin.path.filename();
             UnloadPlugin(plugin_ptr);
-            const auto name = TextUtils::PrintFilename(filename.string());
+            const auto name = TextUtils::PrintFilename(filename.wstring());
             std::wstring detail;
             if ((err == ERROR_VIRUS_INFECTED || err == ERROR_VIRUS_DELETED) && FindRecentDefenderBlock(filename.wstring(), 15, detail))
-                Log::Error("Failed to load plugin %s - Windows Defender blocked it: %s", name.c_str(), TextUtils::WStringToString(detail).c_str());
+                Log::ErrorW(L"Failed to load plugin %s - Windows Defender blocked it: %s", name.c_str(), detail.c_str());
             else
-                Log::Error("Failed to load plugin %s (LoadLibraryW)", name.c_str());
+                Log::ErrorW(L"Failed to load plugin %s (LoadLibraryW)", name.c_str());
             return false;
         }
         using ToolboxPluginInstanceFn = ToolboxPlugin* (*)();

--- a/GWToolboxdll/Modules/PluginModule.cpp
+++ b/GWToolboxdll/Modules/PluginModule.cpp
@@ -6,6 +6,7 @@
 #include <GWToolbox.h>
 #include <GWCA/Managers/ChatMgr.h>
 
+#include <Defender.h>
 #include <Modules/Resources.h>
 #include <filesystem>
 #include <string>
@@ -58,8 +59,15 @@ namespace {
             plugin.dll = LoadLibraryW(plugin.path.wstring().c_str());
         }
         if (!plugin.dll) {
+            const DWORD err = GetLastError();
+            const auto filename = plugin.path.filename();
             UnloadPlugin(plugin_ptr);
-            Log::Error("Failed to load plugin %s (LoadLibraryW)", TextUtils::PrintFilename(plugin.path.filename().string()).c_str());
+            const auto name = TextUtils::PrintFilename(filename.string());
+            std::wstring detail;
+            if ((err == ERROR_VIRUS_INFECTED || err == ERROR_VIRUS_DELETED) && FindRecentDefenderBlock(filename.wstring(), 15, detail))
+                Log::Error("Failed to load plugin %s - Windows Defender blocked it: %s", name.c_str(), TextUtils::WStringToString(detail).c_str());
+            else
+                Log::Error("Failed to load plugin %s (LoadLibraryW)", name.c_str());
             return false;
         }
         using ToolboxPluginInstanceFn = ToolboxPlugin* (*)();

--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -585,13 +585,12 @@ bool Resources::EnsureFolderExists(const std::filesystem::path& path, std::wstri
     std::error_code ec;
     if (create_directories(path, ec)) return true;
 
-    error_description = std::format(L"Failed to create folder:\n{}\n\nReason: {} (code {})",
-                                    path.wstring(), TextUtils::StringToWString(ec.message()), ec.value());
+    error_description = std::format(L"Failed to create folder:\n{}\n\nReason: {} (code {})\n\n{}",
+                                    path.wstring(), FormatWindowsError(ec.value()), ec.value(), PathDiagnoseWritability(path.parent_path()));
     // ERROR_ACCESS_DENIED / ERROR_VIRUS_INFECTED / ERROR_VIRUS_DELETED are what antivirus and Controlled Folder Access return when blocking the write
     if (ec.value() == ERROR_ACCESS_DENIED || ec.value() == ERROR_VIRUS_INFECTED || ec.value() == ERROR_VIRUS_DELETED) {
-        error_description += L"\n\nThis is likely caused by antivirus software or Windows Defender Controlled Folder Access "
-            L"blocking writes to your Documents folder. Try allowing Guild Wars in your antivirus, "
-            L"or turning off Controlled Folder Access.";
+        error_description += L"\n\nIf this is your Documents folder, Windows Defender Controlled Folder Access "
+            L"may be the cause - try allowing Guild Wars, or turning Controlled Folder Access off.";
     }
     return false;
 }

--- a/GWToolboxdll/Modules/TexmodModule.cpp
+++ b/GWToolboxdll/Modules/TexmodModule.cpp
@@ -22,6 +22,7 @@
 #include <GWCA/Utilities/Hooker.h>
 
 #include <ImGuiAddons.h>
+#include <Defender.h>
 #include <Modules/Resources.h>
 #include <Utils/FontLoader.h>
 #include <Utils/TextUtils.h>
@@ -310,7 +311,11 @@ namespace {
 
         gmodDll = LoadLibraryW(path.wstring().c_str());
         if (!gmodDll) {
+            const DWORD err = GetLastError();
             statusMessage = "Error: Could not load gMod.dll.";
+            std::wstring detail;
+            if ((err == ERROR_VIRUS_INFECTED || err == ERROR_VIRUS_DELETED) && FindRecentDefenderBlock(L"gMod.dll", 15, detail))
+                statusMessage += " Windows Defender blocked it: " + TextUtils::WStringToString(detail);
             return false;
         }
         if (!ResolveTextureClientFunctions()) {


### PR DESCRIPTION
## What

Turns the unhelpful `Failed to create crash file` / `GetLastError: 2` message into a real diagnosis, and generalises antivirus-block detection so it's shared across everywhere we write or load code on disk.

### Crash handler
- **Human-readable Win32 error** via `FormatMessage`, plus the file path.
- **Folder writability probe** (`PathDiagnoseWritability`, in `Core/Path`): missing folder, full disk, or a write block — distinguishing a folder-wide permission/lock problem from antivirus blocking one file.
- **Detects "vanished after success"** — re-checks the dump exists and is non-empty after `MiniDumpWriteDump` reports success.

### Shared antivirus-block lookup (`Core/Defender`)
The launcher already had `FindRecentDefenderBlock` (querying the Windows Defender Operational log), but it was launcher-only, fixed to a 30s window and malware/ASR event IDs. Promoted to `Core` and generalised:
- `RunPowerShellCommand` + `FindRecentDefenderBlock(needle, seconds, detail)`.
- Broadened event IDs to include **Controlled Folder Access blocks (1123)** — what catches blocked file *writes* — alongside malware (1116-1119) and ASR (1121).
- Launcher `WindowsDefender.cpp` now reuses the Core helpers (~100 lines deduped).

### Wired into the failure paths
- **Crash handler** appends the matching Defender event when the dump can't be created/written or vanishes.
- **GWCA load**, **gMod load**, and **plugin load** (the `LoadLibraryW` sites) append the Defender event when the load fails with `ERROR_VIRUS_INFECTED`/`ERROR_VIRUS_DELETED`. Gating on those codes keeps the PowerShell lookup to the genuine quarantine case.
- **Updater**: the new DLL is written by the updater but loaded by the launcher's inject path, which already runs the lookup — covered end-to-end without touching the download path.

`Resources::EnsureFolderExists` also reuses the writability helper, keeping only its Documents-specific Controlled Folder Access hint.

## Why

Per Discord: the original message was useless, the first cut over-blamed antivirus, the diagnosis shouldn't live in two places — and the Defender event lookup is most valuable exactly where we download/write/load DLLs at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)