### PR TITLE
feat(defender): mute Windows Security prompt until next update

### DIFF
--- a/GWToolbox/CMakeLists.txt
+++ b/GWToolbox/CMakeLists.txt
@@ -25,4 +25,5 @@ target_link_libraries(GWToolbox PRIVATE
 
     version.lib # for GetFileVersionInfo
     bcrypt.lib # for sha256 of the launcher exe
+    comctl32.lib # for TaskDialogIndirect (Defender prompt checkbox)
     )

--- a/GWToolbox/WindowsDefender.cpp
+++ b/GWToolbox/WindowsDefender.cpp
@@ -5,11 +5,67 @@
 #include "WindowsDefender.h"
 
 #include "Inject.h"
+#include "Registry.h"
 #include "Settings.h"
 
 namespace fs = std::filesystem;
 
 namespace {
+    // Registry value under HKCU\Software\GWToolbox holding the build for which the user ticked
+    // "don't ask again"; the prompt stays hidden only while it matches the running version.
+    constexpr auto kDefenderPromptSuppressKey = L"DefenderPromptSuppressedVersion";
+
+    std::wstring CurrentVersion()
+    {
+        const std::string v = GWTOOLBOXEXE_VERSION;
+        return {v.begin(), v.end()};
+    }
+
+    bool DefenderPromptSuppressed()
+    {
+        wchar_t buffer[64] = {};
+        std::wstring error;
+        if (!RegReadStr(kDefenderPromptSuppressKey, buffer, _countof(buffer), error))
+            return false;
+        return CurrentVersion() == buffer;
+    }
+
+    void SuppressDefenderPromptForThisVersion()
+    {
+        std::wstring error;
+        RegWriteStr(kDefenderPromptSuppressKey, CurrentVersion().c_str(), error);
+    }
+
+    // Yes/No prompt carrying a "don't ask again" checkbox. Returns true for Yes and reports the
+    // checkbox state; falls back to a plain (checkbox-less) message box if TaskDialog is unavailable.
+    bool AskYesNoWithSuppressOption(const wchar_t* base_title, const std::wstring& instruction,
+                                    const std::wstring& content, const std::wstring& verification,
+                                    bool& dont_ask_again)
+    {
+        const std::wstring title = GwtbDialogTitle(base_title);
+
+        TASKDIALOGCONFIG config = {sizeof(config)};
+        config.dwFlags = TDF_ALLOW_DIALOG_CANCELLATION;
+        config.dwCommonButtons = TDCBF_YES_BUTTON | TDCBF_NO_BUTTON;
+        config.pszWindowTitle = title.c_str();
+        config.pszMainIcon = TD_INFORMATION_ICON;
+        config.pszMainInstruction = instruction.c_str();
+        config.pszContent = content.c_str();
+        config.pszVerificationText = verification.c_str();
+        config.nDefaultButton = IDYES;
+
+        int button = 0;
+        BOOL checked = FALSE;
+        if (FAILED(TaskDialogIndirect(&config, &button, nullptr, &checked))) {
+            dont_ask_again = false;
+            const std::wstring text = instruction + L"\n\n" + content;
+            return ShowMessageBoxW(nullptr, text.c_str(), base_title, MB_YESNO | MB_ICONINFORMATION) == IDYES;
+        }
+
+        dont_ask_again = checked == TRUE;
+        return button == IDYES;
+    }
+
     // A snapshot of the Windows Defender settings that decide whether Toolbox can use its folder.
     struct DefenderState {
         bool readable = false;             // false when Get-MpPreference couldn't be read (locked-down host, third-party AV, ...)
@@ -186,21 +242,29 @@ bool AddDefenderExceptions(const std::filesystem::path& exclusion_path,
     const bool is_admin = IsRunningAsAdmin();
 
     if (!is_admin && !quiet) {
-        const int iRet = ShowMessageBoxW(
-            nullptr,
+        bool dont_ask_again = false;
+        const bool proceed = AskYesNoWithSuppressOption(
+            L"Windows Defender Exclusion",
+            L"Add Windows Security exceptions for GWToolbox?",
             L"GWToolbox would like to add Windows Security exceptions for itself (a Defender exclusion and "
             L"Controlled Folder Access permissions) to prevent false positives and let it save settings and crash dumps.\n\n"
-            L"This requires administrator privileges. Would you like to add them?",
-            L"Windows Defender Exclusion",
-            MB_YESNO | MB_ICONINFORMATION);
+            L"This requires administrator privileges.",
+            L"Don't ask again until GWToolbox is updated",
+            dont_ask_again);
 
-        if (iRet != IDYES) {
-            ShowMessageBoxW(
-                nullptr,
-                L"GWToolbox will likely not function correctly without these exceptions.\n\n"
-                L"You will be prompted again next time until they are added.",
-                L"Windows Defender Exclusion - Warning",
-                MB_OK | MB_ICONWARNING);
+        if (dont_ask_again)
+            SuppressDefenderPromptForThisVersion();
+
+        if (!proceed) {
+            // A ticked checkbox already tells the user they won't be nagged again; skip the contradictory warning.
+            if (!dont_ask_again) {
+                ShowMessageBoxW(
+                    nullptr,
+                    L"GWToolbox will likely not function correctly without these exceptions.\n\n"
+                    L"You will be prompted again next time until they are added.",
+                    L"Windows Defender Exclusion - Warning",
+                    MB_OK | MB_ICONWARNING);
+            }
             return true;
         }
     }
@@ -276,6 +340,10 @@ bool AddDefenderExceptions(const std::filesystem::path& exclusion_path,
 void EnsureDefenderReadiness(const std::filesystem::path& exclusion_path,
                              const std::vector<std::filesystem::path>& controlled_folder_access_apps)
 {
+    // The user asked not to be reminded again for this build.
+    if (DefenderPromptSuppressed())
+        return;
+
     DefenderState state;
     if (!QueryDefenderState(state)) {
         // Can't read Defender state (locked-down host, third-party AV): don't nag on a guess.


### PR DESCRIPTION
## What

Adds a **"Don't ask again until GWToolbox is updated"** checkbox to the loader's Windows Defender / Controlled Folder Access exception prompt.

From #gwtoolbox-support: after updating to 8.30 the loader re-shows the "add a Windows Defender exclusion" prompt on **every** launch when the exclusion can't be verified as added (e.g. the user can't/won't elevate, or a third-party AV interferes). This gives them a way to opt out without disabling the feature entirely.

## How

- Replaced the plain Yes/No `MessageBox` for the initial prompt with a `TaskDialogIndirect` that carries a verification checkbox. Falls back to the old checkbox-less message box if the task dialog can't be created.
- When the box is ticked, the current build (`GWTOOLBOXEXE_VERSION`) is written to `HKCU\Software\GWToolbox\DefenderPromptSuppressedVersion`.
- `EnsureDefenderReadiness` skips the prompt while that stored version matches the running build, so it stays quiet for the rest of the current version and **re-prompts automatically after the next update** (version no longer matches).
- When the box is ticked, the follow-up "you'll be prompted again next time" warning is suppressed since it would contradict the choice.
- Added `comctl32.lib` for `TaskDialogIndirect` (the v6 common-controls manifest was already present).

Note: this is the GWToolbox **loader** (`GWToolbox/`) prompt users see after updating Toolbox — not the separate `gwlauncher` repo, which has no Defender code.