### PR TITLE
feat(errors): deep-link AV/Defender error popups to the troubleshooting guide

### DIFF
--- a/Core/Defender.cpp
+++ b/Core/Defender.cpp
@@ -2,6 +2,8 @@
 
 #include "Defender.h"
 
+#include <shellapi.h>
+
 #include <fstream>
 #include <sstream>
 #include <vector>
@@ -106,4 +108,16 @@ bool FindRecentDefenderBlock(const std::wstring& needle, const unsigned seconds,
 
     detail = output;
     return true;
+}
+
+void ShowTroubleshootingError(const std::wstring& message, const wchar_t* title, const wchar_t* url, const unsigned flags)
+{
+    const unsigned base = flags ? flags : MB_ICONERROR | MB_SYSTEMMODAL | MB_SETFOREGROUND | MB_TOPMOST;
+    if (url && *url) {
+        const std::wstring body = message + L"\n\nOpen the troubleshooting guide for step-by-step instructions?\n" + url;
+        if (MessageBoxW(nullptr, body.c_str(), title, base | MB_YESNO) == IDYES)
+            ShellExecuteW(nullptr, L"open", url, nullptr, nullptr, SW_SHOWNORMAL);
+        return;
+    }
+    MessageBoxW(nullptr, message.c_str(), title, base | MB_OK);
 }

--- a/Core/Defender.h
+++ b/Core/Defender.h
@@ -7,3 +7,15 @@ bool RunPowerShellCommand(const std::wstring& command, std::wstring& output);
 
 // Searches the Windows Defender Operational log for a recent malware/ASR/Controlled-Folder-Access block whose message mentions `needle`, within the last `seconds`; on a hit returns true and sets `detail` to the event message.
 bool FindRecentDefenderBlock(const std::wstring& needle, unsigned seconds, std::wstring& detail);
+
+// Deep links into the troubleshooting page so error popups can point users straight at the fix.
+namespace Troubleshooting {
+    inline constexpr wchar_t AntivirusExclusions[] = L"https://www.gwtoolbox.com/docs/troubleshooting/#antivirus-exclusions";
+    inline constexpr wchar_t ControlledFolderAccess[] = L"https://www.gwtoolbox.com/docs/troubleshooting/#controlled-folder-access";
+    inline constexpr wchar_t CantReadMemory[] = L"https://www.gwtoolbox.com/docs/troubleshooting/#toolbox-cant-read-guild-wars-memory";
+    inline constexpr wchar_t CrashDumps[] = L"https://www.gwtoolbox.com/docs/troubleshooting/#crash-dump-errors";
+    inline constexpr wchar_t BlockedFiles[] = L"https://www.gwtoolbox.com/docs/troubleshooting/#blocked-or-quarantined-files";
+}
+
+// Shows an error message box; when `url` is non-empty, adds a Yes/No prompt whose Yes opens that troubleshooting page in the browser. Pass extra MB_* flags (icon/modality) via `flags`.
+void ShowTroubleshootingError(const std::wstring& message, const wchar_t* title, const wchar_t* url, unsigned flags = 0);

--- a/GWToolbox/main.cpp
+++ b/GWToolbox/main.cpp
@@ -277,7 +277,7 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int n
         std::wstring detail;
         if (FindRecentDefenderBlock(L"Gw.exe", 5, detail))
             message += L"\n\nWindows Defender reported:\n" + detail;
-        MessageBoxW(nullptr, message.c_str(), L"GWToolbox - Error", MB_OK | MB_ICONERROR | MB_TOPMOST);
+        ShowTroubleshootingError(message, L"GWToolbox - Error", Troubleshooting::CantReadMemory, MB_ICONERROR | MB_TOPMOST);
         return 1;
     }
 

--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -368,7 +368,7 @@ namespace {
             std::wstring detail;
             if (FindRecentDefenderBlock(L"gwca.dll", 15, detail))
                 message += L"\n\nWindows Defender reported:\n" + detail;
-            MessageBoxW(nullptr, message.c_str(), L"GWToolbox", MB_OK | MB_ICONERROR | MB_TOPMOST);
+            ShowTroubleshootingError(message, L"GWToolbox", Troubleshooting::BlockedFiles, MB_ICONERROR | MB_TOPMOST);
         };
 
         if (!IsValidGWCADll(gwca_dll_path, resource)) {

--- a/GWToolboxdll/Modules/CrashHandler.cpp
+++ b/GWToolboxdll/Modules/CrashHandler.cpp
@@ -174,7 +174,7 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
             L"Allow Guild Wars through Controlled Folder Access, or add an exclusion for your "
             L"GWToolbox folder, then try again.";
         error += OriginalError(extra_info);
-        MessageBoxW(nullptr, error.c_str(), L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_SETFOREGROUND | MB_TOPMOST);
+        ShowTroubleshootingError(error, L"GWToolbox++ crash dump error", Troubleshooting::CrashDumps);
         TerminateProcess(GetCurrentProcess(), 1);
         return EXCEPTION_EXECUTE_HANDLER;
     }
@@ -222,13 +222,13 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
             L"allow Guild Wars through Controlled Folder Access, or add an exclusion for your GWToolbox folder.";
         error += RecentDefenderBlock(L"GWToolbox");
         error += OriginalError(extra_info);
-        MessageBoxW(nullptr, error.c_str(), L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
+        ShowTroubleshootingError(error, L"GWToolbox++ crash dump error", Troubleshooting::CrashDumps, MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
         TerminateProcess(GetCurrentProcess(), 1);
     }
     if (!Resources::EnsureFolderExists(crash_folder.c_str(), ensure_folder_error)) {
         ensure_folder_error += RecentDefenderBlock(crash_folder);
         ensure_folder_error += OriginalError(extra_info);
-        MessageBoxW(nullptr, ensure_folder_error.c_str(), L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
+        ShowTroubleshootingError(ensure_folder_error, L"GWToolbox++ crash dump error", Troubleshooting::CrashDumps, MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
         TerminateProcess(GetCurrentProcess(), 1);
     }
 
@@ -265,7 +265,7 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
         );
         error += RecentDefenderBlock(szFileName);
         error += OriginalError(extra_info);
-        MessageBoxW(nullptr, error.c_str(), L"GWToolbox++ crash dump error", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
+        ShowTroubleshootingError(error, L"GWToolbox++ crash dump error", Troubleshooting::CrashDumps, MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
         TerminateProcess(GetCurrentProcess(), 1);
     }
 
@@ -358,7 +358,7 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
     }
     delete ExpParam;
 
-    MessageBoxW(nullptr, error_info.c_str(), dump_ok ? L"GWToolbox++ crash dump created!" : L"GWToolbox++ crash dump failed!", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_SETFOREGROUND | MB_TOPMOST);
+    ShowTroubleshootingError(error_info, dump_ok ? L"GWToolbox++ crash dump created!" : L"GWToolbox++ crash dump failed!", dump_ok ? nullptr : Troubleshooting::CrashDumps);
 
     #ifdef _DEBUG
     if (IsDebuggerPresent()) {


### PR DESCRIPTION
## What

Follow-up to the new [Troubleshooting page](https://github.com/gwdevhub/GWToolboxpp/pull/2312). Makes the security-software error popups link straight to the relevant fix.

Adds to the shared `Core/Defender.{h,cpp}` (already included by every AV/Defender call site, in both the launcher exe and the dll):

- **`Troubleshooting::` URL constants** — one per shareable section anchor on the docs page (`#antivirus-exclusions`, `#controlled-folder-access`, `#toolbox-cant-read-guild-wars-memory`, `#crash-dump-errors`, `#blocked-or-quarantined-files`).
- **`ShowTroubleshootingError(message, title, url, flags)`** — shows the error and, when a URL is given, adds a **Yes/No** prompt whose **Yes** opens that page via `ShellExecuteW`.

## Why a button, not an inline hyperlink

Plain `MessageBoxW` can't render clickable links, and the only Win32 way to get a true inline hyperlink is `TaskDialog` (`TDF_ENABLE_HYPERLINKS`), which pulls in comctl32 v6 and is risky to invoke **inside the crash handler** while the process is already faulting. A Yes/No button that `ShellExecute`s the URL is robust in both the launcher and the crash path, and matches how the codebase already opens URLs elsewhere. The URL is also printed in the body so it can be copied. (Happy to switch to TaskDialog for the launcher-only popups if you'd prefer a real hyperlink there.)

## Wired into

- Launcher **"found Guild Wars but couldn't read its memory"** → `#toolbox-cant-read-guild-wars-memory`
- Crash-dump failure popups (re-entrancy guard, no Documents folder, folder create failed, CreateFile refused, MiniDump failed / dump gone) → `#crash-dump-errors`
- **gwca.dll blocked by Defender** → `#blocked-or-quarantined-files`

The success "crash dump created!" popup stays a plain OK (no link).

## Notes

- Depends on PR #2312 for the URLs to resolve — **merge/deploy the docs page first** (the anchors are already final, so the strings are correct regardless; they'd just 404 until the page is live).
- Windows/MSVC-only; not compiled locally — needs a CI/Windows build.
- `gMod`/plugin load failures report via `Log`/status text rather than a MessageBox, so they're left as-is; easy to extend later if we want links there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)