### PR TITLE
Fix repeated Defender exclusion prompt on already-excluded folders

### DIFF
--- a/GWToolbox/WindowsDefender.cpp
+++ b/GWToolbox/WindowsDefender.cpp
@@ -91,11 +91,20 @@ namespace {
         return s;
     }
 
+    // Strips a trailing separator so folder exclusions with/without one still compare equal.
+    void TrimTrailingSeparators(std::wstring& s)
+    {
+        while (!s.empty() && (s.back() == L'\\' || s.back() == L'/'))
+            s.pop_back();
+    }
+
     std::wstring LowerCanonical(const fs::path& path)
     {
         std::error_code ec;
         const fs::path canonical = fs::canonical(path, ec);
-        return ToLower((ec ? path : canonical).wstring());
+        std::wstring result = ToLower((ec ? path : canonical).wstring());
+        TrimTrailingSeparators(result);
+        return result;
     }
 
     // True if `target` is one of `list`, or (when prefix is set) sits inside a listed folder.
@@ -139,7 +148,12 @@ namespace {
                 continue;
 
             switch (section) {
-                case Exclusions: out.exclusion_paths.push_back(ToLower(line)); break;
+                case Exclusions: {
+                    std::wstring path = ToLower(line);
+                    TrimTrailingSeparators(path);
+                    out.exclusion_paths.push_back(std::move(path));
+                    break;
+                }
                 case ControlledFolderAccess: out.controlled_folder_access = _wtoi(line.c_str()); break;
                 case Apps: out.cfa_apps.push_back(ToLower(line)); break;
                 default: break;
@@ -304,7 +318,7 @@ bool AddDefenderExceptions(const std::filesystem::path& exclusion_path,
     }
 
     // The folder exclusion we can verify directly; Controlled Folder Access entries we trust to the exit code.
-    const bool verified = !is_admin || IsPathExcludedFromDefender(exclusion_path);
+    const bool verified = IsPathExcludedFromDefender(exclusion_path);
 
     if (!quiet) {
         if (verified) {


### PR DESCRIPTION
## Summary
- `ListCoversPath` compared our canonicalized (no trailing separator) folder path against raw exclusion paths reported by `Get-MpPreference`, which commonly carry a trailing `\` (e.g. when added via the Windows Security GUI). Since the entry was then longer than the target, neither the exact-match nor prefix-match branch could succeed, so an already-excluded folder was permanently reported as missing — causing the exclusion prompt to reappear on every launch no matter how many times it was added.
- `AddDefenderExceptions` also skipped verification entirely for non-admin runs (`!is_admin || ...`), even though `Get-MpPreference` doesn't require admin to read, so a real failure to add the exclusion would silently be reported as success.

Fixes the behavior reported in #gwtoolbox-support: "Keep getting 'add exclusion prompt' which I already did."

## Changes
- Added `TrimTrailingSeparators` and applied it both when parsing exclusion paths from `Get-MpPreference` output and in `LowerCanonical`, so trailing-separator differences no longer break the comparison.
- Removed the `!is_admin ||` shortcut so the added exclusion is actually verified on non-admin runs too.

## Test plan
- [ ] Manually verify: add a folder exclusion via the Windows Security UI (which appends a trailing `\`), relaunch GWToolbox, confirm it no longer prompts to add it again.
- [ ] Manually verify: on a clean machine, decline the prompt, then accept it; confirm the success/verification message now reflects the actual post-add state.