### PR TITLE
feat(site): LLM-friendly endpoints (llms.txt, raw markdown, robots)

### DIFF
--- a/site/src/content/docs/account_inventory.mdx
+++ b/site/src/content/docs/account_inventory.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Account Inventory"
+description: "View, filter, and jump to every item across all your characters, heroes, chests, and accounts in one window."
 section: windows
 ---
 

--- a/site/src/content/docs/armory_window.mdx
+++ b/site/src/content/docs/armory_window.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Armory Window"
+description: "Preview every armor set, costume, and dye colour on your character locally, applied via window or chat command."
 section: windows
 ---
 

--- a/site/src/content/docs/audio_settings.mdx
+++ b/site/src/content/docs/audio_settings.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Audio Settings"
+description: "Log in-game sound effects and music, then block specific ones to silence repetitive or distracting noises."
 section: features
 ---
 

--- a/site/src/content/docs/builds.mdx
+++ b/site/src/content/docs/builds.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Builds"
+description: "Create, edit, and store teambuilds, then ping them to party chat or load them onto your character."
 section: windows
 ---
 

--- a/site/src/content/docs/camera.mdx
+++ b/site/src/content/docs/camera.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Camera"
+description: "Chat commands to unlock and fly the camera freely, control its speed, and toggle fog rendering."
 section: features
 ---
 

--- a/site/src/content/docs/chat.mdx
+++ b/site/src/content/docs/chat.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Chat Settings"
+description: "Configure chat timestamps, speech bubbles, message redirection, link handling, colours, fonts, and related chat commands."
 section: features
 ---
 

--- a/site/src/content/docs/chatfilter.mdx
+++ b/site/src/content/docs/chatfilter.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Chat Filter"
+description: "Suppress drop notices, announcements, warnings, and spam, or hide messages by keyword, regex, or author."
 section: features
 ---
 

--- a/site/src/content/docs/chatlog.mdx
+++ b/site/src/content/docs/chatlog.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Chat Log"
+description: "Persistent, per-account chat history that survives map changes and is re-injected into the Guild Wars chat window."
 section: features
 ---
 

--- a/site/src/content/docs/commands.md
+++ b/site/src/content/docs/commands.md
@@ -1,5 +1,6 @@
 ---
 title: "Chat Commands"
+description: "Reference for the chat commands GWToolbox++ adds, covering windows, targeting, travel, builds, items, dailies and more."
 section: features
 ---
 

--- a/site/src/content/docs/completion.mdx
+++ b/site/src/content/docs/completion.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Completion Window"
+description: "Tracking missions, vanquishes, skills, heroes and Hall of Monuments progress per character across all Guild Wars campaigns."
 section: windows
 ---
 

--- a/site/src/content/docs/credits.md
+++ b/site/src/content/docs/credits.md
@@ -1,5 +1,6 @@
 ---
 title: "Credits"
+description: "The contributors, reverse engineers and sponsors behind GWToolbox++, including JetBrains and everyone who proposed a PR."
 section: meta
 ---
 

--- a/site/src/content/docs/damage_monitor.mdx
+++ b/site/src/content/docs/damage_monitor.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Damage Monitor"
+description: "Per-party-member damage tracking explained, including how Toolbox estimates damage from packets, its limitations and chat commands."
 section: widgets
 ---
 

--- a/site/src/content/docs/donate.md
+++ b/site/src/content/docs/donate.md
@@ -1,5 +1,6 @@
 ---
 title: "Donate"
+description: "Why GWToolbox++ costs money to run and how to support it voluntarily through Open Collective without affecting development."
 section: meta
 ---
 

--- a/site/src/content/docs/duping_window.mdx
+++ b/site/src/content/docs/duping_window.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Duping Window"
+description: "Tracking Soul, Water and Mind Tormentor health, regen and duping status during Domain of Anguish runs."
 section: windows
 ---
 

--- a/site/src/content/docs/enemy_window.mdx
+++ b/site/src/content/docs/enemy_window.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Enemy Window"
+description: "Listing nearby enemies with health, level, regen, status effects and last skill used, with click-to-target support."
 section: widgets
 ---
 

--- a/site/src/content/docs/faq.md
+++ b/site/src/content/docs/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "Frequently Asked Questions"
+description: "Common questions about GWToolbox++, covering bans, antivirus warnings, launch failures, crash dumps and in-game fixes."
 section: meta
 ---
 

--- a/site/src/content/docs/herobuilds.mdx
+++ b/site/src/content/docs/herobuilds.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hero Builds"
+description: "Creating, editing and loading hero teambuilds that assign templates, heroes and behaviours, plus the related chat command."
 section: windows
 ---
 

--- a/site/src/content/docs/history.md
+++ b/site/src/content/docs/history.md
@@ -1,5 +1,6 @@
 ---
 title: "Version History"
+description: "Release changelog for GWToolbox++, listing new features, fixes and minor changes across every published version."
 section: meta
 ---
 

--- a/site/src/content/docs/hotkeys.mdx
+++ b/site/src/content/docs/hotkeys.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hotkeys"
+description: "Binding Toolbox actions to keys, with triggers, conditions and every available hotkey type from chat to flagging heroes."
 section: windows
 ---
 

--- a/site/src/content/docs/info.mdx
+++ b/site/src/content/docs/info.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Info"
+description: "Reading and copying camera, player, target, map, dialog, item and resign data used to set up hotkeys and commands."
 section: windows
 ---
 

--- a/site/src/content/docs/input_modules.mdx
+++ b/site/src/content/docs/input_modules.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Input Modules"
+description: "Mouse fix, mouse-walking toggle and keyboard language fix modules that resolve common Guild Wars input problems."
 section: features
 ---
 

--- a/site/src/content/docs/integrations.mdx
+++ b/site/src/content/docs/integrations.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Integrations"
+description: "Connecting GWToolbox++ to Discord, Teamspeak 5, Twitch, and LiveSplit for rich presence, voice, chat, and autosplitting."
 section: features
 ---
 

--- a/site/src/content/docs/items.mdx
+++ b/site/src/content/docs/items.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Item Management Features"
+description: "Inventory shortcuts, bulk salvage and identify, drop filtering by rarity, and hidden merchant items for managing your gear."
 section: widgets
 ---
 

--- a/site/src/content/docs/materials.mdx
+++ b/site/src/content/docs/materials.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Materials Window"
+description: "Buy, sell, and price-check common and rare crafting materials at traders, with queued orders and automatic gold handling."
 section: windows
 ---
 

--- a/site/src/content/docs/minimap.mdx
+++ b/site/src/content/docs/minimap.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Minimap"
+description: "An enhanced compass showing accurate pathing, shaped agent markers, range circles, AoE footprints, custom drawings, hero flagging, and click-to-target."
 section: widgets
 ---
 

--- a/site/src/content/docs/misc_widgets.mdx
+++ b/site/src/content/docs/misc_widgets.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Miscellaneous Widgets"
+description: "Small overlay widgets for latency, clock, vanquish progress, server info, alcohol level, world map extras, and an in-game notepad."
 section: widgets
 ---
 

--- a/site/src/content/docs/mission_map.mdx
+++ b/site/src/content/docs/mission_map.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Mission Map"
+description: "Overlaying minimap layers, custom lines, and quest paths onto the in-game mission map, with optional click-to-target."
 section: widgets
 ---
 

--- a/site/src/content/docs/party_window.mdx
+++ b/site/src/content/docs/party_window.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Party Window Enhancements"
+description: "Party-window tweaks adding player numbers, renaming summons, listing special NPCs, sorting by profession, and an offline party-search reminder."
 section: widgets
 ---
 

--- a/site/src/content/docs/pcons.mdx
+++ b/site/src/content/docs/pcons.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Pcons"
+description: "Automatically maintaining cons, pcons, and consets from your inventory, with thresholds, storage refills, and auto-disable rules."
 section: windows
 ---
 

--- a/site/src/content/docs/plugins.mdx
+++ b/site/src/content/docs/plugins.mdx
@@ -1,5 +1,6 @@
 ---
 title: "GWToolbox++ Plugins"
+description: "Adding, enabling, and troubleshooting third-party plugin DLLs, plus the safety and Terms-of-Service risks of doing so."
 section: features
 ---
 

--- a/site/src/content/docs/qol_fixes.md
+++ b/site/src/content/docs/qol_fixes.md
@@ -1,5 +1,6 @@
 ---
 title: "Quality of Life Fixes"
+description: "Small base-game bugs and annoyances GWToolbox++ quietly fixes by default, from hero panels to the FPS cap."
 section: features
 ---
 

--- a/site/src/content/docs/quest.mdx
+++ b/site/src/content/docs/quest.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Quest Functionality"
+description: "The active quest widget plus automatic pathing that calculates and draws optimal routes to quest objectives."
 section: widgets
 ---
 

--- a/site/src/content/docs/reroll.mdx
+++ b/site/src/content/docs/reroll.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Reroll Window"
+description: "Quickly switch between account characters, optionally restoring your location and party, using the window or /reroll command."
 section: features
 ---
 

--- a/site/src/content/docs/settings.mdx
+++ b/site/src/content/docs/settings.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Settings"
+description: "Central window for configuring every Toolbox feature, plus quality-of-life game toggles, notifications, updates and storage locations."
 section: windows
 ---
 

--- a/site/src/content/docs/target_widgets.mdx
+++ b/site/src/content/docs/target_widgets.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Target Widgets"
+description: "Widgets showing your current target's distance, health and detailed wiki-sourced info, with colour coding and custom thresholds."
 section: widgets
 ---
 

--- a/site/src/content/docs/texmod.mdx
+++ b/site/src/content/docs/texmod.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Texture Mods (gMod)"
+description: "Load TexMod/uMod texture replacement packs at runtime via built-in gMod, set load order, and capture in-game textures."
 section: features
 ---
 

--- a/site/src/content/docs/text-to-speech.mdx
+++ b/site/src/content/docs/text-to-speech.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Text-to-Speech Module"
+description: "Speak NPC dialogue and speech bubbles aloud through GWDevHub, ElevenLabs, OpenAI and other providers, with per-race voices and cost controls."
 section: features
 ---
 

--- a/site/src/content/docs/theme.mdx
+++ b/site/src/content/docs/theme.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Theme"
+description: "Customise Toolbox's appearance, covering transparency, font scale, element sizes, alignment and the colour of every interface component."
 section: features
 ---
 

--- a/site/src/content/docs/trade.mdx
+++ b/site/src/content/docs/trade.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Trade Window"
+description: "A live Kamadan and Pre-Searing trade chat feed with keyword search, whisper, alerts and party-seeking tools."
 section: windows
 ---
 

--- a/site/src/content/docs/travel.mdx
+++ b/site/src/content/docs/travel.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Travel Window"
+description: "Travel instantly to any unlocked outpost and district, with favourites, quick buttons and /tp chat command shortcuts."
 section: windows
 ---
 

--- a/site/src/content/docs/troubleshooting.md
+++ b/site/src/content/docs/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshooting"
+description: "Fixing security software that blocks GWToolbox++, covering antivirus, Controlled Folder Access, Smart App Control and crash dumps."
 section: meta
 ---
 

--- a/site/src/content/docs/vanquish_overlay.md
+++ b/site/src/content/docs/vanquish_overlay.md
@@ -1,5 +1,6 @@
 ---
 title: "Vanquish Overlay"
+description: "Drawing fog of war, enemy markers and a compass-range circle on the mission map to plan Hard Mode vanquishes."
 section: widgets
 ---
 

--- a/site/src/content/docs/widgets.md
+++ b/site/src/content/docs/widgets.md
@@ -1,5 +1,6 @@
 ---
 title: "Widgets"
+description: "Always-on information overlays GWToolbox++ provides, including timer, health, distance, minimap, damage, bonds and vanquish."
 section: widgets
 ---
 

--- a/site/src/content/docs/windows.md
+++ b/site/src/content/docs/windows.md
@@ -1,5 +1,6 @@
 ---
 title: "Windows"
+description: "How Toolbox windows are opened, closed, moved, resized, and edited, plus a rundown of each one."
 section: windows
 ---
 

--- a/site/src/content/docs/world_map.md
+++ b/site/src/content/docs/world_map.md
@@ -1,5 +1,6 @@
 ---
 title: "World Map"
+description: "Extends the in-game world map with quest markers, elite-capture locations, travel shortcuts, and minimap line overlays."
 section: widgets
 ---
 

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -15,6 +15,7 @@ interface Props {
 const { title, description = siteConfig.tagline } = Astro.props;
 const pageTitle = title ? `${title} — ${siteConfig.title}` : siteConfig.title;
 const release = await getLatestRelease();
+const canonicalURL = new URL(Astro.url.pathname, Astro.site).href;
 ---
 
 <!doctype html>
@@ -24,9 +25,12 @@ const release = await getLatestRelease();
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{pageTitle}</title>
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalURL} />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="alternate" type="text/plain" title="llms.txt" href="/llms.txt" />
     <meta property="og:title" content={pageTitle} />
     <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalURL} />
     <meta property="og:type" content="website" />
     <link
       rel="preload"

--- a/site/src/lib/llms.ts
+++ b/site/src/lib/llms.ts
@@ -1,0 +1,54 @@
+import { getCollection, type CollectionEntry } from 'astro:content';
+import { navGroups } from './nav';
+
+export type Doc = CollectionEntry<'docs'>;
+
+// Keep in sync with `site` in astro.config.mjs.
+export const SITE = 'https://www.gwtoolbox.com';
+
+/** Non-hidden docs in nav order, with any pages missing from the nav appended. */
+export async function orderedDocs(): Promise<Doc[]> {
+  const entries = await getCollection('docs', ({ data }) => !data.hidden);
+  const byId = new Map(entries.map((e) => [e.id, e]));
+  const ordered: Doc[] = [];
+  const seen = new Set<string>();
+
+  for (const group of navGroups) {
+    for (const item of group.items) {
+      const entry = byId.get(item.slug);
+      if (entry && !seen.has(entry.id)) {
+        ordered.push(entry);
+        seen.add(entry.id);
+      }
+    }
+  }
+  for (const entry of entries) {
+    if (!seen.has(entry.id)) ordered.push(entry);
+  }
+  return ordered;
+}
+
+/** Replace inline <ToolboxPath steps={[...]} /> chips with a `A › B › C` breadcrumb. */
+function inlineToolboxPaths(md: string): string {
+  return md.replace(/<ToolboxPath\b[\s\S]*?\/>/g, (tag) => {
+    const stepsBlock = tag.match(/steps=\{\[([\s\S]*?)\]\}/)?.[1] ?? '';
+    const steps = [...stepsBlock.matchAll(/['"]([^'"]+)['"]/g)].map((m) => m[1]);
+    return steps.length ? `\`${steps.join(' › ')}\`` : '';
+  });
+}
+
+/** Raw markdown body with MDX imports, components, and `[back]` boilerplate stripped for clean ingestion. */
+export function cleanBody(entry: Doc): string {
+  return inlineToolboxPaths(entry.body ?? '')
+    .split('\n')
+    .filter((line) => !/^\s*import\s.+from\s.+;?\s*$/.test(line))
+    .join('\n')
+    .replace(/^\s*\[back\]\(\.\/\)\s*$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/** A page rendered as standalone markdown, with a source link for provenance. */
+export function docToMarkdown(entry: Doc): string {
+  return [`# ${entry.data.title}`, '', `Source: ${SITE}/docs/${entry.id}/`, '', cleanBody(entry), ''].join('\n');
+}

--- a/site/src/pages/docs/[...slug].md.ts
+++ b/site/src/pages/docs/[...slug].md.ts
@@ -1,0 +1,16 @@
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { getCollection } from 'astro:content';
+import { docToMarkdown, type Doc } from '../../lib/llms';
+
+// Serves each doc as raw Markdown at /docs/<slug>.md alongside the HTML page.
+export const getStaticPaths: GetStaticPaths = async () => {
+  const entries = await getCollection('docs', ({ data }) => !data.hidden);
+  return entries.map((entry) => ({ params: { slug: entry.id }, props: { entry } }));
+};
+
+export const GET: APIRoute = ({ props }) => {
+  const { entry } = props as { entry: Doc };
+  return new Response(docToMarkdown(entry), {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+  });
+};

--- a/site/src/pages/llms-full.txt.ts
+++ b/site/src/pages/llms-full.txt.ts
@@ -1,0 +1,20 @@
+import type { APIRoute } from 'astro';
+import { orderedDocs, docToMarkdown, SITE } from '../lib/llms';
+import siteConfig from '../../site.config.json';
+
+// Every documentation page concatenated as plain Markdown, for one-shot ingestion.
+export const GET: APIRoute = async () => {
+  const docs = await orderedDocs();
+  const out: string[] = [
+    `# ${siteConfig.title} — full documentation`,
+    '',
+    `> ${siteConfig.tagline}. Generated from ${SITE}. Each section below is one documentation page.`,
+    '',
+  ];
+  for (const entry of docs) {
+    out.push(docToMarkdown(entry), '---', '');
+  }
+  return new Response(out.join('\n'), {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};

--- a/site/src/pages/llms.txt.ts
+++ b/site/src/pages/llms.txt.ts
@@ -1,0 +1,49 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import { navGroups } from '../lib/nav';
+import { SITE } from '../lib/llms';
+import siteConfig from '../../site.config.json';
+
+// llmstxt.org index: a curated, link-first map of the docs for LLM agents.
+export const GET: APIRoute = async () => {
+  const entries = await getCollection('docs', ({ data }) => !data.hidden);
+  const byId = new Map(entries.map((e) => [e.id, e]));
+
+  const lines: string[] = [
+    `# ${siteConfig.title}`,
+    '',
+    '> GWToolbox++ is a free, open-source, all-in-one client modification for the original Guild Wars (2005) — adding builds, hotkeys, automation, widgets, plugins and quality-of-life fixes.',
+    '',
+    'Each page below is also available as raw Markdown by appending `.md` to its URL (e.g. /docs/faq.md). The full documentation concatenated into one file is at /llms-full.txt.',
+    '',
+  ];
+
+  const seen = new Set<string>();
+  for (const group of navGroups) {
+    lines.push(`## ${group.label}`, '');
+    for (const item of group.items) {
+      const entry = byId.get(item.slug);
+      if (!entry) continue;
+      seen.add(entry.id);
+      const desc = entry.data.description ? `: ${entry.data.description}` : '';
+      lines.push(`- [${item.label}](${SITE}/docs/${item.slug}/)${desc}`);
+    }
+    lines.push('');
+  }
+
+  const leftover = entries
+    .filter((e) => !seen.has(e.id))
+    .sort((a, b) => a.data.title.localeCompare(b.data.title));
+  if (leftover.length) {
+    lines.push('## Other', '');
+    for (const e of leftover) {
+      const desc = e.data.description ? `: ${e.data.description}` : '';
+      lines.push(`- [${e.data.title}](${SITE}/docs/${e.id}/)${desc}`);
+    }
+    lines.push('');
+  }
+
+  return new Response(lines.join('\n'), {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};

--- a/site/src/pages/robots.txt.ts
+++ b/site/src/pages/robots.txt.ts
@@ -1,0 +1,18 @@
+import type { APIRoute } from 'astro';
+import { SITE } from '../lib/llms';
+
+export const GET: APIRoute = () => {
+  const body = [
+    '# GWToolbox++ — https://www.gwtoolbox.com',
+    'User-agent: *',
+    'Allow: /',
+    '',
+    `Sitemap: ${SITE}/sitemap-index.xml`,
+    `# LLM-readable docs index: ${SITE}/llms.txt`,
+    `# Full docs as one file:    ${SITE}/llms-full.txt`,
+    '',
+  ].join('\n');
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};


### PR DESCRIPTION
Optimises the docs site for LLM agents and AI search, using the emerging [llmstxt.org](https://llmstxt.org) conventions plus standard discoverability fixes. All generated at build time from the existing content collection, so it stays in sync with the docs automatically.

## What's added

- **`/llms.txt`** — a curated, link-first index of every page, grouped by the same sections as the sidebar nav, with frontmatter descriptions where present.
- **`/llms-full.txt`** — the entire documentation concatenated into one plain-markdown file for one-shot ingestion (~5.6k lines).
- **`/docs/<slug>.md`** — every page available as raw markdown alongside its HTML (e.g. `/docs/faq.md`), so an agent can fetch a single page cleanly.
- **`/robots.txt`** — allow-all, pointing crawlers at the sitemap and `llms.txt`.
- **Canonical `<link>` + `og:url`** in the document head.

## Cleanup applied to generated markdown

- MDX `import` lines stripped.
- `<ToolboxPath steps={[...]} />` UI-breadcrumb chips rewritten to `` `Settings › Builds` `` text (the one custom component used in docs), including step labels that contain `>` like `/flag <1-8>`.

## Notes / possible follow-ups

- Many doc pages have no `description` frontmatter, so their `llms.txt` entries are bare links. Backfilling descriptions would improve both this and SEO meta tags — happy to do that as a separate pass.
- `SITE` is a constant in `src/lib/llms.ts`; it must match `site` in `astro.config.mjs` (noted in a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)