### PR TITLE
docs(site): document Party Statistics window

### DIFF
--- a/site/src/content/docs/commands.md
+++ b/site/src/content/docs/commands.md
@@ -90,7 +90,7 @@ GWToolbox++ adds a wide variety of chat commands that you trigger by typing them
 - `/loadbuild`: Load a [Builds](/docs/builds/) entry by name onto yourself. See [Builds → Chat commands](/docs/builds/#chat-commands).
 - `/pingbuild <template_name> [template_name...]`: Ping one or more saved skill templates to team chat as clickable build links.
 - `/herobuild` or `/heroteam <name>`: Load a saved [Hero Build](/docs/herobuilds/) onto the active hero team.
-- `/skillstats [reset|<player_number>]`: From the [Party Statistics](/docs/party_window/) module, print skill-usage statistics for yourself, for a specific party member (by number), or `reset` to clear collected stats.
+- `/skillstats [reset|<player_number>]`: From the [Party Statistics](/docs/party_statistics/) module, print skill-usage statistics for yourself, for a specific party member (by number), or `reset` to clear collected stats.
 - `/bonds (add|remove) <party_index|all> (<skill_id>|all)`: Add or remove maintained-bond highlights on the [Bonds Monitor](/docs/widgets/#bonds) widget.
 - `/dmg` or `/damage`: Control the [Damage Monitor](/docs/damage_monitor/#chat-commands). See that page for the full sub-command list.
 

--- a/site/src/content/docs/party_statistics.mdx
+++ b/site/src/content/docs/party_statistics.mdx
@@ -1,0 +1,30 @@
+---
+title: "Party Statistics"
+description: "Per-party-member skill-usage tracking, its display options, and how to print the collected counts to team chat via Ctrl+LeftClick or the /skillstats command."
+section: widgets
+---
+
+import ToolboxPath from '../../components/ToolboxPath.astro';
+
+The Party Statistics window records how many times each party member has cast each of their skills, and displays the counts as a grid of skill icons per member. It only collects data in explorable areas — in an outpost the window shows *Statistics will update in explorable area*, and the counts reset when you leave.
+
+This is separate from the [Damage Monitor](/docs/damage_monitor/), which tracks damage dealt rather than skill usage.
+
+## Display options
+
+Settings for this window live under <ToolboxPath steps={["Settings", "Party Statistics"]} />.
+
+- **Show the absolute skill count** — Shows the raw number of times each skill was cast under its icon.
+- **Show the percentage skill count** — Shows each skill's share of that member's total casts, as a percentage.
+- **Print skill statistics by Ctrl+LeftClick** — Enables printing a member's stats to chat: hold **Ctrl** and left-click a member's section in the window to send their per-skill counts to **team chat** (one line per skill, e.g. *PlayerName used Barrage 12 times.*).
+
+Printing is **text only** — nothing is saved to disk as a screenshot or file. The lines go into the in-game chat log like any other team-chat message.
+
+## Chat command
+
+The same output is available through the `/skillstats` command (see [Commands](/docs/commands/)):
+
+- `/skillstats` — Print your own skill statistics.
+- `/skillstats <player_number>` — Print statistics for the party member at that slot (1-based).
+- `/skillstats <player_number> <skill_number>` — Print a single skill (1–8) for that member.
+- `/skillstats reset` — Clear all collected statistics.

--- a/site/src/lib/nav.ts
+++ b/site/src/lib/nav.ts
@@ -51,6 +51,7 @@ export const navGroups: NavGroup[] = [
       { slug: 'minimap', label: 'Minimap' },
       { slug: 'misc_widgets', label: 'Miscellaneous' },
       { slug: 'party_window', label: 'Party' },
+      { slug: 'party_statistics', label: 'Party Statistics' },
       { slug: 'target_widgets', label: 'Target' },
       { slug: 'enemy_window', label: 'Enemy' },
       { slug: 'items', label: 'Items' },


### PR DESCRIPTION
Prompted by a Discord question about whether the Party Statistics module's "Print skill statistics by Ctrl+LeftClick" saves a picture anywhere. It doesn't — the output is text sent to team chat — and the module wasn't documented at all, so this adds a page.

## Changes
- **New page** `site/src/content/docs/party_statistics.mdx` (`section: widgets`) covering:
  - what the window tracks (per-member skill-usage counts, explorable-only, resets on leaving),
  - the three display/print options,
  - that Ctrl+LeftClick prints per-skill counts to **team chat** as text — nothing is saved to disk,
  - the `/skillstats` command variants (self / player / player+skill / reset).
- **`nav.ts`** — registered the page under Widgets, after Party.
- **`commands.md`** — fixed the `/skillstats` link, which pointed at the unrelated Party Window Enhancements page (`/docs/party_window/`), to point at the new page.

Verified `npm --prefix site run build` succeeds and the page appears in `dist/llms.txt` (nav-ordered) and `dist/llms-full.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)