### PR TITLE
ci: sign release binaries with SignPath

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -109,51 +109,98 @@ jobs:
       with:
         path: ${{runner.workspace}}/GWToolboxpp/bin/RelWithDebInfo/
 
-    - name: Check version and create release
+    - name: Determine release version
+      id: version
       if: github.ref == 'refs/heads/master'
       shell: bash
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         VERSION=$(sed -n 's/.*set(GWTOOLBOXDLL_VERSION "\(.*\)").*/\1/p' CMakeLists.txt | tr -d '\r')
         BETA=$(sed -n 's/.*set(GWTOOLBOXDLL_VERSION_BETA "\(.*\)").*/\1/p' CMakeLists.txt | tr -d '\r')
-        
+
         if [ -z "$VERSION" ]; then
           echo "Could not find version in CMakeLists.txt"
           exit 1
         fi
-        
+
         if [ -z "$BETA" ]; then
           TAG_NAME="${VERSION}_Release"
         else
           TAG_NAME="${VERSION}_${BETA}"
         fi
-        
+
         echo "Detected version: $VERSION"
         echo "Detected beta: $BETA"
         echo "Target tag: $TAG_NAME"
-        
-        # Check if tag exists
+        echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+
         if git ls-remote --tags origin "refs/tags/$TAG_NAME" | grep -q .; then
           echo "Tag $TAG_NAME already exists. Skipping release."
-          exit 0
+          echo "should_release=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "Tag $TAG_NAME does not exist. Will create release."
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
         fi
-        
-        echo "Tag $TAG_NAME does not exist. Creating release."
-          
-        # Create tag
+
+    # Signing is skipped automatically until SIGNPATH_ORGANIZATION_ID is set as a
+    # repo variable, so releases keep working (unsigned) before SignPath is wired up.
+    - name: Stage binaries for signing
+      if: steps.version.outputs.should_release == 'true' && vars.SIGNPATH_ORGANIZATION_ID != ''
+      shell: bash
+      run: |
+        BIN_DIR="${{runner.workspace}}/GWToolboxpp/bin/RelWithDebInfo"
+        mkdir -p to-sign
+        cp "$BIN_DIR/GWToolbox.exe" to-sign/
+        cp "$BIN_DIR/GWToolboxdll.dll" to-sign/
+
+    - name: Upload unsigned binaries
+      id: upload-unsigned
+      if: steps.version.outputs.should_release == 'true' && vars.SIGNPATH_ORGANIZATION_ID != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: unsigned-binaries
+        path: to-sign/
+
+    - name: Sign binaries with SignPath
+      if: steps.version.outputs.should_release == 'true' && vars.SIGNPATH_ORGANIZATION_ID != ''
+      uses: signpath/github-action-submit-signing-request@v2
+      with:
+        api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+        organization-id: '${{ vars.SIGNPATH_ORGANIZATION_ID }}'
+        project-slug: 'GWToolboxpp'
+        signing-policy-slug: 'release-signing'
+        artifact-configuration-slug: 'binaries'
+        github-artifact-id: '${{ steps.upload-unsigned.outputs.artifact-id }}'
+        wait-for-completion: true
+        output-artifact-directory: 'signed'
+
+    - name: Create release
+      if: steps.version.outputs.should_release == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        TAG_NAME="${{ steps.version.outputs.tag_name }}"
+        BIN_DIR="${{runner.workspace}}/GWToolboxpp/bin/RelWithDebInfo"
+
+        # Prefer the SignPath-signed binaries; fall back to the build output if
+        # signing was skipped (SignPath not configured yet).
+        if [ -f signed/GWToolbox.exe ]; then
+          EXE="signed/GWToolbox.exe"
+          DLL="signed/GWToolboxdll.dll"
+          echo "Releasing signed binaries."
+        else
+          EXE="$BIN_DIR/GWToolbox.exe"
+          DLL="$BIN_DIR/GWToolboxdll.dll"
+          echo "Releasing unsigned binaries (SignPath not configured)."
+        fi
+
+        gzip -c "$BIN_DIR/GWToolboxdll.pdb" > GWToolboxdll.pdb.gz
+
         git config user.name "GitHub Actions"
         git config user.email "actions@github.com"
         git tag "$TAG_NAME"
         git push origin "$TAG_NAME"
-        
-        # Prepare artifacts
-        BIN_DIR="${{runner.workspace}}/GWToolboxpp/bin/RelWithDebInfo"
-        cp "$BIN_DIR/GWToolboxdll.dll" .
-        cp "$BIN_DIR/GWToolbox.exe" .
-        gzip -c "$BIN_DIR/GWToolboxdll.pdb" > GWToolboxdll.pdb.gz
 
-        # Create release
         gh release create "$TAG_NAME" \
           --title "$TAG_NAME" \
-          GWToolbox.exe GWToolboxdll.dll GWToolboxdll.pdb.gz
+          "$EXE" "$DLL" GWToolboxdll.pdb.gz


### PR DESCRIPTION
## Why

Microsoft Edge's SmartScreen blocks the `GWToolbox.exe` download. The binary is **unsigned**, and SmartScreen reputation is keyed to a download's identity — every self-update ships a fresh unsigned binary with zero reputation, so each release gets re-flagged as "not commonly downloaded."

The free, OSS-friendly fix is to code-sign releases via the **SignPath Foundation**. Once builds are signed with a consistent certificate, SmartScreen reputation accrues to the *certificate* across releases instead of resetting every update, so the warnings fade and stay gone.

## What this changes

In the release job of `cmake.yml`:

1. **`Determine release version`** — splits the old version/tag-check logic out into its own step, exposing `tag_name` and `should_release` outputs. The tag is now created *after* signing, so a signing failure no longer leaves an orphan tag.
2. **Stage → upload → sign** — stages `GWToolbox.exe` + `GWToolboxdll.dll`, uploads them as an artifact, and submits them to SignPath via `signpath/github-action-submit-signing-request@v2`, which returns the signed binaries into `signed/`.
3. **`Create release`** — publishes the signed binaries, falling back to the unsigned build output if signing was skipped.

**Safe to merge before SignPath is set up:** all signing steps are gated on the `SIGNPATH_ORGANIZATION_ID` repo variable. Until that variable exists, releases publish unsigned exactly as they do today — no flag day, no broken releases.

## Manual setup required to activate signing

These are one-time steps that have to happen outside this PR (they need a human with org access):

1. **Apply to the SignPath Foundation** for free OSS code signing at https://signpath.org/ and get the project approved.
2. In the SignPath UI, connect the **GitHub.com** trusted build system to the project, and create:
   - an **artifact configuration** (expects `GWToolbox.exe` and `GWToolboxdll.dll`) — the workflow uses slug `binaries`
   - a **signing policy** — the workflow uses slug `release-signing`
   - confirm the **project slug** is `GWToolboxpp`
   (adjust those three slugs in the workflow if you name them differently)
3. Add the secret **`SIGNPATH_API_TOKEN`** and the variable **`SIGNPATH_ORGANIZATION_ID`** to the repo. Setting the variable is what switches signing on.

Once those exist, the next release off `master` is signed automatically.

## Notes

- This stops *recurring* blocks. To clear the block on the **current** release immediately, also submit `GWToolbox.exe` to Microsoft as a false positive at https://www.microsoft.com/en-us/wdsi/filesubmission.
- The `.pdb` is not signed (debug symbols, not executed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)