### PR TITLE
fix(weather): check dungeon interior before region switch in ClimateForMap

### DIFF
--- a/GWToolboxdll/Modules/WeatherModule.cpp
+++ b/GWToolboxdll/Modules/WeatherModule.cpp
@@ -285,15 +285,16 @@ namespace {
         const auto info = GW::Map::GetMapInfo(map_id);
         if (!GW::Map::HasMapDisplayInfo(info) && !info->GetIsOnWorldMap())
             return Climate::None;
-        // Interiors (dungeons) have no sky, so never apply climate weather. Checked before the region switch:
-        // otherwise a dungeon in a handled region (e.g. a Desolation dungeon) resolves to that region's climate first.
+        // Interiors (dungeons) have no sky, so never apply climate weather. Checked before the region switch so a
+        // dungeon in a region that the switch otherwise maps to a climate still resolves to clear.
         if (info && info->type == GW::RegionType::Dungeon)
             return Climate::None;
         switch (info ? info->region : GW::Region_DevRegion) {
             case GW::Region_NorthernShiverpeaks:
             case GW::Region_FarShiverpeaks:
-            case GW::Region_DepthsOfTyria:
                 return Climate::Mountainous;
+            case GW::Region_DepthsOfTyria: // EotN underground, no sky
+                return Climate::None;
             case GW::Region_CrystalDesert:
             case GW::Region_Desolation:
             case GW::Region_Istan:

--- a/GWToolboxdll/Modules/WeatherModule.cpp
+++ b/GWToolboxdll/Modules/WeatherModule.cpp
@@ -285,6 +285,10 @@ namespace {
         const auto info = GW::Map::GetMapInfo(map_id);
         if (!GW::Map::HasMapDisplayInfo(info) && !info->GetIsOnWorldMap())
             return Climate::None;
+        // Interiors (dungeons) have no sky, so never apply climate weather. Checked before the region switch:
+        // otherwise a dungeon in a handled region (e.g. a Desolation dungeon) resolves to that region's climate first.
+        if (info && info->type == GW::RegionType::Dungeon)
+            return Climate::None;
         switch (info ? info->region : GW::Region_DevRegion) {
             case GW::Region_NorthernShiverpeaks:
             case GW::Region_FarShiverpeaks:
@@ -304,10 +308,6 @@ namespace {
             case GW::Region_TarnishedCoast:
                 return Climate::Tropical;
             case GW::Region_DomainOfAnguish:
-                return Climate::None;
-        }
-        switch (info ? info->type : GW::RegionType::DevRegion) {
-            case GW::RegionType::Dungeon:
                 return Climate::None;
         }
         return Climate::Temperate;


### PR DESCRIPTION
## Problem

`ClimateForMap`'s dungeon guard (`type == RegionType::Dungeon -> Climate::None`) sat **after** the region `switch`. That switch has no `default` and returns early for every handled region, so a `Dungeon`-typed map whose region *is* handled never reached the guard and still got that region's climate.

Separately, `Region_DepthsOfTyria` (EotN underground) was mapped to `Mountainous`, giving snow/blizzard in zones that have no sky.

## Fix

- Move the `type == RegionType::Dungeon` check ahead of the region switch so any map GW flags as a dungeon resolves to clear regardless of region. Removes the now-redundant trailing type switch.
- Map `Region_DepthsOfTyria` to `Climate::None` (Northern/Far Shiverpeaks stay `Mountainous`).

## Scope / what this does NOT fix

The dungeon guard only catches maps GW actually tags as `RegionType::Dungeon`. Interiors GW types as something else (e.g. the Forsaken Tunnels, an explorable cave — region not in the switch, so it falls through to `Temperate`) are not covered and still need a per-map override or genuine "no-sky / interior" detection.