### PR TITLE
docs: document /target item filter

### DIFF
--- a/site/src/content/docs/commands.md
+++ b/site/src/content/docs/commands.md
@@ -52,9 +52,10 @@ GWToolbox++ adds a wide variety of chat commands that you trigger by typing them
 
 - `/target` / `/tgt`: Targeting utilities.
   - `/target closest` (or `nearest`): Target the closest agent.
-  - `/target closest <filter> [name|model_id]`: Restrict the closest-target search to a type — `npc`, `player`, `gadget`, `ally`, `enemy`, etc.
-  - `/target <name|model_id> [index]`: Target the nearest NPC matching the name or model ID; `[index]` picks the N-th match.
+  - `/target closest <filter> [name|model_id]`: Restrict the closest-target search to a type — `npc`, `item`, `gadget`, `player`, `ally`, `enemy`.
+  - `/target <name|model_id> [index]`: Target the nearest NPC matching the name or model ID; `[index]` picks the N-th match. Names match on any substring, and `|` separates alternatives (e.g. `/target dhuum|dwayna`).
   - `/target player <name|player_number>`: Target the nearest player by name or player number.
+  - `/target item <name|model_id>`: Target the nearest dropped item by name or model ID.
   - `/target gadget <name|gadget_id>`: Target the nearest interactive gadget.
   - `/target priority [party_member]`: Target the priority target of the given party member (defaults to yourself).
   - `/target ee`: Target the furthest ally within spell range in front of you (for Ebon Escape).


### PR DESCRIPTION
The `/target` command supports an `item` filter (`GW::TargetFilter::Items`) that targets dropped items by name or model ID, but the docs didn't mention it — this came up when a user tried `/target Red Iris Flower` (which defaults to living-NPC filtering) and it didn't work.

Changes to `commands.md`:
- Add `/target item <name|model_id>` as a documented subcommand.
- Complete the closest-filter list with `item` (was missing) and list all filters explicitly.
- Note that names match on any substring and that `|` separates alternatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)