### PR TITLE
fix: preserve zplane in SyncPolys polygon points

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
@@ -826,8 +826,7 @@ GameWorldRenderer::RenderableVectors GameWorldRenderer::SyncPolys()
             // don't draw normal polys in doa outpost
             continue;
         }
-        std::vector<GW::GamePos> pts{};
-        std::ranges::transform(poly.points, std::back_inserter(pts), [](const GW::Vec2f& pt) { return GW::GamePos(pt); });
+        const std::vector<GW::GamePos> pts(poly.points.begin(), poly.points.end());
 
         auto poly_to_add = GenericPolyRenderable(poly.map, pts, poly.color, poly.filled);
 


### PR DESCRIPTION
Fixes #2345

`GamePos → Vec2f → GamePos` implicit conversion in `SyncPolys` was silently dropping `zplane`, causing polygon points to always drape against plane 0 regardless of which surface they were placed on. Fixed by copying `GamePos` objects directly.

Generated with [Claude Code](https://claude.ai/code)