### PR TITLE
fix(herobuilds): migrate legacy ini from configs/default, not computer root

### DIFF
--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -653,8 +653,9 @@ void HeroBuildsWindow::LoadFromFile()
     }
     else {
         // Legacy herobuilds.ini parser; only used when herobuilds.json doesn't exist yet.
+        // The ini lived in configs/default (or computer root pre-configs/default), not GetLegacySettingFile's path.
         ToolboxIni inifile(false, false, false);
-        inifile.LoadFile(Resources::GetLegacySettingFile(INI_FILENAME).c_str());
+        inifile.LoadFile(Resources::GetSettingFileOrLegacy(INI_FILENAME).c_str());
 
         TNamesDepend entries;
         inifile.GetAllSections(entries);


### PR DESCRIPTION
## Problem

Reported in #gwtoolbox-support: after upgrading/reinstalling, hero & team builds disappear.

The JSON migration in `744460aa` reads the legacy `herobuilds.ini` via `Resources::GetLegacySettingFile(INI_FILENAME)`, which for the default config resolves to the **computer root**. But the ini was always written/read via `GetSettingFile`, i.e. **`configs/default/herobuilds.ini`**. So on upgrade the migration looks in the wrong folder, finds no sections, and the user ends up with empty hero builds. Once they save anything a `herobuilds.json` is created and the ini is never consulted again.

## Fix

Read the legacy ini via `GetSettingFileOrLegacy(INI_FILENAME)` — checks `configs/default` first (where it actually lives), with a computer-root fallback for the pre-`configs/default` layout.

## Note

This only triggers when `herobuilds.json` does not yet exist. Users who already launched the new build and saved a build (creating a `herobuilds.json`) will need to delete/rename that json so the migration runs once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)