### PR TITLE
docs(site): SignPath attribution + Privacy Policy page

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -31,6 +31,7 @@ import siteConfig from '../../site.config.json';
       <a href={siteConfig.discordUrl} target="_blank" rel="noopener" class="hover:text-(--color-accent)">Discord</a>
       <a href="/docs/faq/" class="hover:text-(--color-accent)">FAQ</a>
       <a href="/docs/donate/" class="hover:text-(--color-accent)">Donate</a>
+      <a href="/docs/privacy/" class="hover:text-(--color-accent)">Privacy</a>
     </div>
   </div>
   <div

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -76,6 +76,27 @@ import siteConfig from '../../site.config.json';
       GWToolbox++ is an independent fan project and is in no way affiliated with or endorsed by ArenaNet or NCSoft.
     </p>
     <p class="mt-1">
+      Free code signing provided by
+      {' '}
+      <a
+        href="https://about.signpath.io"
+        target="_blank"
+        rel="noopener"
+        class="text-(--color-fg-meta) underline decoration-(--color-border-glass) underline-offset-2 hover:text-(--color-accent) hover:decoration-(--color-accent)"
+      >
+        SignPath.io
+      </a>, certificate by
+      {' '}
+      <a
+        href="https://signpath.org"
+        target="_blank"
+        rel="noopener"
+        class="text-(--color-fg-meta) underline decoration-(--color-border-glass) underline-offset-2 hover:text-(--color-accent) hover:decoration-(--color-accent)"
+      >
+        SignPath Foundation
+      </a>.
+    </p>
+    <p class="mt-1">
       Guild Wars and all associated game content are
       © 2005&ndash;{new Date().getFullYear()} ArenaNet, Inc. All rights reserved. NCsoft, the interlocking NC logo,
       ArenaNet, Arena.net, Guild Wars, Guild Wars Factions, Factions, Guild Wars Nightfall, Nightfall,

--- a/site/src/content/docs/privacy.md
+++ b/site/src/content/docs/privacy.md
@@ -1,0 +1,39 @@
+---
+title: "Privacy Policy"
+section: meta
+description: "What data GWToolbox++ collects, what it does not, and how to opt out."
+---
+
+GWToolbox++ is free, open-source software that runs locally on your computer. It does not require an account, and it does not collect personal information such as your name, email address, or IP address. This page explains the limited data the software does send, when it is sent, and how to turn it off.
+
+## What we do not collect
+
+- No account name, email address, or password.
+- No IP address logging by GWToolbox++.
+- No advertising or third-party tracking.
+- The GWToolbox++ website (gwtoolbox.com) uses no analytics, cookies, or tracking scripts.
+
+## Anonymous gameplay data (opt-in toggle)
+
+GWToolbox++ can send **anonymous gameplay data** to third-party services to power community features. This is controlled by the **"Send anonymous gameplay stats"** checkbox in **Settings → Toolbox Settings** and can be disabled at any time, which stops all such transmissions immediately.
+
+No account name or IP address is ever included. Some transmissions include character names (which are already publicly visible in-game) or a persistent **account UUID** that is derived from your Guild Wars account and cannot be reversed into your account name or email.
+
+The two services involved are:
+
+- **gwmarket.net** — when you whisper a seller/buyer from the Market Browser, an anonymous record of the item, price, and order type is sent so the service can track completed trades.
+- **party.gwtoolbox.com** — while you are in an outpost, the party-search listings already visible to you are relayed so other players can find groups across clients.
+
+A full field-by-field breakdown of exactly what is sent, and when, is on the [Anonymous Analytics](/docs/analytics/) page.
+
+## Update checks
+
+The launcher and the Toolbox DLL contact GitHub's public release API to check for and download updates. These are ordinary web requests to GitHub; GitHub may log them under [its own privacy policy](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement). GWToolbox++ sends no additional data with these requests.
+
+## Crash dumps
+
+When GWToolbox++ crashes it may write a crash dump file to your local `Documents\GWToolboxpp` folder. These files stay on your computer and are **not** uploaded automatically. You may choose to share one with the developers (for example, on Discord or GitHub) when reporting a bug.
+
+## Contact
+
+Questions about this policy can be raised on our [GitHub issue tracker](https://github.com/gwdevhub/GWToolboxpp/issues) or [Discord](https://discord.gg/pGS5pFn).

--- a/site/src/lib/nav.ts
+++ b/site/src/lib/nav.ts
@@ -17,6 +17,7 @@ export const navGroups: NavGroup[] = [
       { slug: 'launch_options', label: 'Launcher Arguments' },
       { slug: 'linux', label: 'Linux Install Guide' },
       { slug: 'analytics', label: 'Anonymous Analytics' },
+      { slug: 'privacy', label: 'Privacy Policy' },
       { slug: 'history', label: 'Version History' },
       { slug: 'credits', label: 'Credits' },
       { slug: 'donate', label: 'Donate' },

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -88,6 +88,9 @@ const featureCards = [
       <p class="mt-4 text-xs text-(--color-fg-meta)">
         Free, open source, MIT licensed. Windows only.
       </p>
+      <p class="mt-2 text-xs text-(--color-fg-meta)">
+        Code signing policy: free code signing provided by <a href="https://about.signpath.io" target="_blank" rel="noopener" class="text-(--color-accent) hover:underline">SignPath.io</a>, certificate by <a href="https://signpath.org" target="_blank" rel="noopener" class="text-(--color-accent) hover:underline">SignPath Foundation</a>.
+      </p>
 
       <div class="mt-10 max-w-full">
         <p class="mb-2 text-xs font-semibold uppercase tracking-widest text-(--color-fg-meta)">


### PR DESCRIPTION
## Why

Two SignPath Foundation OSS-application requirements (see #2331):
1. *"A page where users can download your software"* that mentions the project uses SignPath Foundation for code signing.
2. *"Link to your project's privacy policy"* (required because Toolbox collects anonymous data).

## What

**SignPath attribution** — adds *"Free code signing provided by SignPath.io, certificate by SignPath Foundation"* (linking [SignPath.io](https://about.signpath.io) and [SignPath Foundation](https://signpath.org)) in two spots:
- Landing page (`index.astro`), as a "Code signing policy" line under the Download button — the required download-page mention.
- Footer (`Footer.astro`), site-wide.

**Privacy Policy** — adds a dedicated page at `/docs/privacy/`:
- Summarises what is **not** collected (no account/email/IP, no website tracking), the opt-in anonymous gameplay data (gwmarket.net + party.gwtoolbox.com), update checks, and local-only crash dumps. Links the detailed [Anonymous Analytics](/docs/analytics/) page for the field-by-field breakdown.
- Added to the sidebar nav and linked in the footer (`Privacy`).

Content was checked against the codebase: crash dumps are written locally and not auto-uploaded, and the site ships no analytics scripts.

Mergeable independently of the CI signing change in #2331 so the pages can go live to support the application. Site builds clean (`npm run build`, 51 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)