### PR TITLE
Clear Condition Trackers on New Zone

### DIFF
--- a/GWToolboxdll/Widgets/PartyDamage.cpp
+++ b/GWToolboxdll/Widgets/PartyDamage.cpp
@@ -339,6 +339,11 @@ void PartyDamage::MapLoadedCallback(GW::HookStatus*, const GW::Packet::StoC::Map
         default:
             break;
     }
+
+    cond_tracker_count = 0;
+    for (auto& d : cond_damage) {
+        d = 0.0;
+    }
 }
 
 void PartyDamage::ConditionValueCallback(GW::HookStatus*, const GW::Packet::StoC::GenericValue* packet)
@@ -500,11 +505,6 @@ void PartyDamage::ResetDamage()
     first_packet_time = 0;
     last_packet_time = 0;
     accumulated_combat_time_ms = 0;
-
-    cond_tracker_count = 0;
-    for (auto& d : cond_damage) {
-        d = 0.0;
-    }
 }
 
 void PartyDamage::WriteOwnDamage()

--- a/GWToolboxdll/Widgets/PartyDamage.cpp
+++ b/GWToolboxdll/Widgets/PartyDamage.cpp
@@ -326,9 +326,6 @@ void PartyDamage::WritePartyDamage()
 void PartyDamage::MapLoadedCallback(GW::HookStatus*, const GW::Packet::StoC::MapLoaded*)
 {
     cond_tracker_count = 0;
-    for (auto& d : cond_damage) {
-        d = 0.0;
-    }
 
     switch (GW::Map::GetInstanceType()) {
         case GW::Constants::InstanceType::Outpost:
@@ -505,6 +502,9 @@ void PartyDamage::ResetDamage()
     first_packet_time = 0;
     last_packet_time = 0;
     accumulated_combat_time_ms = 0;
+    for (auto& d : cond_damage) {
+        d = 0.0;
+    }
 }
 
 void PartyDamage::WriteOwnDamage()

--- a/GWToolboxdll/Widgets/PartyDamage.cpp
+++ b/GWToolboxdll/Widgets/PartyDamage.cpp
@@ -325,6 +325,11 @@ void PartyDamage::WritePartyDamage()
 
 void PartyDamage::MapLoadedCallback(GW::HookStatus*, const GW::Packet::StoC::MapLoaded*)
 {
+    cond_tracker_count = 0;
+    for (auto& d : cond_damage) {
+        d = 0.0;
+    }
+
     switch (GW::Map::GetInstanceType()) {
         case GW::Constants::InstanceType::Outpost:
             in_explorable = false;
@@ -338,11 +343,6 @@ void PartyDamage::MapLoadedCallback(GW::HookStatus*, const GW::Packet::StoC::Map
         case GW::Constants::InstanceType::Loading:
         default:
             break;
-    }
-
-    cond_tracker_count = 0;
-    for (auto& d : cond_damage) {
-        d = 0.0;
     }
 }
 


### PR DESCRIPTION
I found a small bug in my condition tracking code. If you zone from explorable to explorable while an enemy has a degen condition active, the tracker won't get cleared, and might get reused in the new explorable area (it's keyed by agentId). Moved the clear from ResetDamage() to MapLoadCallback. It should also hopefully fix Fendi Nin fight (the despawn/respawn mechanic unique to that fight causes stale trackers as well).