### PR TITLE
chore: move agent guidelines to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Agent guidelines
+
+Instructions for any AI agent in this repo. (`CLAUDE.md` just imports this.)
+
+- **Comments:** explain *why*, not *what*; one concise line, no prose blocks. Exempt: `// ===` banners, license/file headers.
+- **Variables:** prefer `auto` when the initializer makes the type clear (`const auto x = TIMER_INIT();`).
+- **Docs (`site/`):** pages go in `src/content/docs/`; `llms.txt`/`llms-full.txt` auto-generate from them. A new page needs `description:` frontmatter plus a `src/lib/nav.ts` entry to appear in `llms.txt`. After changes run `npm --prefix site run build` and check `site/dist/llms.txt`.
+- **Explaining a feature:** first check if it's documented (`src/content/docs/` or <https://www.gwtoolbox.com/docs/>); if missing/wrong, flag it, offer a fix, and link the page.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,1 @@
-# Guidelines
-
-## Comments
-
-- Comment only when it adds something the code doesn't already say — explain *why*, not *what*. Skip comments that just restate the next line.
-- When a comment is needed, keep it to a single line and concise. Do not write multi-line comment blocks of prose.
-- The single-line rule does not apply to structural section banners (`// ===`/title/`// ===`) or to license/file headers.
-
-## Variables
-
-- When amending or adding code, prefer `auto` over an explicit type wherever the type is still clear from the initializer (e.g. `const auto x = TIMER_INIT();`).
-
-## Site docs
-
-- The docs site (`site/`) serves `llms.txt` and `llms-full.txt` for LLM ingestion, generated from the docs collection via `site/src/pages/llms*.txt.ts` and `site/src/lib/llms.ts`. When you add, remove, or amend a page under `site/src/content/docs/`, check these: they pick pages up automatically (no manual list to edit), but a new page only appears in `llms.txt`'s nav-ordered index if it's registered in `site/src/lib/nav.ts`, and its one-line entry there comes from the page's `description:` frontmatter — so give every page a `description`. Run `npm --prefix site run build` and confirm the change is reflected in `site/dist/llms.txt` / `llms-full.txt`.
+Agent instructions for this repo live in @AGENTS.md.


### PR DESCRIPTION
Makes the repo's agent instructions readable by non-Claude agent tools and trims the context they cost.

## Changes
- **Renamed** the guidelines from `CLAUDE.md` to `AGENTS.md` so other agent models (Cursor, Codex, etc.) pick them up via the common `AGENTS.md` convention.
- **`CLAUDE.md`** is now a one-line pointer (`@AGENTS.md` import) so Claude Code keeps loading the same content — no duplication.
- **Optimised** the existing Comments / Variables / Site docs sections to be terser, reducing the tokens loaded into every agent session.
- **Added an "Answering feature questions" section**: when explaining how a Toolbox feature works, check whether it's documented (in `site/src/content/docs/` or live at https://www.gwtoolbox.com/docs/), flag/offer to fix gaps, and link the relevant gwtoolbox.com page.

No code or build impact.