### PR TITLE
feat(inject): diagnose AV-blocked memory reads instead of blaming a stale RVA

### DIFF
--- a/GWToolbox/Inject.cpp
+++ b/GWToolbox/Inject.cpp
@@ -94,9 +94,17 @@ InjectReply InjectWindow::AskInjectProcess(Process* target_process)
 
     uintptr_t charname_rva = 0;
     uintptr_t email_rva = 0;
+    bool read_blocked = false;
+    DWORD read_error = 0;
 
     for (int i = 0; i < processes.size(); i++) {
         const ProcessScanner scanner(&processes[i]);
+        if (!scanner.IsValid()) {
+            // Couldn't read the GW image to scan it - almost always AV/anti-tamper stripping our access.
+            read_blocked = true;
+            read_error = scanner.GetError();
+            continue;
+        }
         if (!scanner.FindPatternRva("\x6a\x14\x83\xc0\x18\x50\x68", "xxxxxxx", 7, &charname_rva)) {
             continue;
         }
@@ -109,6 +117,10 @@ InjectReply InjectWindow::AskInjectProcess(Process* target_process)
     }
 
     if (!charname_rva || !email_rva) {
+        if (read_blocked) {
+            fprintf(stderr, "Couldn't read Guild Wars memory to scan for RVAs (error %lu) - likely anti-virus interference\n", read_error);
+            return InjectReply_MemoryBlocked;
+        }
         fprintf(stderr, "Couldn't find charname/email RVAs in any potential process\n");
         return InjectReply_PatternError;
     }

--- a/GWToolbox/Inject.h
+++ b/GWToolbox/Inject.h
@@ -7,8 +7,9 @@
 enum InjectReply {
     InjectReply_Inject,
     InjectReply_Cancel,
-    InjectReply_NoProcess, 
+    InjectReply_NoProcess,
     InjectReply_PatternError,
+    InjectReply_MemoryBlocked,
     InjectReply_NoValidProcess
 };
 

--- a/GWToolbox/Process.cpp
+++ b/GWToolbox/Process.cpp
@@ -49,7 +49,8 @@ bool Process::Open(const uint32_t pid, const DWORD rights)
     Close();
     m_hProcess = OpenProcess(rights, FALSE, pid);
     if (m_hProcess == nullptr) {
-        // fprintf(stderr, "OpenProcess failed: %lu\n", GetLastError());
+        m_last_error = GetLastError();
+        // fprintf(stderr, "OpenProcess failed: %lu\n", m_last_error);
         return false;
     }
 
@@ -80,7 +81,8 @@ bool Process::Read(const uintptr_t address, void* buffer, const size_t size) con
         &NumberOfBytesRead);
 
     if (!(success && size == NumberOfBytesRead)) {
-        fprintf(stderr, "ReadProcessMemory failed: %lu\n", GetLastError());
+        m_last_error = GetLastError();
+        fprintf(stderr, "ReadProcessMemory failed: %lu\n", m_last_error);
         return false;
     }
 
@@ -119,6 +121,7 @@ bool Process::GetName(std::wstring& name)
         if (!QueryFullProcessImageNameW(m_hProcess, 0, process_path.data(), &size)) {
             const DWORD error = GetLastError();
             if (error != ERROR_INSUFFICIENT_BUFFER) {
+                m_last_error = error;
                 fprintf(stderr, "QueryFullProcessImageNameW failed: %lu\n", error);
                 Close();
                 return false;
@@ -159,26 +162,30 @@ bool Process::GetModule(ProcessModule* module, const wchar_t* module_name) const
 
     DWORD cbNeeded;
     if (!EnumProcessModules(m_hProcess, nullptr, 0, &cbNeeded)) {
-        fprintf(stderr, "EnumProcessModules failed: %lu\n", GetLastError());
+        m_last_error = GetLastError();
+        fprintf(stderr, "EnumProcessModules failed: %lu\n", m_last_error);
         return false;
     }
 
     std::vector<HMODULE> handles(cbNeeded / sizeof(HMODULE));
     if (!EnumProcessModules(m_hProcess, handles.data(), cbNeeded, &cbNeeded)) {
-        fprintf(stderr, "EnumProcessModules failed: %lu\n", GetLastError());
+        m_last_error = GetLastError();
+        fprintf(stderr, "EnumProcessModules failed: %lu\n", m_last_error);
         return false;
     }
 
     for (const HMODULE hModule : handles) {
         wchar_t name[512];
         if (!GetModuleBaseNameW(m_hProcess, hModule, name, _countof(name))) {
-            fprintf(stderr, "GetModuleBaseNameW failed: %lu\n", GetLastError());
+            m_last_error = GetLastError();
+            fprintf(stderr, "GetModuleBaseNameW failed: %lu\n", m_last_error);
             return false;
         }
 
         MODULEINFO ModuleInfo;
         if (!GetModuleInformation(m_hProcess, hModule, &ModuleInfo, sizeof(ModuleInfo))) {
-            fprintf(stderr, "GetModuleInformation failed: %lu\n", GetLastError());
+            m_last_error = GetLastError();
+            fprintf(stderr, "GetModuleInformation failed: %lu\n", m_last_error);
             return false;
         }
 
@@ -326,12 +333,20 @@ bool GetProcessesByWindowClass(std::vector<Process>& processes, const wchar_t* c
 ProcessScanner::ProcessScanner(Process* process)
 {
     ProcessModule module;
-    process->GetModule(&module);
+    if (!process->GetModule(&module)) {
+        m_error = process->GetLastErrorCode();
+        return;
+    }
 
     m_base = module.base;
     m_size = module.size;
     m_buffer = new uint8_t[module.size];
-    process->Read(module.base, m_buffer, m_size);
+    if (!process->Read(module.base, m_buffer, m_size)) {
+        m_error = process->GetLastErrorCode();
+        return;
+    }
+
+    m_valid = true;
 }
 
 ProcessScanner::~ProcessScanner()

--- a/GWToolbox/Process.h
+++ b/GWToolbox/Process.h
@@ -32,9 +32,13 @@ public:
     HANDLE GetHandle() const { return m_hProcess; }
     DWORD GetProcessId() const;
 
+    // Win32 error captured at the last failing OpenProcess/Read/GetModule call.
+    DWORD GetLastErrorCode() const { return m_last_error; }
+
 private:
     HANDLE m_hProcess = nullptr;
     DWORD m_Rights = 0;
+    mutable DWORD m_last_error = 0;
 };
 
 bool GetProcessesByName(std::vector<Process>& processes, const wchar_t* name, DWORD rights = PROCESS_ALL_ACCESS);
@@ -49,8 +53,15 @@ public:
     uintptr_t FindPattern(const char* pattern, const char* mask, int Offset) const;
     bool FindPatternRva(const char* pattern, const char* mask, int offset, uintptr_t* rva) const;
 
+    // False if the process image couldn't be read (module enumeration or ReadProcessMemory failed).
+    bool IsValid() const { return m_valid; }
+    // Win32 error from the failing call when IsValid() is false.
+    DWORD GetError() const { return m_error; }
+
 private:
     uintptr_t m_base = 0;
     size_t m_size = 0;
     uint8_t* m_buffer = nullptr;
+    bool m_valid = false;
+    DWORD m_error = 0;
 };

--- a/GWToolbox/main.cpp
+++ b/GWToolbox/main.cpp
@@ -269,6 +269,18 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int n
         return 1;
     }
 
+    if (reply == InjectReply_MemoryBlocked) {
+        std::wstring message =
+            L"GWToolbox found Guild Wars but couldn't read its memory to locate your character.\n\n"
+            L"This is almost always anti-virus or Controlled Folder Access blocking GWToolbox. "
+            L"Add an exclusion for your GWToolbox folder in Windows Security, allow GWToolbox through Controlled Folder Access, then re-launch.";
+        std::wstring detail;
+        if (FindRecentDefenderBlock(L"Gw.exe", 30, detail))
+            message += L"\n\nWindows Defender reported:\n" + detail;
+        MessageBoxW(nullptr, message.c_str(), L"GWToolbox - Error", MB_OK | MB_ICONERROR | MB_TOPMOST);
+        return 1;
+    }
+
     if (reply == InjectReply_NoValidProcess) {
         if (IsRunningAsAdmin()) {
             ShowError(L"Failed to inject GWToolbox into Guild Wars\n");

--- a/GWToolbox/main.cpp
+++ b/GWToolbox/main.cpp
@@ -275,7 +275,7 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int n
             L"This is almost always anti-virus or Controlled Folder Access blocking GWToolbox. "
             L"Add an exclusion for your GWToolbox folder in Windows Security, allow GWToolbox through Controlled Folder Access, then re-launch.";
         std::wstring detail;
-        if (FindRecentDefenderBlock(L"Gw.exe", 30, detail))
+        if (FindRecentDefenderBlock(L"Gw.exe", 5, detail))
             message += L"\n\nWindows Defender reported:\n" + detail;
         MessageBoxW(nullptr, message.c_str(), L"GWToolbox - Error", MB_OK | MB_ICONERROR | MB_TOPMOST);
         return 1;


### PR DESCRIPTION
## Context

Follow-up to the Defender-diagnostics work just merged into `dev`. From the `#gwtoolbox` thread about *"Couldn't find character name RVA."* errors: this message blames a stale signature / out-of-date launcher, but the real cause is almost always anti-virus or Controlled Folder Access blocking the launcher from reading Guild Wars' memory.

## The pinch points AV intercepts

The RVA scan in `InjectWindow::AskInjectProcess` runs entirely inside the `ProcessScanner` ctor, and every step is a classic AV target on a foreign process:

- **`OpenProcess(PROCESS_ALL_ACCESS, …)`** — full-access handle to GW is routinely denied (`ERROR_ACCESS_DENIED`).
- **`EnumProcessModules` / `GetModuleInformation`** — needed to get the module base+size.
- **`ReadProcessMemory(base, …, SizeOfImage)`** — bulk-reading another process's whole image is exactly the scanner/cheat signature AV blocks, failing with `ERROR_ACCESS_DENIED` (5) or `ERROR_PARTIAL_COPY` (299).

The root cause of the misleading message: the `ProcessScanner` ctor **discarded the return values of both `GetModule` and `Read`**. On a blocked read it proceeded to scan an empty/garbage buffer, found nothing, and returned `InjectReply_PatternError` → *"Couldn't find character name RVA. You need to update the launcher."* AV interference and a genuinely-broken signature were collapsed into one message — and it's nearly always the former.

## Changes

- **`ProcessScanner`** now checks `GetModule`/`Read` and records `IsValid()` + the captured Win32 error (`GetError()`).
- **`Process`** stashes the last Win32 error at each failing `OpenProcess`/`Read`/`GetModule`/`GetName` call, exposed via `GetLastErrorCode()` (also tidies the existing `fprintf`s to log the captured code).
- **`AskInjectProcess`** distinguishes a blocked read from a real pattern miss via a new `InjectReply_MemoryBlocked`. The old `InjectReply_PatternError` now means what it says — read succeeded, signature genuinely absent (i.e. GW actually updated).
- **`main.cpp`** shows an AV / Controlled-Folder-Access message for `InjectReply_MemoryBlocked`, leveraging the recently-merged `FindRecentDefenderBlock` to append any matching Defender event (mirrors the gwca/gMod/crash-file handlers).

## Notes / possible follow-up

- Not addressed here: if AV denies `OpenProcess` for **every** GW client, `GetGuildWarsProcesses()` returns empty and we still report `InjectReply_NoProcess` ("ensure Guild Wars is running"). Detecting "GW window exists but the process can't be opened" would need a signal plumbed out of `GetProcessesByWindowClass`; happy to do it in a follow-up.
- Windows/MSVC-only project, so this hasn't been compiled locally — please give it a build on CI/Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)