### PR TITLE
Minimap: draw Symbiosis spirit range circle

### DIFF
--- a/Dependencies/GWCA/include/GWCA/Constants/AgentIDs.h
+++ b/Dependencies/GWCA/include/GWCA/Constants/AgentIDs.h
@@ -279,6 +279,7 @@ namespace GW {
 
             constexpr int Winnowing = 2926;
             constexpr int EoE = 2927;
+            constexpr int Symbiosis = 2930;
             constexpr int FrozenSoil = 2933;
             constexpr int QZ = 2937;
 

--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.cpp
@@ -194,6 +194,7 @@ void AgentRenderer::RegisterSettings(ToolboxModule* module)
         {"color_qz", &color_qz},
         {"color_winnowing", &color_winnowing},
         {"color_frozen_soil", &color_frozen_soil},
+        {"color_symbiosis", &color_symbiosis},
         {"color_target", &color_target},
         {"color_player", &color_player},
         {"color_player_dead", &color_player_dead},
@@ -350,6 +351,7 @@ void AgentRenderer::LoadDefaultColors()
     color_qz = 0x320000FF;
     color_winnowing = 0x3200FFFF;
     color_frozen_soil = 0x00FEFFFF;
+    color_symbiosis = 0x32FF00FF;
     color_target = 0xFFFFFF00;
     color_player = 0xFFFF8000;
     color_player_dead = 0x64FF8000;
@@ -398,6 +400,7 @@ void AgentRenderer::DrawSettings()
             {"QZ", &color_qz, nullptr, nullptr, "This is the color at the edge, the color in the middle is the same, with alpha-50"},
             {"Winnowing", &color_winnowing, nullptr, nullptr, "This is the color at the edge, the color in the middle is the same, with alpha-50"},
             {"Frozen Soil", &color_frozen_soil, nullptr, nullptr, "This is the color at the edge, the color in the middle is the same, with alpha-50"},
+            {"Symbiosis", &color_symbiosis, nullptr, nullptr, "This is the color at the edge, the color in the middle is the same, with alpha-50"},
             {"Target", &color_target, nullptr, nullptr, nullptr},
             {"Player (alive)", &color_player, nullptr, nullptr, nullptr},
             {"Player (dead)", &color_player_dead, nullptr, nullptr, nullptr},
@@ -819,6 +822,9 @@ void AgentRenderer::Render(IDirect3DDevice9* device)
                     break;
                 case GW::Constants::ModelID::FrozenSoil:
                     Enqueue(BigCircle, agent, GW::Constants::Range::SpiritExtended, color_frozen_soil);
+                    break;
+                case GW::Constants::ModelID::Symbiosis:
+                    Enqueue(BigCircle, agent, GW::Constants::Range::SpiritExtended, color_symbiosis);
                     break;
                 default:
                     break;

--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.cpp
@@ -351,7 +351,7 @@ void AgentRenderer::LoadDefaultColors()
     color_qz = 0x320000FF;
     color_winnowing = 0x3200FFFF;
     color_frozen_soil = 0x00FEFFFF;
-    color_symbiosis = 0x32FF00FF;
+    color_symbiosis = 0x00FF00FF;
     color_target = 0xFFFFFF00;
     color_player = 0xFFFF8000;
     color_player_dead = 0x64FF8000;

--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
@@ -174,6 +174,7 @@ private:
     Color color_qz = 0x320000FF;
     Color color_winnowing = 0x3200FFFF;
     Color color_frozen_soil = 0x00FEFFFF;
+    Color color_symbiosis = 0x32FF00FF;
     Color color_target = 0xFFFFFF00;
     Color color_player = 0xFFFF8000;
     Color color_player_dead = 0x64FF8000;

--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
@@ -174,7 +174,7 @@ private:
     Color color_qz = 0x320000FF;
     Color color_winnowing = 0x3200FFFF;
     Color color_frozen_soil = 0x00FEFFFF;
-    Color color_symbiosis = 0x32FF00FF;
+    Color color_symbiosis = 0x00FF00FF;
     Color color_target = 0xFFFFFF00;
     Color color_player = 0xFFFF8000;
     Color color_player_dead = 0x64FF8000;

--- a/site/src/content/docs/minimap.mdx
+++ b/site/src/content/docs/minimap.mdx
@@ -30,7 +30,7 @@ The Minimap widget is an advanced version of the Guild Wars compass. It shows th
 
 ### Agents
 
-- **Edge of Extinction**, **Quickening Zephyr**, **Winnowing**, and **Frozen Soil** areas of effect are visible on the minimap.
+- **Edge of Extinction**, **Quickening Zephyr**, **Winnowing**, **Frozen Soil**, and **Symbiosis** areas of effect are visible on the minimap.
 - Agents that can move or turn have a teardrop shape with the point indicating facing. Static agents (passive spirits, etc.) are circles. Signposts and items on the ground are squares.
 - Bosses can be drawn at a different size, and (optionally) tinted by primary profession.
 - You can override the colour, text colour, size and shape of any specific agent by model id — optionally restricted to a particular map and/or combat / weapon state.
@@ -66,7 +66,7 @@ Settings sit under <ToolboxPath steps={["Settings", "Minimap", "Agents"]} /> wit
 
 #### Agent Colors
 
-- AoE auras: **EoE**, **QZ**, **Winnowing**, **Frozen Soil** — the picker is the rim colour; the centre is the same hue with alpha-50, gradient in between.
+- AoE auras: **EoE**, **QZ**, **Winnowing**, **Frozen Soil**, **Symbiosis** — the picker is the rim colour; the centre is the same hue with alpha-50, gradient in between.
 - **Target** — border surrounding the currently targeted agent.
 - **Player (alive)** / **Player (dead)** — you.
 - **Signpost** / **Item** — interactive props / ground items.


### PR DESCRIPTION
Requested on Discord (#gwtoolbox): add Symbiosis to the list of spirits that get a range circle on the minimap.

- Adds `ModelID::Symbiosis = 2930` to GWCA's AgentIDs (verified against the values already in the file: Winnowing 2926, EoE 2927, Frozen Soil 2933, QZ 2937 — Symbiosis sits in the same nature-ritual model block, cross-checked against Py4GW's spirit model list which agrees on all four existing IDs).
- AgentRenderer draws a `SpiritExtended` big circle for it, with a new `color_symbiosis` setting exposed in Minimap → Agents → Agent Colors and persisted as `color_symbiosis`. Default is `0x00FF00FF` (alpha 0 — hidden until the user sets a color), same pattern as Frozen Soil.
- Docs: minimap page updated to mention Symbiosis in both spirit-circle lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)