### PR TITLE
fix(window-title): stop mojibake when setting GW window title to char name

### DIFF
--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -86,7 +86,11 @@ namespace {
         }
         const std::wstring title = GetPlayerName();
         if (!title.empty()) {
-            SetWindowTextW(hwnd, title.c_str());
+            // Guild Wars' window may be registered as an ANSI (non-Unicode) window class; in that
+            // case SetWindowTextW() gets thunked down to the system codepage before being applied,
+            // corrupting any character outside it. Sending WM_SETTEXT via DefWindowProcW directly
+            // bypasses that thunking, same trick already used for our own windows in imgui_impl_win32.cpp.
+            DefWindowProcW(hwnd, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(title.c_str()));
         }
     }
 

--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -1004,9 +1004,18 @@ namespace ToolboxUtils {
         if (!player_number) {
             player = GW::PlayerMgr::GetPlayerByID(GW::PlayerMgr::GetPlayerNumber());
             if (!player || !player->name) {
-                // Map not loaded; try to get from character context
+                // Map not loaded; try to get from character context.
+                // player_name is a fixed-size buffer that may not be populated/null-terminated
+                // yet (e.g. still on the login/char select screen); reading it unbounded via
+                // wcslen can run off into unrelated memory and produce garbled (often CJK-looking)
+                // output. Bail out to an empty string instead so callers retry later.
                 const auto c = GW::GetCharContext();
-                return c ? c->player_name : L"";
+                if (!c) {
+                    return L"";
+                }
+                constexpr size_t max_len = sizeof(c->player_name) / sizeof(c->player_name[0]);
+                const size_t len = wcsnlen(c->player_name, max_len);
+                return len < max_len ? std::wstring(c->player_name, len) : L"";
             }
         }
         else {


### PR DESCRIPTION
## Summary
- The game window's title (when "Set Guild Wars window title as current logged-in character" is enabled) sometimes rendered as garbled/CJK-looking mojibake instead of the player name.
- `GetPlayerName()`'s fallback path read `CharContext::player_name` (a fixed `wchar_t[20]` buffer) via an unbounded `wcslen()`-based conversion. If that buffer isn't yet null-terminated (e.g. still on the login/char-select screen — there's an existing dev comment noting this exact "garbage on first load" issue), the read runs off into unrelated memory, producing effectively random UTF-16 code units — a large fraction of which render as CJK/Hangul/Kana glyphs.
- Separately, `SetWindowTitle()` called `SetWindowTextW` directly on GW's own `HWND`. If that window is registered as an ANSI (non-Unicode) window class, Windows silently thunks the wide string through the system codepage before applying it, corrupting non-ASCII characters. This codebase already works around the identical pitfall for its own ImGui windows in `imgui_impl_win32.cpp` (send `WM_SETTEXT` via `DefWindowProcW` directly); applied the same fix here.

## Changes
- `GWToolboxdll/Utils/ToolboxUtils.cpp`: bound the `CharContext::player_name` read with `wcsnlen`, returning empty (not garbage) when the buffer isn't properly null-terminated within its size.
- `GWToolboxdll/Modules/GameSettings.cpp`: set the window title via `DefWindowProcW(hwnd, WM_SETTEXT, ...)` instead of `SetWindowTextW`.

## Test plan
- [ ] Build and confirm the window title still updates correctly to the character name on login/map load
- [ ] Toggle "Set Guild Wars window title as current logged-in character" off/on and confirm it still works
- [ ] Watch for the previously-reported garbled title, especially right after logging in / on the first map load

🤖 Generated with [Claude Code](https://claude.com/claude-code)