### PR TITLE
fix(launcher): warn to restart Guild Wars after allowing it through CFA

### DIFF
--- a/GWToolbox/WindowsDefender.cpp
+++ b/GWToolbox/WindowsDefender.cpp
@@ -4,6 +4,7 @@
 #include <Path.h>
 #include "WindowsDefender.h"
 
+#include "Inject.h"
 #include "Settings.h"
 
 namespace fs = std::filesystem;
@@ -169,6 +170,19 @@ bool AddDefenderExceptions(const std::filesystem::path& exclusion_path,
     if (cmdlets.empty())
         return true;
 
+    // Controlled Folder Access fixes a process's allowed status at launch, so allowing an
+    // already-running Gw.exe now won't let the injected Toolbox write to Documents until that
+    // client restarts. Note it here so we can tell the user once the change lands.
+    bool allowing_running_gw = false;
+    if (state.controlled_folder_access == 1) {
+        for (const auto& gw : GetGuildWarsExecutablePaths()) {
+            if (!ListCoversPath(state.cfa_apps, LowerCanonical(gw), false)) {
+                allowing_running_gw = true;
+                break;
+            }
+        }
+    }
+
     const bool is_admin = IsRunningAsAdmin();
 
     if (!is_admin && !quiet) {
@@ -232,7 +246,12 @@ bool AddDefenderExceptions(const std::filesystem::path& exclusion_path,
         if (verified) {
             ShowMessageBoxW(
                 nullptr,
-                L"Windows Security exceptions added successfully!",
+                allowing_running_gw
+                    ? L"Windows Security exceptions added successfully!\n\n"
+                      L"Guild Wars is now allowed through Controlled Folder Access (Ransomware protection), "
+                      L"but Windows only applies that to newly-started programs. Close and re-open Guild Wars, "
+                      L"then start Toolbox again, so it can save your settings and crash dumps."
+                    : L"Windows Security exceptions added successfully!",
                 L"Windows Defender Exclusion",
                 MB_OK | MB_ICONINFORMATION);
         }


### PR DESCRIPTION
## Problem

As reported in Discord: **Toolbox needs a restart after adding Controlled Folder Access (CFA) rules.**

Windows Controlled Folder Access fixes a process's *allowed* status when the process **launches** — a running process isn't re-evaluated when you add it to the allow-list. Because `GWToolboxdll.dll` is injected into **`Gw.exe`**, Toolbox's runtime writes (settings, crash dumps into `Documents\GWToolboxpp`) are attributed to `Gw.exe`. So when the launcher allows the already-running `Gw.exe` through CFA during a first install, that client stays blocked until it's restarted — and nothing told the user.

The launcher adds the allow entry from two paths (`Install()` and `EnsureDefenderReadiness()`), both of which funnel through `AddDefenderExceptions()`.

## Fix

In `AddDefenderExceptions`, detect when we're about to allow a **currently-running** `Gw.exe` through CFA (CFA enabled + a running client not yet on the allow-list). Once the change lands successfully, the "exceptions added" dialog tells the user to close and re-open Guild Wars so Toolbox can save its settings and crash dumps.

Placing it at this single choke point covers both the install and the pre-injection readiness paths without touching `main.cpp` or the header.

## Notes
- Only fires when CFA is actually **on** and a running `Gw.exe` isn't already allowed — no nag otherwise.
- Quiet installs stay silent (message is gated on `!quiet`).
- The launcher only ever injects into a pre-existing `Gw.exe`, so there's no false positive from a client the launcher started itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)