### PR TITLE
Docker + Wine build for Linux hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ vcpkg_installed/
 /bin/
 build/
 build-clang/
+build-wine/
 
 # Cmake generated
 _deps/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,6 +29,26 @@
         "CMAKE_C_FLAGS_INIT": "-m32",
         "CMAKE_CXX_FLAGS_INIT": "-m32"
       }
+    },
+    {
+      "name": "wine",
+      "inherits": "vcpkg",
+      "displayName": "Real MSVC under Wine (Ninja, headless Linux build)",
+      "generator": "Ninja",
+      "architecture": {
+        "value": "Win32",
+        "strategy": "external"
+      },
+      "binaryDir": "${sourceDir}/build-wine",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "Windows",
+        "CMAKE_SYSTEM_PROCESSOR": "x86",
+        "CMAKE_C_COMPILER": "cl",
+        "CMAKE_CXX_COMPILER": "cl",
+        "CMAKE_RC_COMPILER": "rc",
+        "FXC": "/opt/msvc/bin/x86/fxc",
+        "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/scripts/wine-msvc/vcpkg-triplets;${sourceDir}/vcpkg-overlays/triplets"
+      }
     }
   ]
 }

--- a/GWToolboxdll/CMakeLists.txt
+++ b/GWToolboxdll/CMakeLists.txt
@@ -162,11 +162,24 @@ add_custom_target(compile_shaders DEPENDS ${SHADER_OUTPUTS})
 
 add_dependencies(GWToolboxdll compile_shaders) 
 
-add_custom_command(TARGET GWToolboxdll POST_BUILD
-    COMMAND powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass
-            -File "${CMAKE_CURRENT_SOURCE_DIR}/compress.ps1"
-            "$<TARGET_PDB_FILE:GWToolboxdll>"
-            "$<CONFIG>"
-    COMMENT "Compressing PDB for distribution (RelWithDebInfo only)"
-    VERBATIM
-)
+# compress.ps1 needs PowerShell, which isn't available when configuring from a non-Windows
+# host (e.g. the wine cross-build in scripts/build-wine-prefix.sh); gzip is a POSIX
+# equivalent for the RelWithDebInfo-only PDB compression it does.
+if(CMAKE_HOST_WIN32)
+    add_custom_command(TARGET GWToolboxdll POST_BUILD
+        COMMAND powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass
+                -File "${CMAKE_CURRENT_SOURCE_DIR}/compress.ps1"
+                "$<TARGET_PDB_FILE:GWToolboxdll>"
+                "$<CONFIG>"
+        COMMENT "Compressing PDB for distribution (RelWithDebInfo only)"
+        VERBATIM
+    )
+else()
+    add_custom_command(TARGET GWToolboxdll POST_BUILD
+        COMMAND $<IF:$<CONFIG:RelWithDebInfo>,gzip,${CMAKE_COMMAND}>
+                $<IF:$<CONFIG:RelWithDebInfo>,-kf,-E>
+                $<IF:$<CONFIG:RelWithDebInfo>,$<TARGET_PDB_FILE:GWToolboxdll>,true>
+        COMMENT "Compressing PDB for distribution (RelWithDebInfo only)"
+        VERBATIM
+    )
+endif()

--- a/README.md
+++ b/README.md
@@ -29,6 +29,29 @@ If you are here to check toolbox features or for a download link, go to [https:/
 
 7. Run.
 
+## Building on Linux (Docker + Wine)
+
+GWToolboxdll can also be cross-compiled from Linux using a real MSVC toolchain running under Wine, packaged in a Docker image.
+
+### Requirements
+* [Docker](https://docs.docker.com/get-docker/)
+
+### Steps
+1. Clone the repository and `cd` into it.
+2. Build: `./scripts/build-wine-prefix.sh`
+
+The first run builds the Docker image (downloads MSVC + Windows SDK, expect it to take a while), then configures and builds `GWToolboxdll` into `bin/GWToolboxdll.dll`. Later runs reuse the cached image and only rebuild changed files.
+
+Useful options (see `./scripts/build-wine-prefix.sh --help`):
+* `--target <name>` - build a different CMake target (default: `GWToolboxdll`; use `all` for everything)
+* `--config <Debug|RelWithDebInfo|Release>` - CMake config to build (default: `RelWithDebInfo`)
+* `--shell` - drop into a shell in the build container instead of building
+* `--rebuild-image` - force a clean rebuild of the Docker image
+
+Notes:
+* The container runs as root; the script hands ownership of any files it writes back to your user once done.
+* Build output lives in `build-wine/` (gitignored). Delete it for a fully clean reconfigure, e.g. after switching `--config` or branches.
+
 ## Notes
 * GWToolbox compiles as a DLL (`GWToolboxdll.dll`) and EXE (`GWToolbox.exe`). The exe lets you select a Guild Wars Client and injects the dll, but you can also use other dll injectors of your choice.
 * By default, the launcher (`GWToolbox.exe`) will run the `GWToolboxdll.dll` in the same folder, if there is none, it will inject the one in your installation folder.

--- a/cmake/imgui.cmake
+++ b/cmake/imgui.cmake
@@ -1,15 +1,24 @@
 include_guard()
 include(FetchContent)
 
+# apply_patch.bat can't run directly when configuring from a non-Windows host (e.g. the
+# wine cross-compile toolchain in scripts/build-wine-prefix.sh); use the POSIX equivalent there.
+if(CMAKE_HOST_WIN32)
+    set(_IMGUI_PATCH_COMMAND "${CMAKE_CURRENT_LIST_DIR}/patches/apply_patch.bat")
+else()
+    set(_IMGUI_PATCH_COMMAND sh "${CMAKE_CURRENT_LIST_DIR}/patches/apply_patch.sh")
+endif()
+
 FetchContent_Declare(
     imgui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
     GIT_TAG v1.92.7-docking
-    PATCH_COMMAND ${CMAKE_CURRENT_LIST_DIR}/patches/apply_patch.bat imgui_transparent_viewports.patch
+    PATCH_COMMAND ${_IMGUI_PATCH_COMMAND} imgui_transparent_viewports.patch
     LOG_PATCH true
     LOG_MERGED_STDOUTERR true
     LOG_OUTPUT_ON_FAILURE true
     )
+unset(_IMGUI_PATCH_COMMAND)
 FetchContent_GetProperties(imgui)
 if (imgui_POPULATED)
     return()

--- a/cmake/patches/apply_patch.sh
+++ b/cmake/patches/apply_patch.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+# POSIX equivalent of apply_patch.bat, used when configuring from a non-Windows host
+# (e.g. cross-compiling via scripts/build-wine-prefix.sh), where .bat scripts can't run.
+set -e
+dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+patch_file="$dir/$1"
+
+if git apply --reverse --check --ignore-whitespace "$patch_file" 2>/dev/null; then
+    echo "Already applied, nothing to do"
+    exit 0
+fi
+echo "Applying patch"
+git apply --ignore-whitespace "$patch_file"

--- a/scripts/build-wine-prefix.sh
+++ b/scripts/build-wine-prefix.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Build a Docker image with a headless Wine + real MSVC (x86 v143+) + vcpkg toolchain,
+# then configure and build GWToolboxdll inside it.
+#
+# Why Docker: MSVC-under-wine needs a fair pile of host state (a wine prefix, the
+# unpacked MSVC/WinSDK trees, a bootstrapped vcpkg) - keeping all of that inside an
+# image/container makes the whole thing disposable: `docker image rm` wipes it cleanly,
+# and it never touches the host's actual Wine setup (if the machine has one for gaming).
+#
+# See scripts/wine-msvc/Dockerfile for how the toolchain itself is assembled
+# (mstorsjo/msvc-wine downloads the real MSVC + Windows SDK under the VS Build Tools
+# EULA, and wraps cl/link/lib/rc to run under wine).
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/.." && pwd)
+IMAGE_NAME="gwtoolboxpp-wine-msvc"
+
+CONFIG="RelWithDebInfo"
+TARGET="GWToolboxdll"
+REBUILD_IMAGE=0
+SHELL_ONLY=0
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options]
+
+Options:
+  --config <Debug|RelWithDebInfo|Release>   CMake config to build (default: ${CONFIG})
+  --target <name>                           CMake build target (default: ${TARGET}; use "all" for everything)
+  --rebuild-image                           Force a clean rebuild of the docker image
+  --shell                                   Drop into an interactive shell in the container instead of building
+  -h, --help                                Show this help
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --config) CONFIG="$2"; shift 2 ;;
+        --target) TARGET="$2"; shift 2 ;;
+        --rebuild-image) REBUILD_IMAGE=1; shift ;;
+        --shell) SHELL_ONLY=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required but not found in PATH." >&2
+    exit 1
+fi
+
+if [ "${REBUILD_IMAGE}" -eq 1 ] || ! docker image inspect "${IMAGE_NAME}" >/dev/null 2>&1; then
+    echo "[build-wine-prefix] building docker image '${IMAGE_NAME}' (this downloads MSVC + Windows SDK; expect it to take a while the first time)..."
+    docker build "${REBUILD_IMAGE:+--no-cache}" -t "${IMAGE_NAME}" -f "${SCRIPT_DIR}/wine-msvc/Dockerfile" "${SCRIPT_DIR}/wine-msvc"
+fi
+
+RUN_ARGS=(--rm -v "${REPO_ROOT}:/src" -w /src "${IMAGE_NAME}")
+
+if [ "${SHELL_ONLY}" -eq 1 ]; then
+    exec docker run -it "${RUN_ARGS[@]}" bash
+fi
+
+# The container runs as root, so anything it writes into the bind-mounted repo (build-wine/,
+# bin/, vcpkg_installed/, generated shader headers, ...) ends up root-owned on the host.
+# Hand it back to the invoking user once we're done so the repo stays normally editable.
+fix_ownership() {
+    docker run --rm -v "${REPO_ROOT}:/src" "${IMAGE_NAME}" chown -R "$(id -u):$(id -g)" /src >/dev/null 2>&1 || true
+}
+trap fix_ownership EXIT
+
+echo "[build-wine-prefix] configuring (preset: wine, config: ${CONFIG})..."
+docker run "${RUN_ARGS[@]}" bash -lc "cmake --preset wine -DCMAKE_BUILD_TYPE='${CONFIG}'"
+
+echo "[build-wine-prefix] building target '${TARGET}'..."
+if [ "${TARGET}" = "all" ]; then
+    docker run "${RUN_ARGS[@]}" bash -lc "cmake --build build-wine --config '${CONFIG}'"
+else
+    docker run "${RUN_ARGS[@]}" bash -lc "cmake --build build-wine --config '${CONFIG}' --target '${TARGET}'"
+fi
+
+echo "[build-wine-prefix] done. Output under ${REPO_ROOT}/bin/"

--- a/scripts/wine-msvc/Dockerfile
+++ b/scripts/wine-msvc/Dockerfile
@@ -1,0 +1,94 @@
+# Headless Wine + real MSVC (x86) toolchain for cross-compiling GWToolboxdll on Linux.
+#
+# GWToolboxdll is injected into the (32-bit) Guild Wars process, so it must be built
+# x86/Win32 with an actual MSVC v143+ toolset (CMakeLists.txt enforces both). Since MSVC
+# isn't redistributable, we can't ship prebuilt binaries here - instead we use
+# mstorsjo/msvc-wine, which downloads the real MSVC + Windows SDK components straight
+# from Microsoft's official installer manifests (same ones Visual Studio's installer
+# uses) under the VS Build Tools EULA, then wraps cl/link/lib/rc as thin scripts that
+# run the real Windows binaries under Wine. From CMake's point of view this is
+# indistinguishable from a native MSVC install.
+FROM ubuntu:24.04
+
+ARG MSVC_WINE_REF=514f8ea34842cd6d831804d0e9658d3a32870ae1
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gpg \
+        wget \
+        python3 \
+        msitools \
+        git \
+        unzip \
+        zip \
+        tar \
+        build-essential \
+        ninja-build \
+        pkg-config \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Ubuntu 24.04's bundled wine (9.0) has broken mspdbsrv named-pipe IPC: any cl.exe invocation
+# with /FS (which CMake adds unconditionally for MSVC >= 18.0, regardless of generator or
+# debug-info settings) fails with "fatal error C1902: Program database manager mismatch".
+# WineHQ's own build fixes this - use it instead of the distro package.
+RUN mkdir -pm755 /etc/apt/keyrings \
+    && wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key \
+    && wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/noble/winehq-noble.sources \
+    && dpkg --add-architecture i386 \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --install-recommends winehq-staging \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# The repo's CMakeLists.txt requires >= 3.29 (Ubuntu 24.04's apt cmake is 3.28); grab the
+# same Kitware release the maintainers build with (see CMakeLists.txt's CMake 4.3 comment).
+ARG CMAKE_VERSION=4.3.3
+RUN curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz" \
+        | tar -xz -C /opt \
+    && ln -s "/opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/cmake" /usr/local/bin/cmake \
+    && ln -s "/opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/ctest" /usr/local/bin/ctest \
+    && ln -s "/opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/cpack" /usr/local/bin/cpack
+
+# Initialize the wine prefix once at build time and bake it into the image layer -
+# avoids re-running wineboot (and its first-run overhead) on every `docker run`.
+# Ubuntu's wine64 package only ships a "wine" binary (no separate "wine64"); msvc-wine's
+# own scripts fall back the same way, so we mirror that here.
+RUN $(command -v wine64 || command -v wine) wineboot --init && while pgrep wineserver > /dev/null; do sleep 1; done
+
+WORKDIR /opt/msvc-wine
+RUN git clone https://github.com/mstorsjo/msvc-wine.git . && git checkout "${MSVC_WINE_REF}"
+
+# This project always builds 32-bit (x86 target), but we still need the x64 *target*
+# component too: install.sh only builds msvctricks.exe (a small helper the wrapper scripts
+# use to reliably reap wine child processes/pipes) when a Hostx64/x64/cl.exe exists, since
+# it's shared across all bin/<arch> wrappers. Without it, the bin/x86 wrapper falls back to
+# a plain shell-pipe implementation that can hang (ninja waiting forever on a defunct child
+# holding a fifo open) - so pull x64 as well purely to get msvctricks.exe built.
+RUN PYTHONUNBUFFERED=1 ./vsdownload.py --accept-license --architecture x86 x64 --dest /opt/msvc \
+    && ./install.sh /opt/msvc
+
+# Real MSVC toolchain, wrapped for wine, now lives here. Deliberately NOT setting
+# CC/CXX=cl globally: vcpkg also needs a native x64-linux compiler (g++, from
+# build-essential) to build its own host tools (e.g. detect_compiler); the project's
+# own CMake preset (see CMakePresets.json's "wine" preset) sets CMAKE_C/CXX_COMPILER=cl
+# explicitly for the actual x86-windows target build.
+ENV PATH="/opt/msvc/bin/x86:${PATH}"
+
+RUN git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg \
+    && /opt/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+ENV VCPKG_ROOT=/opt/vcpkg
+ENV PATH="${VCPKG_ROOT}:${PATH}"
+
+COPY entrypoint.sh /opt/entrypoint.sh
+RUN chmod +x /opt/entrypoint.sh
+
+# GWToolboxdll compiles a few HLSL shaders with fxc.exe (from the Windows SDK, not wrapped
+# by msvc-wine itself); drop in a wrapper alongside cl/link/rc following the same pattern.
+COPY fxc /opt/msvc/bin/x86/fxc
+RUN chmod +x /opt/msvc/bin/x86/fxc
+
+WORKDIR /src
+ENTRYPOINT ["/opt/entrypoint.sh"]
+CMD ["bash"]

--- a/scripts/wine-msvc/entrypoint.sh
+++ b/scripts/wine-msvc/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Container entrypoint: starts a persistent wineserver (cl/link/lib/rc under wine are much
+# faster with a warm server instead of spawning+killing one per invocation) then execs the
+# requested command against the mounted repo.
+set -euo pipefail
+
+WINE=$(command -v wine64 || command -v wine)
+
+wineserver -k >/dev/null 2>&1 || true
+wineserver -p
+"${WINE}" wineboot >/dev/null 2>&1
+
+exec "$@"

--- a/scripts/wine-msvc/fxc
+++ b/scripts/wine-msvc/fxc
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# fxc.exe wrapper for the wine cross-build (see scripts/build-wine-prefix.sh). fxc.exe ships
+# in the Windows SDK, not the VC toolset, so msvc-wine doesn't provide a wrapper for it.
+#
+# fxc.exe under wine non-deterministically corrupts its own /Fh output: a single stray byte
+# gets inserted right before the "#endif" that closes the generated disassembly comment block,
+# breaking the #if 0/#endif balance and causing a "C1004: unexpected end-of-file" wherever the
+# header later gets #included. It isn't tied to concurrency, repeated invocations, or a
+# particular wineserver/prefix state (all ruled out by testing) - it just happens sometimes,
+# consistent with a latent uninitialized-memory bug in fxc.exe itself that Windows' allocator
+# usually masks but wine's doesn't. Since the corruption always lands as extra characters
+# immediately before "#endif" on its own line, sanitize the output afterwards rather than
+# trying to prevent it.
+#
+# This also skips msvc-wine's wine-msvc.sh wrapper (used by cl/link/rc): its mkfifo-based
+# stdout/stderr piping isn't needed here, and only added noise while diagnosing the above.
+DIR="$(dirname "$0")"
+. "$DIR"/msvcenv.sh
+
+FXC_EXE=$(ls "$DIR"/../../kits/10/bin/*/x86/fxc.exe 2>/dev/null | head -1)
+if [ -z "$FXC_EXE" ]; then
+    echo "fxc.exe not found under Windows Kits (kits/10/bin/*/x86/fxc.exe)" >&2
+    exit 1
+fi
+
+WINE=$(command -v wine64 || command -v wine || false)
+export WINEDEBUG=${WINEDEBUG:-"-all"}
+
+OUT_FILES=()
+ARGS=()
+prev=
+for a; do
+    if [ "$prev" = "/Fh" ] || [ "$prev" = "-Fh" ]; then
+        OUT_FILES+=("$a")
+    fi
+
+    path=
+    case "$a" in
+    [-/][A-Za-z]/*)
+        path=${a#??}
+        ;;
+    [-/][A-Za-z][A-Za-z]/*)
+        path=${a#???}
+        ;;
+    [-/][A-Za-z][A-Za-z][A-Za-z]*:/*)
+        path=${a#*:}
+        ;;
+    /*)
+        path=$a
+        ;;
+    *)
+        ;;
+    esac
+    if [ -n "$path" ] && [ -d "$(dirname "$path")" ] && [ "$(dirname "$path")" != "/" ]; then
+        opt=${a%$path}
+        a="${opt}z:${path//\//\\}"
+    fi
+    ARGS+=("$a")
+    prev=$a
+done
+
+"$WINE" "$FXC_EXE" "${ARGS[@]}"
+ec=$?
+
+if [ $ec -eq 0 ]; then
+    for f in "${OUT_FILES[@]}"; do
+        [ -f "$f" ] && sed -i -E 's/^.+#endif[[:space:]]*\r?$/#endif\r/' "$f"
+    done
+fi
+exit $ec

--- a/scripts/wine-msvc/vcpkg-triplets/wine-msvc-toolchain.cmake
+++ b/scripts/wine-msvc/vcpkg-triplets/wine-msvc-toolchain.cmake
@@ -1,0 +1,34 @@
+# Chainloaded by x86-windows-mixed.cmake below when cross-building from Linux. vcpkg's stock
+# windows triplet logic assumes a native Visual Studio Developer Prompt (vcvarsall.bat), which
+# doesn't exist here - point it directly at the wine-wrapped MSVC tools on PATH instead
+# (see scripts/wine-msvc/Dockerfile).
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86)
+set(CMAKE_C_COMPILER cl)
+set(CMAKE_CXX_COMPILER cl)
+set(CMAKE_RC_COMPILER rc)
+
+# Using VCPKG_CHAINLOAD_TOOLCHAIN_FILE replaces vcpkg's own scripts/toolchains/windows.cmake
+# entirely, including the bits that enforce VCPKG_CRT_LINKAGE - without this, ports built here
+# default to /MD (dynamic) and fail to link against the rest of the project, which is always
+# built /MT (static; see CMakeLists.txt's CMAKE_MSVC_RUNTIME_LIBRARY setting) via
+# VCPKG_CRT_LINKAGE=dynamic|static per PORT in x86-windows-mixed.cmake. Mirror both mechanisms
+# vcpkg's own toolchain uses: CMAKE_MSVC_RUNTIME_LIBRARY (gated behind CMake's CMP0091 policy,
+# so some ports' own older cmake_minimum_required ignore it) and explicit /MT or /MD in
+# CMAKE_C/CXX_FLAGS_DEBUG|RELEASE (unconditional, and what actually fixed recastnavigation).
+if(DEFINED VCPKG_CRT_LINKAGE)
+    if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+        set(_CRT_FLAG_PREFIX "/MD")
+    elseif(VCPKG_CRT_LINKAGE STREQUAL "static")
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+        set(_CRT_FLAG_PREFIX "/MT")
+    else()
+        message(FATAL_ERROR "Invalid setting for VCPKG_CRT_LINKAGE: \"${VCPKG_CRT_LINKAGE}\". It must be \"static\" or \"dynamic\"")
+    endif()
+    set(CMAKE_CXX_FLAGS_DEBUG "${_CRT_FLAG_PREFIX}d /Z7 /Ob0 /Od /RTC1" CACHE STRING "")
+    set(CMAKE_C_FLAGS_DEBUG "${_CRT_FLAG_PREFIX}d /Z7 /Ob0 /Od /RTC1" CACHE STRING "")
+    set(CMAKE_CXX_FLAGS_RELEASE "${_CRT_FLAG_PREFIX} /O2 /Oi /Gy /DNDEBUG /Z7" CACHE STRING "")
+    set(CMAKE_C_FLAGS_RELEASE "${_CRT_FLAG_PREFIX} /O2 /Oi /Gy /DNDEBUG /Z7" CACHE STRING "")
+    unset(_CRT_FLAG_PREFIX)
+endif()

--- a/scripts/wine-msvc/vcpkg-triplets/x86-windows-mixed.cmake
+++ b/scripts/wine-msvc/vcpkg-triplets/x86-windows-mixed.cmake
@@ -1,0 +1,33 @@
+# Cross-building x86-windows-mixed from Linux via wine (see scripts/build-wine-prefix.sh):
+# mirrors vcpkg-overlays/triplets/x86-windows-mixed.cmake (kept in sync manually - vcpkg's
+# own triplet-file parser doesn't support include(), so this can't just include() that file)
+# plus the settings needed to point vcpkg at the wine-wrapped MSVC toolchain instead of
+# trying to auto-detect a native Visual Studio Developer Prompt.
+set(VCPKG_TARGET_ARCHITECTURE x86)
+
+if(PORT MATCHES "discord-game-sdk|curl")
+    set(VCPKG_CRT_LINKAGE dynamic)
+    set(VCPKG_LIBRARY_LINKAGE dynamic)
+else()
+    set(VCPKG_CRT_LINKAGE static)
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
+# we never run BC6H/BC7 software compression. Also disable the "dx11" default feature here
+# (wine-build only, see wine-msvc-toolchain.cmake): it default-compiles GPU compute shaders
+# via a CompileShaders.cmd batch file invoked directly by the port's CMakeLists.txt, which
+# isn't runnable on Linux (no cmd.exe interpreter outside of an explicit `wine` invocation).
+# The codebase only calls directxtex's core Compress/Decompress/Convert functions - actual
+# DDS/WIC texture loading goes through the separately-fetched D3D9 DDSTextureLoader9 (see
+# cmake/directxtexloader.cmake), never through directxtex's own DX11 loader.
+if(PORT STREQUAL "directxtex")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DBC_USE_OPENMP=OFF;-DBUILD_DX11=OFF")
+endif()
+
+# Skip vcpkg's native-Windows Visual Studio Developer Prompt auto-detection (which doesn't
+# exist on Linux) and point it at the wine-wrapped MSVC toolchain instead. Deliberately NOT
+# setting VCPKG_CMAKE_SYSTEM_NAME here: vcpkg's "windows" platform-expression match (used by
+# ports' "supports" checks, e.g. directxtex/minhook/discord-game-sdk) only recognizes it as
+# Windows-family when left unset (empty) or "WindowsStore"/"MinGW" - an explicit "Windows"
+# value doesn't match and makes every Windows-only port look unsupported.
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/wine-msvc-toolchain.cmake")


### PR DESCRIPTION
Run with `scripts/build-wine-prefix.sh` which outputs GWToolbox.dll + pdb in `bin/`