### PR TITLE
fix(settings): match on-screen text in search + make sub-headers searchable/navigable

### DIFF
--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -73,6 +73,8 @@ namespace {
     GW::MemoryPatcher gold_confirm_patch;
     GW::MemoryPatcher remove_skill_warmup_duration_patch;
 
+    constexpr char combine_overhead_numbers_help[] = "Merges damage/heal numbers stacking on an agent into a single floater to reduce UI noise";
+
     void SetWindowTitle(const bool enabled)
     {
         if (!enabled) {
@@ -1456,6 +1458,7 @@ void GameSettings::Initialize()
 {
     ToolboxModule::Initialize();
     SettingsRegistry::Register(this, settings);
+    SettingsRegistry::Describe(this, "combine_overhead_numbers", "Combine floating numbers above character", combine_overhead_numbers_help);
 
     OnSkillTomeWindow_UIMessage_Func = (GW::UI::UIInteractionCallback)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("GmSkTome.cpp", "selection.skillId", 0, 0), 0xfff);
     Log::Log("[GameSettings] OnSkillTomeWindow_UIMessage_Func = %p\n", OnSkillTomeWindow_UIMessage_Func);
@@ -1958,7 +1961,7 @@ void GameSettings::DrawSettingsInternal()
     ImGui::NextSpacedElement();
     ImGui::Checkbox("Healing given", &settings.block_giving_heals);
     ImGui::Unindent();
-    ImGui::CheckboxWithHelp("Combine floating numbers above character", &settings.combine_overhead_numbers, "Merges damage/heal numbers stacking on an agent into a single floater to reduce UI noise");
+    ImGui::CheckboxWithHelp("Combine floating numbers above character", &settings.combine_overhead_numbers, combine_overhead_numbers_help);
     if (ImGui::Checkbox("Show experience progress instead of current level on your experience bar", &settings.useful_level_progress_label)) {
         GW::GameThread::Enqueue(SetXpBarLabel);
     }

--- a/GWToolboxdll/Utils/SettingsRegistry.cpp
+++ b/GWToolboxdll/Utils/SettingsRegistry.cpp
@@ -76,6 +76,21 @@ namespace SettingsRegistry {
         detail::AddEntry(module, key, Type::Float2, ptr, false, description);
     }
 
+    void Describe(ToolboxModule* module, const std::string_view key, const std::string_view label, const std::string_view description)
+    {
+        const auto found = std::ranges::find_if(entries, [module, key](const Entry& e) {
+            return e.module == module && e.key == key;
+        });
+        if (found == entries.end()) {
+            Log::Log("SettingsRegistry::Describe: no entry for %s.%.*s", module->Name(), static_cast<int>(key.size()), key.data());
+            return;
+        }
+        if (!label.empty()) {
+            found->label = label;
+        }
+        found->description = description;
+    }
+
     void Unregister(ToolboxModule* module)
     {
         std::erase_if(entries, [module](const Entry& e) { return e.module == module; });

--- a/GWToolboxdll/Utils/SettingsRegistry.h
+++ b/GWToolboxdll/Utils/SettingsRegistry.h
@@ -91,6 +91,10 @@ namespace SettingsRegistry {
     void RegisterField(ToolboxModule* module, std::string_view key, Colors::SettingColor* ptr, std::string_view description = {});
     void RegisterField(ToolboxModule* module, std::string_view key, std::array<float, 2>* ptr, std::string_view description = {});
 
+    // Override the auto-prettified label and attach a description on an already-registered entry, so
+    // settings search, the locate-highlight and /tb_setting match the text the user actually sees on screen.
+    void Describe(ToolboxModule* module, std::string_view key, std::string_view label, std::string_view description = {});
+
     // Called from ToolboxModule::Terminate.
     void Unregister(ToolboxModule* module);
 

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -40,6 +40,7 @@
 #include <Modules/QuestModule.h>
 #include <Modules/Resources.h>
 #include <Utils/TextUtils.h>
+#include <Windows/SettingsWindow.h>
 #include "Minimap.h"
 #include <Utils/FontLoader.h>
 #include <Utils/ToolboxUtils.h>
@@ -846,6 +847,10 @@ void Minimap::Initialize()
     custom_renderer.RegisterSettings(this);
     GameWorldRenderer::RegisterSettings(this);
 
+    for (const char* sub : {"Ranges", "Pings and drawings", "AoE Effects", "Symbols", "Terrain", "Hero flagging", "In-game rendering"}) {
+        SettingsWindow::RegisterSubSection(SettingsName(), sub);
+    }
+
     uintptr_t address = GW::Scanner::Find("\x8b\x46\x40\x85\xc0\x74\x0c", "xxxxx?x", 0x5);
     if (address) {
         hide_flagging_controls_patch.SetPatch(address, "\xeb", 1);
@@ -1100,19 +1105,19 @@ void Minimap::DrawSettingsInternal()
     ImGui::Text("You can set the color alpha to 0 to disable any minimap feature.");
     // agent_rendered has its own TreeNodes
     agent_renderer.DrawSettings();
-    if (ImGui::TreeNodeEx("Ranges", ImGuiTreeNodeFlags_FramePadding | ImGuiTreeNodeFlags_SpanAvailWidth)) {
+    if (SettingsWindow::SubSectionHeader(SettingsName(), "Ranges")) {
         range_renderer.DrawSettings();
         ImGui::TreePop();
     }
-    if (ImGui::TreeNodeEx("Pings and drawings", ImGuiTreeNodeFlags_FramePadding | ImGuiTreeNodeFlags_SpanAvailWidth)) {
+    if (SettingsWindow::SubSectionHeader(SettingsName(), "Pings and drawings")) {
         pingslines_renderer.DrawSettings();
         ImGui::TreePop();
     }
-    if (ImGui::TreeNodeEx("AoE Effects", ImGuiTreeNodeFlags_FramePadding | ImGuiTreeNodeFlags_SpanAvailWidth)) {
+    if (SettingsWindow::SubSectionHeader(SettingsName(), "AoE Effects")) {
         EffectRenderer::DrawSettings();
         ImGui::TreePop();
     }
-    if (ImGui::TreeNodeEx("Symbols", ImGuiTreeNodeFlags_FramePadding | ImGuiTreeNodeFlags_SpanAvailWidth)) {
+    if (SettingsWindow::SubSectionHeader(SettingsName(), "Symbols")) {
         symbols_renderer.DrawSettings();
         ImGui::Separator();
         ImGui::Text("Cardinal (N/S/E/W) directions");
@@ -1123,7 +1128,7 @@ void Minimap::DrawSettingsInternal()
         ImGui::SliderFloat("Font size##cardinal", &cardinal_font_size, 16.f, 56.f, "%.0f px");
         ImGui::TreePop();
     }
-    if (ImGui::TreeNodeEx("Terrain", ImGuiTreeNodeFlags_FramePadding | ImGuiTreeNodeFlags_SpanAvailWidth)) {
+    if (SettingsWindow::SubSectionHeader(SettingsName(), "Terrain")) {
         ImGui::SmallConfirmButton("Restore Defaults", "Are you sure?", [&](bool result, void*) {
             if (result) {
                 color_map = 0xFF999999;
@@ -1137,13 +1142,13 @@ void Minimap::DrawSettingsInternal()
         ImGui::TreePop();
     }
     custom_renderer.DrawSettings();
-    if (ImGui::TreeNodeEx("Hero flagging", ImGuiTreeNodeFlags_FramePadding | ImGuiTreeNodeFlags_SpanAvailWidth)) {
+    if (SettingsWindow::SubSectionHeader(SettingsName(), "Hero flagging")) {
         ImGui::Checkbox("Show hero flag controls", &hero_flag_controls_show);
         ImGui::CheckboxWithHelp("Attach to minimap", &hero_flag_window_attach, "If disabled, you can move/resize the window with 'Unlock Move All'.");
         Colors::DrawSettingHueWheel("Background", &hero_flag_controls_background);
         ImGui::TreePop();
     }
-    if (ImGui::TreeNodeEx("In-game rendering", ImGuiTreeNodeFlags_FramePadding | ImGuiTreeNodeFlags_SpanAvailWidth)) {
+    if (SettingsWindow::SubSectionHeader(SettingsName(), "In-game rendering")) {
         GameWorldRenderer::DrawSettings();
         ImGui::TreePop();
     }

--- a/GWToolboxdll/Windows/SettingsWindow.cpp
+++ b/GWToolboxdll/Windows/SettingsWindow.cpp
@@ -26,6 +26,10 @@ namespace {
         int score = 0;
     };
 
+    // Settings sub-headers (ImGui::TreeNodeEx within a section's draw) declared via RegisterSubSection,
+    // so search can surface them even while the parent section is collapsed.
+    std::vector<std::pair<std::string, std::string>> sub_sections; // {section, label}
+
     // -1 = no match; lower is better: exact prefix > word prefix > substring
     int MatchScore(const std::string& text_lower, const std::string& query_lower)
     {
@@ -172,6 +176,12 @@ namespace {
                 results.push_back({e.module->SettingsName(), e.label, best});
             }
         }
+        for (const auto& [section, label] : sub_sections) {
+            const auto score = MatchScore(TextUtils::ToLower(label), query_lower);
+            if (score >= 0) {
+                results.push_back({section, label, score});
+            }
+        }
         // The "Enable the following features" checkboxes; labels match the checkbox text so locate works
         const auto* toggles_section = ToolboxSettings::Instance().SettingsName();
         for (const auto& [name, description] : ToolboxSettings::GetOptionalModuleToggles()) {
@@ -241,7 +251,7 @@ namespace {
             const auto label = activated->label;
             search_buf[0] = 0;
             last_query.clear();
-            SettingsWindow::Instance().NavigateToSection(section.c_str());
+            SettingsWindow::Instance().NavigateToSection(section.c_str(), !label.empty());
             if (!label.empty()) {
                 locate.Arm(label);
             }
@@ -249,11 +259,31 @@ namespace {
     }
 } // namespace
 
-void SettingsWindow::NavigateToSection(const char* section)
+void SettingsWindow::NavigateToSection(const char* section, const bool expand_subsections)
 {
     visible = true;
     pending_uncollapse = true;
     pending_navigate_to = section;
+    pending_expand_subsections = expand_subsections;
+}
+
+void SettingsWindow::RegisterSubSection(const char* section, const char* label)
+{
+    const auto exists = std::ranges::any_of(sub_sections, [&](const auto& e) {
+        return e.first == section && e.second == label;
+    });
+    if (!exists) {
+        sub_sections.emplace_back(section, label);
+    }
+}
+
+bool SettingsWindow::SubSectionHeader(const char* section, const char* label)
+{
+    auto& self = Instance();
+    if (self.pending_expand_subsections && self.pending_navigate_to == section) {
+        ImGui::SetNextItemOpen(true, ImGuiCond_Always);
+    }
+    return ImGui::TreeNodeEx(label, ImGuiTreeNodeFlags_FramePadding | ImGuiTreeNodeFlags_SpanAvailWidth);
 }
 
 void SettingsWindow::Initialize()
@@ -507,7 +537,10 @@ void SettingsWindow::Draw(IDirect3DDevice9*)
     ImGui::End();
     UpdateLocate();
     // Clear only targets present at frame start (consumed or stale); keep a mid-draw set for next frame.
-    if (had_pending_navigate) pending_navigate_to.clear();
+    if (had_pending_navigate) {
+        pending_navigate_to.clear();
+        pending_expand_subsections = false;
+    }
 }
 
 bool SettingsWindow::DrawSettingsSection(const char* section)

--- a/GWToolboxdll/Windows/SettingsWindow.h
+++ b/GWToolboxdll/Windows/SettingsWindow.h
@@ -28,8 +28,16 @@ public:
 
     bool DrawSettingsSection(const char* section);
 
-    // Open this window and scroll/expand the given settings section
-    void NavigateToSection(const char* section);
+    // Open this window and scroll/expand the given settings section. With expand_subsections set, any
+    // SubSectionHeader() tree nodes in that section are forced open so a nested setting can be located.
+    void NavigateToSection(const char* section, bool expand_subsections = false);
+
+    // Drop-in for ImGui::TreeNodeEx in settings draw code: force-opens the sub-header while navigating to
+    // a setting inside section, so the existing locate-highlight can reach controls nested under it.
+    static bool SubSectionHeader(const char* section, const char* label);
+
+    // Declare a settings sub-header (call from a module's Initialize) so it appears in settings search.
+    static void RegisterSubSection(const char* section, const char* label);
 
     size_t sep_modules = 0;
     size_t sep_windows = 0;
@@ -40,4 +48,5 @@ private:
     bool hide_when_entering_explorable = false;
     bool pending_uncollapse = false;
     std::string pending_navigate_to;
+    bool pending_expand_subsections = false;
 };


### PR DESCRIPTION
From the #gwtoolbox thread: settings search didn't match the text shown on screen, and the jump-to-setting couldn't reach controls nested under sub-headers (e.g. the whole Minimap section).

## 1. Search matches the on-screen text (combine-floats)

Searching **float** didn't find the *"Combine floating numbers above character"* toggle. The search indexes each `SettingsRegistry` entry's `label` (auto-prettified from the **member name** `combine_overhead_numbers` → "Combine overhead numbers") and `description` (empty for struct-registered settings). So only *combine/overhead/numbers* matched. The divergent label also broke the locate-highlight, which couldn't match "Combine overhead numbers" against the rendered checkbox text.

- Add `SettingsRegistry::Describe(module, key, label, description)` to override the auto-prettified label and attach a description on an already-registered entry (no effect on persistence).
- Apply it to `combine_overhead_numbers`, pointing at the real checkbox label + help text (now a shared constant so tooltip and search text can't drift).

Result: *float*, *floating*, *character*, *merge*, *damage*, *heal* all find it, and the jump now scrolls to + highlights the right checkbox.

## 2. Sub-section headers searchable + auto-navigable (Minimap)

Settings nested under `ImGui::TreeNodeEx` sub-headers couldn't be found: the sub-header names (Ranges, Symbols, Terrain, …) weren't indexed, and even the *registered* leaf settings inside them couldn't be highlighted because their tree node stays collapsed, so the located item never renders.

- Add `SettingsWindow::RegisterSubSection` + a `SubSectionHeader()` drop-in for `ImGui::TreeNodeEx` that registers the sub-header for search and force-opens it while navigating to a setting in that section.
- `NavigateToSection` gains an `expand_subsections` flag (set whenever a result targets a label) so the existing locate-highlight can reach controls nested under a sub-header.
- Wired up the Minimap's top-level sub-headers (Ranges, Pings and drawings, AoE Effects, Symbols, Terrain, Hero flagging, In-game rendering).

Follow-up candidates: the renderers' own nested tree nodes (agent/custom renderers, "Profession colors") and registering the remaining unregistered leaf controls for per-control search.

> Note: I can't run the Windows/D3D9 client in my environment, so the ImGui scroll/expand/highlight timing needs an in-app sanity check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)