### PR TITLE
fix: default occlude_behind_terrain to false

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
@@ -32,7 +32,7 @@ namespace {
     bool exclude_compass = true;
 
     // Test overlays against the scene depth buffer so world geometry hides them; z_near/z_far must match GW's projection (near clip ~47, valid 45-48; far insensitive 50k-200k).
-    bool occlude_behind_terrain = true;
+    bool occlude_behind_terrain = false;
     float z_near = 47.0f;
     float z_far = 100000.f;
 


### PR DESCRIPTION
Fixes #2345

Default `occlude_behind_terrain` to `false` so custom lines/circles behave the same as before the setting was introduced. Users who want terrain occlusion can still opt in via In-Game-Rendering settings.

Generated with [Claude Code](https://claude.ai/code)