### PR TITLE
feat(pathing): draw the multimap path on the mission map and compass

### DIFF
--- a/GWToolboxdll/MinimapPlugin.h
+++ b/GWToolboxdll/MinimapPlugin.h
@@ -33,6 +33,7 @@ struct MinimapRenderContext : RectF {
     D3DCOLOR background_color = D3DCOLOR_ARGB(50, 0, 0, 0); // Background color (or 0 to use renderer's default)
     D3DCOLOR foreground_color = D3DCOLOR_ARGB(0xff, 0xe0, 0xe0, 0xe0); // Foreground color (or 0 to use renderer's default)
     D3DCOLOR shadow_color = 0; // Drop shadow for foreground color
+    float shadow_translation = -100.f; // Drop-shadow offset, in the view's output space (px under a game->px view_override)
     D3DCOLOR cardinal_color = 0;
 
     bool draw_ranges = false;

--- a/GWToolboxdll/Modules/QuestModule.cpp
+++ b/GWToolboxdll/Modules/QuestModule.cpp
@@ -130,7 +130,7 @@ namespace {
             minimap_lines.clear();
         }
 
-        // Current-map segments draw on in-game surfaces; off-map segments stay world coords (world map only) to avoid overflow.
+        // Current-map segments draw on in-game surfaces; off-map segments stay world coords (world & mission map) to avoid overflow.
         void DrawLines()
         {
             ClearMinimapLines();
@@ -157,8 +157,10 @@ namespace {
                 l = Minimap::Instance().custom_renderer.AddCustomLine({route_world[i].x, route_world[i].y, 0}, {route_world[i + 1].x, route_world[i + 1].y, 0}, label.c_str(), true);
                 l->world_coords = true;
                 l->draw_on_terrain = false;
-                l->draw_on_minimap = false;
-                l->draw_on_mission_map = false;
+                // World coords render on the world map, mission map, and compass (each projects them
+                // into its own space); in-world terrain can't place other maps' positions.
+                l->draw_on_minimap = settings.draw_quest_path_on_minimap;
+                l->draw_on_mission_map = settings.draw_quest_path_on_mission_map;
                 l->created_by_toolbox = true;
                 l->color = color;
                 minimap_lines.push_back(l);

--- a/GWToolboxdll/Widgets/Minimap/CustomRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/CustomRenderer.cpp
@@ -19,6 +19,7 @@
 #include <Modules/Resources.h>
 #include <Widgets/Minimap/CustomRenderer.h>
 #include <Widgets/Minimap/Minimap.h>
+#include <Widgets/WorldMapWidget.h>
 #include <Color.h>
 #include <GWToolbox.h>
 #include <Utils/GuiUtils.h>
@@ -988,7 +989,8 @@ void CustomRenderer::Render(IDirect3DDevice9* device)
         marker_file_dirty = true;
         markers_changed = false;
         Invalidate();
-        return;
+        // Don't return: the draw below re-uploads the buffer this frame. Skipping it blinks the
+        // lines for one frame when a quest path is cleared and re-added.
     }
 
     DrawCustomMarkers(device);
@@ -1042,6 +1044,18 @@ void CustomRenderer::DrawCustomLines(const IDirect3DDevice9*)
         if (!line->visible || !line->draw_on_minimap) continue;
         if (line->map != GW::Constants::MapID::None && line->map != GW::Map::GetMapID()) continue;
         if (doa_outpost && !line->draw_everywhere) continue;
+
+        if (line->world_coords) {
+            // Cross-map route tail stored in world-map coords; project into current-map game space
+            // so it renders on the compass (heads off toward the next map). WorldMapToGamePos is
+            // exact for the current map and continent-linear beyond it.
+            GW::GamePos g1, g2;
+            if (!WorldMapWidget::WorldMapToGamePos({line->p1.x, line->p1.y}, g1) || !WorldMapWidget::WorldMapToGamePos({line->p2.x, line->p2.y}, g2)) continue;
+            vertices.push_back({g1.x, g1.y, 0.f, line->color});
+            vertices.push_back({g2.x, g2.y, 0.f, line->color});
+            dirty = true;
+            continue;
+        }
 
         if (line->from_player_pos && my_pos) {
             vertices.push_back({my_pos->x, my_pos->y, 0.f, line->color});

--- a/GWToolboxdll/Widgets/Minimap/CustomRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/CustomRenderer.h
@@ -136,8 +136,8 @@ public:
         bool created_by_toolbox = false;
         bool from_player_pos = false;
         bool dotted = true; // toolbox terrain lines dash by default; set false for a solid line
-        // p1/p2 hold world-map coords, not game coords; only the world map renders these
-        // (cross-map route tails, whose game positions belong to other maps).
+        // p1/p2 hold world-map coords, not game coords; the world map, mission map, and compass
+        // render these (cross-map route tails, whose game positions belong to other maps).
         bool world_coords = false;
         char name[128]{};
     };

--- a/GWToolboxdll/Widgets/Minimap/PmapRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/PmapRenderer.cpp
@@ -108,7 +108,7 @@ void PmapRenderer::Render(IDirect3DDevice9* device, const MinimapRenderContext& 
 
     if (ctx.shadow_color & IM_COL32_A_MASK) {
         D3DMATRIX oldview;
-        SetDeviceTranslation(device, 0, -100.f, 0.f, &oldview);
+        SetDeviceTranslation(device, 0, ctx.shadow_translation, 0.f, &oldview);
 
         SetDeviceColor(device, ctx.shadow_color);
         D3DVertexBuffer::Render(device);

--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -319,6 +319,11 @@ namespace {
         ctx.draw_background = false;
         ctx.draw_cardinals = false; // mission map is always north-aligned
         ctx.draw_pmap = settings.draw_pmap;
+        // The pmap shadow offset is applied in the view's output space, which for the mission map's
+        // game->px view is raw pixels; express a small game-unit offset in px so it stays subtle and
+        // scales with the mission-map zoom (the compass keeps the default, applied in its own space).
+        constexpr float shadow_gwinches = 180.f;
+        ctx.shadow_translation = shadow_gwinches / cached_px_to_game;
         ctx.draw_symbols = settings.draw_symbols;
         ctx.draw_ranges = settings.draw_ranges;
         ctx.draw_agents = settings.draw_agents;
@@ -340,6 +345,7 @@ namespace {
         const float LINE_HALF_THICKNESS = 1.f * cached_px_to_game;
         for (const auto& line : lines) {
             if (!line->visible) continue;
+            if (line->world_coords) continue; // world coords, not game coords; drawn by DrawWorldCoordRouteLines
             if (!line->draw_on_mission_map && !(settings.draw_all_minimap_lines && line->draw_on_minimap) && !(settings.draw_all_terrain_lines && line->draw_on_terrain)) continue;
             if (line->map != map_id) continue;
             if (line->from_player_pos && player_pos) {
@@ -349,7 +355,30 @@ namespace {
                 minimap_lines.push_back(D3DLine(line->p1, line->p2, LINE_HALF_THICKNESS, static_cast<DWORD>(line->color)));
             }
         }
-        
+
+    }
+
+    // Cross-map route tails are stored in world-map coords (the only form that can place other
+    // maps' positions). Draw them in an ImGui overlay via the world->mission-map transform,
+    // clipped to the widget. These cover the whole route (incl. the current map's exit stretch
+    // past the nearest portal, which the game-coord lines don't reach); the overlap with the
+    // game-coord current-map lines is the same path, so it's harmless - matches the world map.
+    void DrawWorldCoordRouteLines()
+    {
+        const auto& lines = Minimap::Instance().custom_renderer.GetLines();
+        if (lines.empty()) return;
+
+        auto* draw_list = ImGui::GetBackgroundDrawList();
+        draw_list->PushClipRect({mission_map_top_left.x, mission_map_top_left.y}, {mission_map_bottom_right.x, mission_map_bottom_right.y}, true);
+        const float thickness = 1.5f * mission_map_scale.x;
+        for (const auto& line : lines) {
+            if (!(line->visible && line->world_coords && line->draw_on_mission_map)) continue;
+            GW::Vec2f s1, s2;
+            WorldMapCoordsToMissionMapScreenPos({line->p1.x, line->p1.y}, s1);
+            WorldMapCoordsToMissionMapScreenPos({line->p2.x, line->p2.y}, s2);
+            draw_list->AddLine({s1.x, s1.y}, {s2.x, s2.y}, line->color, thickness);
+        }
+        draw_list->PopClipRect();
     }
 } // namespace
 
@@ -376,6 +405,8 @@ void MissionMapWidget::Draw(IDirect3DDevice9* dx_device)
     if (!visible || !mission_map_ready) return;
 
     SubmitVertexBuffers(dx_device);
+
+    DrawWorldCoordRouteLines();
 
     // POC: mission map icons, desaturated. Res shrine icon (maybe others) are wrong colour by default so we desaturate, but this impacts other icons!
     #if 0


### PR DESCRIPTION
Mission map & compass now render the cross-map route's world_coords segments (projected per-surface), not just the
world map.
Fixed the mission-map pmap drop-shadow: was a fixed 100px offset, now an offset that scales with zoom.
Fixed a one-frame compass blink on quest-path updates (CustomRenderer::Render no longer skips a frame after
invalidating).