### PR TITLE
fix(settings): hide window buttons in any non-windowed mode

### DIFF
--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -1047,8 +1047,8 @@ namespace {
             GW::UI::SetFrameVisible(GW::UI::GetFrameByLabel(L"BtnRestore"), false); // @TODO: Show this, but make it maximise the window on click instead
             GW::UI::SetFrameVisible(GW::UI::GetFrameByLabel(L"BtnExit"), true);
         }
-        // pref 1 = borderless, pref 2 = fullscreen; hide window buttons if the user opted in
-        if (pref == 1 || pref == 2) {
+        // pref 0 = windowed; any other mode (borderless, fullscreen, etc.) hides window buttons if the user opted in
+        if (pref != 0) {
             const bool visible = !settings.hide_window_buttons_in_fullscreen;
             GW::UI::SetFrameVisible(GW::UI::GetFrameByLabel(L"BtnMin"), visible);
             GW::UI::SetFrameVisible(GW::UI::GetFrameByLabel(L"BtnRestore"), visible);


### PR DESCRIPTION
Per Jon's note: the "Hide minimize/restore/close buttons in borderless and fullscreen modes" option was gated on the `ScreenBorderless` preference being exactly `1` or `2`.

This changes the check to **anything that isn't windowed** (`pref != 0`), so the hide/show is applied for any non-windowed mode rather than only the two specific values we happened to enumerate.

`pref == 0` (windowed) is still handled separately by the existing window-border block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)