### PR TITLE
fix(crash): stop crash handler re-entering when Documents folder is blocked (CFA/AV)

### DIFF
--- a/GWToolboxdll/Modules/CrashHandler.cpp
+++ b/GWToolboxdll/Modules/CrashHandler.cpp
@@ -27,6 +27,21 @@ namespace {
         return L"";
     }
 
+    // Resolve the crashes folder WITHOUT asserting. Resources::GetPath() runs through
+    // GetComputerFolderPath(), which ASSERTs when the Documents folder can't be resolved or
+    // created (e.g. Controlled Folder Access blocking it). That assert re-enters this crash
+    // handler, so resolving the path defensively keeps a blocked folder from cascading into a
+    // secondary crash and lets EnsureFolderExists report the real cause to the user.
+    std::wstring ResolveCrashFolder()
+    {
+        std::filesystem::path folder;
+        if (!PathGetDocumentsPath(folder, L"GWToolboxpp"))
+            return L"";
+        if (std::filesystem::path computer; PathGetComputerName(computer))
+            folder /= computer;
+        return (folder / L"crashes").wstring();
+    }
+
     struct GWDebugInfo {
         size_t len;
         uint32_t log_file_name[0x82];
@@ -144,7 +159,21 @@ void CrashHandler::FatalAssert(const char* expr, const char* file, const unsigne
 
 LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const char* extra_info)
 {
-
+    // A crash while handling a crash must not recurse. This happens when the crash-dump folder
+    // can't be reached (most often Controlled Folder Access or antivirus blocking Documents),
+    // so resolving or creating it asserts again and re-enters here. Bail with a clear message.
+    static volatile LONG crashing = 0;
+    if (InterlockedExchange(&crashing, 1) != 0) {
+        MessageBoxW(nullptr,
+            L"Guild Wars crashed, and GWToolbox crashed again while trying to write the crash dump.\n\n"
+            L"This almost always means something is blocking your Documents\\GWToolboxpp folder - "
+            L"usually Windows Defender Controlled Folder Access or antivirus.\n\n"
+            L"Allow Guild Wars through Controlled Folder Access, or add an exclusion for your "
+            L"GWToolbox folder, then try again.",
+            L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_SETFOREGROUND | MB_TOPMOST);
+        TerminateProcess(GetCurrentProcess(), 1);
+        return EXCEPTION_EXECUTE_HANDLER;
+    }
 
     // Disable WER right at the start of crash handling
     SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
@@ -178,10 +207,21 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
     }
 #endif
 
-    const std::wstring crash_folder = Resources::GetPath(L"crashes");
+    const std::wstring crash_folder = ResolveCrashFolder();
 
     std::wstring ensure_folder_error;
+    if (crash_folder.empty()) {
+        std::wstring error =
+            L"Guild Wars crashed!\n\n"
+            L"GWToolbox couldn't find your Documents folder to write a crash dump.\n\n"
+            L"This is usually Windows Defender Controlled Folder Access or antivirus blocking access - "
+            L"allow Guild Wars through Controlled Folder Access, or add an exclusion for your GWToolbox folder.";
+        error += RecentDefenderBlock(L"GWToolbox");
+        MessageBoxW(nullptr, error.c_str(), L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
+        TerminateProcess(GetCurrentProcess(), 1);
+    }
     if (!Resources::EnsureFolderExists(crash_folder.c_str(), ensure_folder_error)) {
+        ensure_folder_error += RecentDefenderBlock(crash_folder);
         MessageBoxW(nullptr, ensure_folder_error.c_str(), L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
         TerminateProcess(GetCurrentProcess(), 1);
     }

--- a/GWToolboxdll/Modules/CrashHandler.cpp
+++ b/GWToolboxdll/Modules/CrashHandler.cpp
@@ -27,11 +27,7 @@ namespace {
         return L"";
     }
 
-    // Resolve the crashes folder WITHOUT asserting. Resources::GetPath() runs through
-    // GetComputerFolderPath(), which ASSERTs when the Documents folder can't be resolved or
-    // created (e.g. Controlled Folder Access blocking it). That assert re-enters this crash
-    // handler, so resolving the path defensively keeps a blocked folder from cascading into a
-    // secondary crash and lets EnsureFolderExists report the real cause to the user.
+    // Resolve the crashes folder without asserting; Resources::GetPath() would assert and re-enter the crash handler when Documents is blocked.
     std::wstring ResolveCrashFolder()
     {
         std::filesystem::path folder;
@@ -159,9 +155,7 @@ void CrashHandler::FatalAssert(const char* expr, const char* file, const unsigne
 
 LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const char* extra_info)
 {
-    // A crash while handling a crash must not recurse. This happens when the crash-dump folder
-    // can't be reached (most often Controlled Folder Access or antivirus blocking Documents),
-    // so resolving or creating it asserts again and re-enters here. Bail with a clear message.
+    // A crash while handling a crash (e.g. resolving the blocked crash folder asserts again) must not recurse.
     static volatile LONG crashing = 0;
     if (InterlockedExchange(&crashing, 1) != 0) {
         MessageBoxW(nullptr,

--- a/GWToolboxdll/Modules/CrashHandler.cpp
+++ b/GWToolboxdll/Modules/CrashHandler.cpp
@@ -27,6 +27,15 @@ namespace {
         return L"";
     }
 
+    // The assertion/exception that triggered the crash, so a screenshot shows the root cause even when no dump could be written.
+    std::wstring OriginalError(const char* extra_info)
+    {
+        const char* message = extra_info && *extra_info ? extra_info : tb_exception_message;
+        if (message && *message)
+            return L"\n\nOriginal error:\n" + TextUtils::StringToWString(message);
+        return L"";
+    }
+
     // Resolve the crashes folder without asserting; Resources::GetPath() would assert and re-enter the crash handler when Documents is blocked.
     std::wstring ResolveCrashFolder()
     {
@@ -158,13 +167,14 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
     // A crash while handling a crash (e.g. resolving the blocked crash folder asserts again) must not recurse.
     static volatile LONG crashing = 0;
     if (InterlockedExchange(&crashing, 1) != 0) {
-        MessageBoxW(nullptr,
+        std::wstring error =
             L"Guild Wars crashed, and GWToolbox crashed again while trying to write the crash dump.\n\n"
             L"This almost always means something is blocking your Documents\\GWToolboxpp folder - "
             L"usually Windows Defender Controlled Folder Access or antivirus.\n\n"
             L"Allow Guild Wars through Controlled Folder Access, or add an exclusion for your "
-            L"GWToolbox folder, then try again.",
-            L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_SETFOREGROUND | MB_TOPMOST);
+            L"GWToolbox folder, then try again.";
+        error += OriginalError(extra_info);
+        MessageBoxW(nullptr, error.c_str(), L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_SETFOREGROUND | MB_TOPMOST);
         TerminateProcess(GetCurrentProcess(), 1);
         return EXCEPTION_EXECUTE_HANDLER;
     }
@@ -211,11 +221,13 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
             L"This is usually Windows Defender Controlled Folder Access or antivirus blocking access - "
             L"allow Guild Wars through Controlled Folder Access, or add an exclusion for your GWToolbox folder.";
         error += RecentDefenderBlock(L"GWToolbox");
+        error += OriginalError(extra_info);
         MessageBoxW(nullptr, error.c_str(), L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
         TerminateProcess(GetCurrentProcess(), 1);
     }
     if (!Resources::EnsureFolderExists(crash_folder.c_str(), ensure_folder_error)) {
         ensure_folder_error += RecentDefenderBlock(crash_folder);
+        ensure_folder_error += OriginalError(extra_info);
         MessageBoxW(nullptr, ensure_folder_error.c_str(), L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
         TerminateProcess(GetCurrentProcess(), 1);
     }
@@ -252,6 +264,7 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
             last_error, FormatWindowsError(last_error), szFileName, PathDiagnoseWritability(crash_folder)
         );
         error += RecentDefenderBlock(szFileName);
+        error += OriginalError(extra_info);
         MessageBoxW(nullptr, error.c_str(), L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
         TerminateProcess(GetCurrentProcess(), 1);
     }
@@ -320,6 +333,7 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
             );
         }
         error_info += RecentDefenderBlock(szFileName);
+        error_info += OriginalError(extra_info);
     }
     else {
         error_info = L"Guild Wars crashed!\n\n";


### PR DESCRIPTION
## Repro (from the #gwtoolbox thread)

Turn on Windows Defender **Controlled Folder Access**, then trigger toolbox's folder access:

1. `Resources::GetComputerFolderPath()` hits its 2nd `ASSERT` — `PathGetDocumentsPath` fails (`SHGetFolderPathW` returns a failure HRESULT).
2. `ASSERT` → `Log::FatalAssert` → `throw` → `__except(CrashHandler::Crash(...))` — the crash handler starts.
3. **Inside** `Crash()`, `Resources::GetPath(L"crashes")` (CrashHandler.cpp:181) calls `GetComputerFolderPath()` *again* → the same `ASSERT` fails → `FatalAssert` → `Crash()` **re-enters**.
4. That recursion (each level calling `PathGetDocumentsPath` → `fwprintf(stderr, …)`) runs away into a **secondary crash**, observed landing in the `fwprintf` for `"%S: SHGetFolderPathW failed (HRESULT:0x%lX)"`.

The kicker: the graceful handler at `CrashHandler.cpp:184` — `EnsureFolderExists` → `PathDiagnoseWritability` + the Defender/CFA-aware message — was built for *exactly* this case, but is **unreachable** because the asserting `GetPath` on the line above blows up first.

(Note: `%S` with `__func__` is actually correct under the project's default MSVC format-specifier mode — `%S` in a wide `fwprintf` means a narrow `char*`. The fault is the re-entrant recursion, not the format string.)

## Fix

- **`ResolveCrashFolder()`** — resolve the crash-dump folder without asserting (`PathGetDocumentsPath` + `PathGetComputerName`, both non-throwing `bool` primitives). The crash handler now reaches the existing `EnsureFolderExists` diagnostics and tells the user Controlled Folder Access / antivirus is blocking their `Documents\GWToolboxpp` folder, instead of secondary-crashing. Also appends `RecentDefenderBlock` detail on the empty-path branch.
- **Re-entrancy guard** at the top of `Crash()` (`InterlockedExchange`): a crash *while handling a crash* shows a clear CFA/AV message and `TerminateProcess` instead of recursing — the canonical safety net for any other assert/fault that might fire mid-handling.

## Notes

- Windows/MSVC-only; not compiled locally — please give it a CI/Windows build.
- Behaviour is unchanged on the happy path: `ResolveCrashFolder()` produces the same `Documents\GWToolboxpp\<computer>\crashes` path that `GetPath(L"crashes")` did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)