### PR TITLE
docs(site): help users past browser download blocks

### DIFF
--- a/site/src/content/docs/faq.md
+++ b/site/src/content/docs/faq.md
@@ -31,6 +31,8 @@ However, ArenaNet has indicated that GWToolbox++ from the official source is **a
 ### My antivirus detects toolbox as a virus! Are you hacking me?
 The detection is a false positive, and it is caused by some techniques that GWToolbox needs to use. Most notably, toolbox has to run into another program and manipulate its memory at runtime (note: no modification is permanent). Toolbox is open source, so if you don't trust me you can read through the source code and compile directly from the source yourself.
 
+**Can't even download it?** Chromium-based browsers (Chrome, Edge, Brave, etc.) often block `GWToolbox.exe` while it downloads, for the same false-positive reason. Lower your browser's Safe Browsing level before re-downloading — paste `chrome://settings/security` (or `edge://settings/privacy` on Edge) into the address bar, switch **Safe Browsing** to **Standard protection** (or turn it off temporarily), then download again. See the [troubleshooting page](/docs/troubleshooting/#your-browser-blocked-the-download) for the full steps.
+
 ### Can I run Toolbox with other programs such as Multi client Launchers, TexMod, uMod, or a screen recording software?
 TexMod, uMod, screen recording software (in game capture mode) and Toolbox all use similar techniques to capture and display information on the screen. Because of this, they may interfere with each other. Also note that when you use more than one of the above programs Guild Wars may crash when you close any of them.
 

--- a/site/src/content/docs/troubleshooting.md
+++ b/site/src/content/docs/troubleshooting.md
@@ -19,6 +19,23 @@ Work through these first — they resolve the majority of issues:
 
 If you are still stuck after this, the cause is almost always security software — keep reading.
 
+## Your browser blocked the download
+
+Chromium-based browsers (Chrome, Edge, Brave, Opera, and others) increasingly block `GWToolbox.exe` **before it even finishes downloading**, showing a warning like *"This file isn't commonly downloaded"* or *"Failed – Virus detected"* with no obvious way to keep it. This is **Safe Browsing** reacting to an unsigned, infrequently-downloaded executable — the same false positive your antivirus makes — not a real threat.
+
+If your browser will not let you keep the file, lower its Safe Browsing level, download, then turn it back up if you like:
+
+1. Paste this into your browser's address bar and press Enter:
+   - Chrome / Brave / Opera: `chrome://settings/security`
+   - Edge: `edge://settings/privacy`
+2. Find **Safe Browsing** (Edge calls it **Microsoft Defender SmartScreen**).
+3. Switch it from **Enhanced protection** to **Standard protection**, or temporarily turn it **Off** / to **No protection**.
+4. Re-download `GWToolbox.exe` from [gwtoolbox.com](https://gwtoolbox.com/).
+
+You may still see a "keep anyway" prompt on the download — that one you *can* dismiss to keep the file. Once you have `GWToolbox.exe`, you can set Safe Browsing back to its previous level.
+
+> **Note:** managed browsers (a work or school computer, or an enterprise antivirus that locks browser settings) can grey this out entirely. If so, download on a personal device, or ask whoever manages the machine to allow it.
+
 ## Antivirus exclusions
 
 Toolbox has to inject into `Gw.exe` and read its memory, which looks like the behaviour antivirus software is built to stop — so antivirus (including Windows Defender) frequently flags it as a **false positive** and blocks it. The fix is to add an **exclusion** for your GWToolbox folder.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -87,6 +87,7 @@ const featureCards = [
       </div>
       <p class="mt-4 text-xs text-(--color-fg-meta)">
         Free, open source, MIT licensed. Windows only.
+        <a href="/docs/troubleshooting/#your-browser-blocked-the-download" class="text-(--color-accent) hover:underline">Trouble downloading?</a>
       </p>
       <p class="mt-2 text-xs text-(--color-fg-meta)">
         Code signing policy: free code signing provided by <a href="https://about.signpath.io" target="_blank" rel="noopener" class="text-(--color-accent) hover:underline">SignPath.io</a>, certificate by <a href="https://signpath.org" target="_blank" rel="noopener" class="text-(--color-accent) hover:underline">SignPath Foundation</a>.


### PR DESCRIPTION
Users are hitting Chromium Safe Browsing blocking `GWToolbox.exe` mid-download (Chrome won't even offer a "keep" option in enhanced mode), prompted by a Discord report.

- **Troubleshooting page:** new *"Your browser blocked the download"* section explaining how to lower Safe Browsing (`chrome://settings/security` / `edge://settings/privacy`), download, and restore it — with a note about managed/locked-down browsers.
- **FAQ page:** added a short "Can't even download it?" note under the *antivirus detects toolbox as a virus* entry, directing Chromium users to the chrome:// URL and linking to the new troubleshooting section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)