### PR TITLE
perf(terrain): compute draped altitude natively instead of per-frame QueryAltitude

### DIFF
--- a/GWToolboxdll/Modules/TestHarness.cpp
+++ b/GWToolboxdll/Modules/TestHarness.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <cmath>
 #include <filesystem>
+#include <set>
 #include <sstream>
 #include <string>
 #include <system_error>
@@ -14,6 +15,7 @@
 #include <GWCA/GameEntities/Skill.h>
 #include <GWCA/GameEntities/Quest.h>
 #include <GWCA/Context/CharContext.h>
+#include <GWCA/Context/MapContext.h>
 #include <GWCA/Context/PreGameContext.h>
 #include <GWCA/Constants/Constants.h>
 #include <GWCA/Managers/AgentMgr.h>
@@ -607,6 +609,54 @@ namespace {
             char b[160];
             snprintf(b, sizeof(b), "nativez: samples=%u both=%u max_delta=%.2f avg_delta=%.3f", samples, both, max_delta,
                      both ? sum_delta / both : 0.0);
+            Log::Log("[harness] %s", b);
+            Log::FlushFile();
+            write_status(b);
+            return;
+        }
+        if (verb == "propprobe") { // propprobe [radius]: enumerate map props, their world z, and which ones back a walkable pathing plane
+            float radius = 2500.f;
+            is >> radius;
+            radius = std::clamp(radius, 200.f, 20000.f);
+            const auto self = GW::Agents::GetControlledCharacter();
+            const auto* mc = GW::GetMapContext();
+            if (!self || !mc || !mc->props) { write_status("propprobe: no character or props"); return; }
+            const auto& props = mc->props->propArray;
+            const auto* pm = GW::Map::GetPathingMap();
+            const auto n_planes = pm ? static_cast<uint32_t>(pm->size()) : 0u;
+
+            // Which prop indices back a walkable pathing plane? PathingMap+0x00 (GWCA 'zplane') is the prop index
+            // for non-ground planes (ground plane = UINT_MAX).
+            std::set<uint32_t> walkable_props;
+            for (uint32_t zp = 0; pm && zp < n_planes; ++zp) {
+                const uint32_t pidx = (*pm)[zp].zplane;
+                if (pidx != 0xFFFFFFFFu) walkable_props.insert(pidx);
+            }
+
+            Log::Log("[propprobe] map=%d props=%u planes=%u walkable_prop_planes=%u player=(%.0f,%.0f,z%u,%.0f)",
+                     static_cast<int>(GW::Map::GetMapID()), static_cast<unsigned>(props.size()), n_planes,
+                     static_cast<unsigned>(walkable_props.size()), self->pos.x, self->pos.y, self->pos.zplane, self->z);
+
+            uint32_t near_count = 0, elevated = 0, elevated_nonwalkable = 0, logged = 0;
+            for (uint32_t i = 0; i < props.size(); ++i) {
+                const GW::MapProp* p = props[i];
+                if (!p) continue;
+                const float dx = p->position.x - self->pos.x, dy = p->position.y - self->pos.y;
+                if (dx * dx + dy * dy > radius * radius) continue;
+                ++near_count;
+                const float terrain = TerrainDrape::NativeTerrainZ(p->position.x, p->position.y);
+                const float above = terrain != 0.f ? (terrain - p->position.z) : 0.f; // >0 means prop origin sits above ground (up=-z)
+                const bool walkable = walkable_props.count(i) != 0;
+                if (above > 50.f) { ++elevated; if (!walkable) ++elevated_nonwalkable; }
+                if (logged++ < 25)
+                    Log::Log("[propprobe]   prop[%u] file=0x%X pos=(%.0f,%.0f,z=%.0f) terrain_z=%.0f above=%.0f walkable=%d model=%p",
+                             i, p->model_file_id, p->position.x, p->position.y, p->position.z, terrain, above,
+                             static_cast<int>(walkable), static_cast<const void*>(p->interactive_model));
+            }
+            char b[224];
+            snprintf(b, sizeof(b), "propprobe: props=%u near=%u elevated=%u elevated_nonwalkable=%u walkable_planes=%u",
+                     static_cast<unsigned>(props.size()), near_count, elevated, elevated_nonwalkable,
+                     static_cast<unsigned>(walkable_props.size()));
             Log::Log("[harness] %s", b);
             Log::FlushFile();
             write_status(b);

--- a/GWToolboxdll/Modules/TestHarness.cpp
+++ b/GWToolboxdll/Modules/TestHarness.cpp
@@ -612,6 +612,78 @@ namespace {
             write_status(b);
             return;
         }
+        if (verb == "drapeverify") { // drapeverify [n radius]: does new SurfaceZ match the old all-planes-highest-point query?
+            uint32_t n = 1500;
+            float radius = 1500.f;
+            is >> n >> radius;
+            n = std::clamp(n, 100u, 100000u);
+            radius = std::clamp(radius, 100.f, 5000.f);
+            const auto self = GW::Agents::GetControlledCharacter();
+            const auto* pm = GW::Map::GetPathingMap();
+            if (!self || !pm || !pm->size()) {
+                write_status("drapeverify: no character or pathing map");
+                return;
+            }
+            const auto n_planes = static_cast<uint32_t>(pm->size());
+            uint32_t seed = 0x1234567u;
+            const auto next01 = [&seed] {
+                seed = seed * 1664525u + 1013904223u;
+                return (seed >> 8) * (1.f / 16777216.f);
+            };
+            Log::Log("[drapeverify] map=%d n=%u planes=%u radius=%.0f", static_cast<int>(GW::Map::GetMapID()), n, n_planes, radius);
+            uint32_t both = 0;             // points with data on both old and new
+            uint32_t prune_mismatch = 0;   // points where pruned selection != all-planes selection (the real test)
+            uint32_t nonzero_hits = 0;     // points whose highest surface came from a non-zero plane
+            uint32_t logged = 0;
+            float max_prune = 0.f, max_total = 0.f;
+            double sum_total = 0.0;
+            for (uint32_t i = 0; i < n; ++i) {
+                const float ang = next01() * 6.2831853f, r = radius * std::sqrt(next01());
+                const float x = self->pos.x + std::cos(ang) * r, y = self->pos.y + std::sin(ang) * r;
+                float old_all = 0.f, new_z = 0.f, prune = 0.f;
+                TerrainDrape::DrapeCompare(x, y, n_planes, &old_all, &new_z, &prune);
+
+                // Pruning correctness: prune uses the SAME game values as old_all, differing only in which
+                // planes are considered. Any gap here is a plane the trapezoid pruning wrongly dropped/added.
+                const float dp = std::fabs(old_all - prune);
+                if (dp > max_prune) max_prune = dp;
+                if (dp > 0.5f) {
+                    ++prune_mismatch;
+                    if (logged++ < 15)
+                        Log::Log("[drapeverify]   PRUNE MISMATCH (%.0f,%.0f) old_all=%.1f prune=%.1f new=%.1f d=%.1f",
+                                 x, y, old_all, prune, new_z, dp);
+                }
+                // Did the highest surface come from a non-zero plane here? (i.e. was a bridge/prop plane picked)
+                if (old_all != 0.f) {
+                    GW::GamePos g0{x, y, 0};
+                    if (std::fabs(GW::Map::QueryAltitude(&g0) - old_all) > 0.5f) ++nonzero_hits;
+                }
+                // Total new-vs-old (includes native point vs game radius-5 on plane 0).
+                if (old_all != 0.f && new_z != 0.f) {
+                    ++both;
+                    const float dt = std::fabs(old_all - new_z);
+                    sum_total += dt;
+                    if (dt > max_total) max_total = dt;
+                    if (dt > 25.f && logged < 25) {
+                        ++logged;
+                        // Sample the game terrain in a tiny cross to reveal a cliff (why radius-5 disk-max != point).
+                        GW::GamePos c(x, y, 0), e(x + 8.f, y, 0), w(x - 8.f, y, 0), nq(x, y + 8.f, 0), s(x, y - 8.f, 0);
+                        Log::Log("[drapeverify]   BIG DELTA (%.0f,%.0f) old=%.1f new=%.1f d=%.1f | game@center=%.1f nbrs(+-8gw)=[%.0f %.0f %.0f %.0f]",
+                                 x, y, old_all, new_z, dt, GW::Map::QueryAltitude(&c),
+                                 GW::Map::QueryAltitude(&e), GW::Map::QueryAltitude(&w),
+                                 GW::Map::QueryAltitude(&nq), GW::Map::QueryAltitude(&s));
+                    }
+                }
+            }
+            char b[240];
+            snprintf(b, sizeof(b),
+                     "drapeverify: n=%u both=%u nonzero_plane_hits=%u | PRUNE mismatches=%u max=%.2f | total new-vs-old avg=%.2f max=%.2f",
+                     n, both, nonzero_hits, prune_mismatch, max_prune, both ? sum_total / both : 0.0, max_total);
+            Log::Log("[harness] %s", b);
+            Log::FlushFile();
+            write_status(b);
+            return;
+        }
         if (verb == "drapebench") { // drapebench [n radius]: A/B the old all-planes QueryAltitude loop vs the new pruned SurfaceZ
             uint32_t n = 2000;
             float radius = 1200.f;

--- a/GWToolboxdll/Modules/TestHarness.cpp
+++ b/GWToolboxdll/Modules/TestHarness.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 
+#include <chrono>
 #include <cmath>
 #include <filesystem>
 #include <sstream>
@@ -71,6 +72,11 @@ namespace {
     // skill's visual effect id, and locally emulate a PlayEffect to confirm it renders at chosen coords.
     bool log_play_effects = false;
     GW::HookEntry PlayEffect_Entry;
+
+    bool fps_active = false;
+    int fps_frames = 0;
+    clock_t fps_start = 0;
+    long fps_duration_ms = 0;
 
     std::filesystem::path cmd_path() { return Resources::GetPath(L"harness_command.txt"); }
     std::filesystem::path status_path() { return Resources::GetPath(L"harness_status.txt"); }
@@ -570,6 +576,110 @@ namespace {
             write_status("dattex: queued");
             return;
         }
+        if (verb == "nativez") { // nativez [radius step]: compare native terrain z vs GW::Map::QueryAltitude(plane 0) on a grid
+            float radius = 1200.f, step = 96.f;
+            is >> radius >> step;
+            radius = std::clamp(radius, 100.f, 5000.f);
+            step = std::clamp(step, 24.f, 500.f);
+            const auto self = GW::Agents::GetControlledCharacter();
+            if (!self) { write_status("nativez: no character"); return; }
+            Log::Log("[nativez] map=%d player=(%.0f,%.0f,z%u) radius=%.0f step=%.0f",
+                     static_cast<int>(GW::Map::GetMapID()), self->pos.x, self->pos.y, self->pos.zplane, radius, step);
+            uint32_t samples = 0, both = 0, logged = 0;
+            float max_delta = 0.f;
+            double sum_delta = 0.0;
+            for (float dx = -radius; dx <= radius; dx += step) {
+                for (float dy = -radius; dy <= radius; dy += step) {
+                    const float x = self->pos.x + dx, y = self->pos.y + dy;
+                    const float native = TerrainDrape::NativeTerrainZ(x, y);
+                    GW::GamePos p(x, y, 0);
+                    const float game = GW::Map::QueryAltitude(&p);
+                    ++samples;
+                    if (native == 0.f || game == 0.f) continue; // OOB on either side
+                    ++both;
+                    const float d = std::fabs(native - game);
+                    max_delta = std::max(max_delta, d);
+                    sum_delta += d;
+                    if (d > 5.f && logged++ < 20)
+                        Log::Log("[nativez]   (%.0f,%.0f) native=%.1f game=%.1f delta=%.1f", x, y, native, game, d);
+                }
+            }
+            char b[160];
+            snprintf(b, sizeof(b), "nativez: samples=%u both=%u max_delta=%.2f avg_delta=%.3f", samples, both, max_delta,
+                     both ? sum_delta / both : 0.0);
+            Log::Log("[harness] %s", b);
+            Log::FlushFile();
+            write_status(b);
+            return;
+        }
+        if (verb == "drapebench") { // drapebench [n radius]: A/B the old all-planes QueryAltitude loop vs the new pruned SurfaceZ
+            uint32_t n = 2000;
+            float radius = 1200.f;
+            is >> n >> radius;
+            n = std::clamp(n, 100u, 200000u);
+            radius = std::clamp(radius, 100.f, 5000.f);
+            const auto self = GW::Agents::GetControlledCharacter();
+            const auto* pm = GW::Map::GetPathingMap();
+            if (!self || !pm || !pm->size()) {
+                write_status("drapebench: no character or pathing map");
+                return;
+            }
+            const auto n_planes = static_cast<uint32_t>(pm->size());
+            // Same pseudo-random disk of sample points for both methods.
+            std::vector<std::pair<float, float>> pts(n);
+            uint32_t seed = 0x9E3779B9u;
+            const auto next01 = [&seed] {
+                seed = seed * 1664525u + 1013904223u;
+                return (seed >> 8) * (1.f / 16777216.f);
+            };
+            for (uint32_t i = 0; i < n; ++i) {
+                const float ang = next01() * 6.2831853f, r = radius * std::sqrt(next01());
+                pts[i] = {self->pos.x + std::cos(ang) * r, self->pos.y + std::sin(ang) * r};
+            }
+
+            // OLD path: QueryAltitude on every plane, keep highest surface (min z). This is what SurfaceZ did before.
+            float sink_old = 0.f;
+            const auto t_old0 = std::chrono::steady_clock::now();
+            for (uint32_t i = 0; i < n; ++i) {
+                float best = 0.f;
+                for (uint32_t zp = 0; zp < n_planes; ++zp) {
+                    GW::GamePos p(pts[i].first, pts[i].second, zp);
+                    const float a = GW::Map::QueryAltitude(&p);
+                    if (a != 0.f && (best == 0.f || a < best)) best = a;
+                }
+                sink_old += best;
+            }
+            const auto us_old = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - t_old0).count();
+
+            // NEW path: native plane-0 read + trapezoid-pruned non-zero planes.
+            float sink_new = 0.f;
+            const auto t_new0 = std::chrono::steady_clock::now();
+            for (uint32_t i = 0; i < n; ++i)
+                sink_new += TerrainDrape::SurfaceZ(pts[i].first, pts[i].second, self->pos.zplane, n_planes);
+            const auto us_new = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - t_new0).count();
+
+            char b[220];
+            snprintf(b, sizeof(b),
+                     "drapebench: n=%u planes=%u | OLD %.2fms (%.2fus/q) | NEW %.2fms (%.2fus/q) | speedup %.1fx | sink d=%.0f",
+                     n, n_planes, us_old / 1000.0, static_cast<double>(us_old) / n, us_new / 1000.0,
+                     static_cast<double>(us_new) / n, us_new ? static_cast<double>(us_old) / us_new : 0.0,
+                     std::fabs(sink_old - sink_new));
+            Log::Log("[harness] %s", b);
+            Log::FlushFile();
+            write_status(b);
+            return;
+        }
+        if (verb == "fpsprobe") { // fpsprobe [seconds]: count frames over a window, report avg fps
+            float seconds = 3.f;
+            is >> seconds;
+            seconds = std::clamp(seconds, 0.5f, 30.f);
+            fps_duration_ms = static_cast<long>(seconds * 1000.f);
+            fps_frames = 0;
+            fps_start = TIMER_INIT();
+            fps_active = true;
+            write_status("fpsprobe: running");
+            return;
+        }
         write_status("unknown_command: " + verb);
     }
 } // namespace
@@ -604,6 +714,18 @@ void TestHarness::Update(float)
 {
 #ifdef HARNESS_ENABLED
     if (terminating) return;
+    if (fps_active) {
+        ++fps_frames;
+        const long elapsed = TIMER_DIFF(fps_start);
+        if (elapsed >= fps_duration_ms) {
+            fps_active = false;
+            char b[96];
+            snprintf(b, sizeof(b), "fpsprobe: frames=%d secs=%.2f avg_fps=%.1f", fps_frames, elapsed / 1000.f, fps_frames * 1000.f / elapsed);
+            Log::Log("[harness] %s", b);
+            Log::FlushFile();
+            write_status(b);
+        }
+    }
     if (last_poll && TIMER_DIFF(last_poll) < kPollMs) return;
     last_poll = TIMER_INIT();
 

--- a/GWToolboxdll/Utils/TerrainDrape.cpp
+++ b/GWToolboxdll/Utils/TerrainDrape.cpp
@@ -208,3 +208,37 @@ uint32_t TerrainDrape::PathingPlaneCount()
     const GW::PathingMapArray* pm = GW::Map::GetPathingMap();
     return pm ? static_cast<uint32_t>(pm->size()) : 0;
 }
+
+void TerrainDrape::DrapeCompare(const float x, const float y, const uint32_t n_planes,
+                                float* old_all, float* new_z, float* prune_gp0)
+{
+    // OLD behavior: QueryAltitude on every plane, keep the highest surface (min z); 0 = no data.
+    if (old_all) {
+        float best = 0.f;
+        for (uint32_t zp = 0; zp < n_planes; ++zp) {
+            GW::GamePos p{x, y, zp};
+            const float a = GW::Map::QueryAltitude(&p);
+            if (a != 0.f && (best == 0.f || a < best)) best = a;
+        }
+        *old_all = best;
+    }
+
+    if (new_z) *new_z = SurfaceZ(x, y, 0, n_planes);
+
+    // Pruning isolated: game's plane-0 value + only the trapezoid-containing non-zero planes.
+    if (prune_gp0) {
+        GW::GamePos p0{x, y, 0};
+        float best = GW::Map::QueryAltitude(&p0); // raw game plane-0, identical to old_all's zp==0 step
+        const GW::PathingMapArray* pm = GW::Map::GetPathingMap();
+        if (pm) {
+            const auto planes = std::min<uint32_t>(n_planes, static_cast<uint32_t>(pm->size()));
+            for (uint32_t zp = 1; zp < planes; ++zp) {
+                if (!PlaneContains((*pm)[zp], x, y)) continue;
+                GW::GamePos p{x, y, zp};
+                const float a = GW::Map::QueryAltitude(&p);
+                if (a != 0.f && (best == 0.f || a < best)) best = a;
+            }
+        }
+        *prune_gp0 = best;
+    }
+}

--- a/GWToolboxdll/Utils/TerrainDrape.cpp
+++ b/GWToolboxdll/Utils/TerrainDrape.cpp
@@ -1,13 +1,158 @@
 #include "stdafx.h"
 
+#include <cfloat>
+#include <cmath>
+#include <cstddef>
+
 #include <GWCA/GameContainers/GamePos.h>
 #include <GWCA/GameEntities/Pathing.h>
+#include <GWCA/Context/MapContext.h>
 #include <GWCA/Managers/MapMgr.h>
 
 #include <Utils/TerrainDrape.h>
 
+namespace {
+    // GW's terrain heightfield object (MapContext+0x84). Only the fields the altitude sampler touches
+    // are named; layout reverse-engineered from Terrain_QueryAltitude (Gw.exe FUN_0074eb10). See
+    // memory reference-gw-terrain-altitude-internals for the full derivation.
+    struct GwTerrain {
+        uint32_t type;           // +0x00
+        uint32_t dim_x;          // +0x04 tiles in x (multiple of 32)
+        uint32_t dim_y;          // +0x08 tiles in y
+        uint32_t chunks_x;       // +0x0C dim_x >> 5
+        uint32_t chunks_y;       // +0x10 dim_y >> 5
+        uint32_t flags;          // +0x14 bit0: clamp z>0 result to 0
+        float min_x;             // +0x18
+        float min_y;             // +0x1C
+        float max_x;             // +0x20
+        float max_y;             // +0x24 grid anchored at (min_x, max_y)
+        uint32_t pad0[2];        // +0x28
+        uint32_t grid_dim_x;     // +0x30
+        uint32_t grid_dim_y;     // +0x34
+        uint32_t chunks_per_row; // +0x38 (dim_x >> 5) + 1  (the +1 is a border chunk column)
+        uint32_t chunk_rows;     // +0x3C (dim_y >> 5) + 1
+        float** chunk_ptrs;      // +0x40 chunks_per_row * chunk_rows entries -> 32x32 float32
+        uint32_t chunk_count;    // +0x44
+        uint32_t chunk_capacity; // +0x48
+    };
+    static_assert(offsetof(GwTerrain, dim_x) == 0x04);
+    static_assert(offsetof(GwTerrain, flags) == 0x14);
+    static_assert(offsetof(GwTerrain, min_x) == 0x18);
+    static_assert(offsetof(GwTerrain, max_y) == 0x24);
+    static_assert(offsetof(GwTerrain, chunks_per_row) == 0x38);
+    static_assert(offsetof(GwTerrain, chunk_ptrs) == 0x40);
+    static_assert(offsetof(GwTerrain, chunk_capacity) == 0x48);
+
+    constexpr float kTile = 96.0f;
+    constexpr float kNoData = FLT_MAX; // internal "no surface" sentinel; mapped to GW's 0.f at the API edge
+
+    const GwTerrain* GetTerrain()
+    {
+        const GW::MapContext* mc = GW::GetMapContext();
+        if (!mc || !mc->terrain) return nullptr;
+        const auto* t = static_cast<const GwTerrain*>(mc->terrain);
+        // Cheap sanity gate against a torn-down / mid-load terrain object.
+        if (t->dim_x == 0 || t->dim_x > 0x8000 || t->dim_y == 0 || t->dim_y > 0x8000) return nullptr;
+        if (t->chunks_per_row == 0 || !t->chunk_ptrs) return nullptr;
+        return t;
+    }
+
+    float SampleGrid(const GwTerrain* t, const uint32_t gx, const uint32_t gy)
+    {
+        const uint32_t ci = (gy >> 5) * t->chunks_per_row + (gx >> 5);
+        if (ci >= t->chunk_capacity) return kNoData;
+        const float* chunk = t->chunk_ptrs[ci];
+        if (!chunk) return kNoData;
+        return chunk[(gy & 31) * 32 + (gx & 31)];
+    }
+
+    // cross2d(P,A,B) = (P.y-A.y)(B.x-A.x) - (P.x-A.x)(B.y-A.y); the exact side test GW uses (FUN_007294e0).
+    float Cross2D(const float px, const float py, const float ax, const float ay, const float bx, const float by)
+    {
+        return (py - ay) * (bx - ax) - (px - ax) * (by - ay);
+    }
+
+    // GW's strict point-in-trapezoid test (FUN_0072b680): y-band open, left edge >= 0, right edge <= 0.
+    bool TrapezoidContains(const GW::PathingTrapezoid* pt, const float x, const float y)
+    {
+        if (!(pt->YB < y && y < pt->YT)) return false;
+        if (Cross2D(x, y, pt->XTL, pt->YT, pt->XBL, pt->YB) < 0.f) return false;
+        if (Cross2D(x, y, pt->XTR, pt->YT, pt->XBR, pt->YB) > 0.f) return false;
+        return true;
+    }
+
+    // Walk one plane's point-location DAG (root at PathingMap::root_node) to the containing trapezoid.
+    // Returns true iff a real trapezoid of this plane covers (x,y). Mirrors GW's exact locator
+    // (FUN_0072aa80); the toolbox's older Pathing::FindTrapezoid has an inverted entry guard, so this is
+    // implemented fresh rather than reused.
+    bool PlaneContains(const GW::PathingMap& pm, const float x, const float y)
+    {
+        const GW::Node* n = pm.root_node;
+        int guard = 100000;
+        while (n && guard-- > 0) {
+            switch (n->type) {
+                case 0: { // XNode
+                    const auto* xn = static_cast<const GW::XNode*>(n);
+                    const float d = (y - xn->pos.y) * xn->dir.x - (x - xn->pos.x) * xn->dir.y;
+                    n = d >= 0.f ? xn->right : xn->left;
+                    break;
+                }
+                case 1: { // YNode
+                    const auto* yn = static_cast<const GW::YNode*>(n);
+                    n = (y > yn->pos.y) ? yn->above
+                        : (y < yn->pos.y) ? yn->below
+                        : (x >= yn->pos.x) ? yn->above : yn->below;
+                    break;
+                }
+                case 2: { // SinkNode -- the leaf's trapezoid contains (x,y) only if the point is really on it
+                    const auto* sn = static_cast<const GW::SinkNode*>(n);
+                    return sn->trapezoid && TrapezoidContains(sn->trapezoid, x, y);
+                }
+                default:
+                    return false;
+            }
+        }
+        return false;
+    }
+}
+
+float TerrainDrape::NativeTerrainZ(const float x, const float y)
+{
+    const GwTerrain* t = GetTerrain();
+    if (!t) return 0.f;
+
+    const float gxf = (x - t->min_x) / kTile;
+    const float gyf = (t->max_y - y) / kTile; // grid rows grow toward -y
+    if (gxf < 0.f || gyf < 0.f) return 0.f;
+
+    const auto gxi = static_cast<uint32_t>(gxf);
+    const auto gyi = static_cast<uint32_t>(gyf);
+    if (gxi >= t->dim_x || gyi >= t->dim_y) return 0.f; // gxi+1 <= dim_x reads the border chunk column
+
+    const float fx = gxf - static_cast<float>(gxi);
+    const float fy = gyf - static_cast<float>(gyi);
+
+    const float zA = SampleGrid(t, gxi, gyi);
+    const float zB = SampleGrid(t, gxi + 1, gyi);
+    const float zC = SampleGrid(t, gxi, gyi + 1);
+    const float zD = SampleGrid(t, gxi + 1, gyi + 1);
+    if (zA == kNoData || zB == kNoData || zC == kNoData || zD == kNoData) return 0.f;
+
+    // Cell is split on the B-C diagonal (fx+fy==1), matching the game's triangulation.
+    float z;
+    if (fx + fy <= 1.f)
+        z = zA + fx * (zB - zA) + fy * (zC - zA);
+    else
+        z = zB + (fx + fy - 1.f) * (zD - zB) + (1.f - fx) * (zC - zB);
+
+    if ((t->flags & 1u) && z > 0.f) z = 0.f; // GW clamps below-zero-plane surfaces
+    return z;
+}
+
 float TerrainDrape::QueryAltAt(const float x, const float y, const uint32_t zplane)
 {
+    if (zplane == 0)
+        return NativeTerrainZ(x, y);
     GW::GamePos p{x, y, zplane};
     return GW::Map::QueryAltitude(&p);
 }
@@ -15,13 +160,25 @@ float TerrainDrape::QueryAltAt(const float x, const float y, const uint32_t zpla
 float TerrainDrape::DrapeZ(const float x, const float y, const uint32_t zplane, const uint32_t n_planes, const float ref)
 {
     float best = ref, best_d = FLT_MAX;
-    for (uint32_t zp = 0; zp < n_planes; ++zp) {
-        const float a = QueryAltAt(x, y, zp);
-        if (a == 0.f) continue;
-        const float d = std::fabs(a - ref);
-        if (d < best_d || (d == best_d && zp == zplane)) {
-            best_d = d;
-            best = a;
+
+    const float ground = NativeTerrainZ(x, y);
+    if (ground != 0.f) {
+        best_d = std::fabs(ground - ref);
+        best = ground;
+    }
+
+    const GW::PathingMapArray* pm = GW::Map::GetPathingMap();
+    if (pm) {
+        const auto planes = std::min<uint32_t>(n_planes, static_cast<uint32_t>(pm->size()));
+        for (uint32_t zp = 1; zp < planes; ++zp) {
+            if (!PlaneContains((*pm)[zp], x, y)) continue;
+            const float a = QueryAltAt(x, y, zp);
+            if (a == 0.f) continue;
+            const float d = std::fabs(a - ref);
+            if (d < best_d || (d == best_d && zp == zplane)) {
+                best_d = d;
+                best = a;
+            }
         }
     }
     return best;
@@ -29,10 +186,19 @@ float TerrainDrape::DrapeZ(const float x, const float y, const uint32_t zplane, 
 
 float TerrainDrape::SurfaceZ(const float x, const float y, const uint32_t, const uint32_t n_planes)
 {
-    float best = 0.f;
-    for (uint32_t zp = 0; zp < n_planes; ++zp) {
-        const float a = QueryAltAt(x, y, zp);
-        if (a != 0.f && (best == 0.f || a < best)) best = a;
+    // Highest surface = min z. Plane-0 ground is a native read; only planes whose trapezoid actually
+    // covers (x,y) can add a higher (bridge/prop) surface, so the old blind all-planes loop is pruned
+    // to those candidates.
+    float best = NativeTerrainZ(x, y); // 0.f when off-terrain
+
+    const GW::PathingMapArray* pm = GW::Map::GetPathingMap();
+    if (pm) {
+        const auto planes = std::min<uint32_t>(n_planes, static_cast<uint32_t>(pm->size()));
+        for (uint32_t zp = 1; zp < planes; ++zp) {
+            if (!PlaneContains((*pm)[zp], x, y)) continue;
+            const float a = QueryAltAt(x, y, zp);
+            if (a != 0.f && (best == 0.f || a < best)) best = a;
+        }
     }
     return best;
 }

--- a/GWToolboxdll/Utils/TerrainDrape.h
+++ b/GWToolboxdll/Utils/TerrainDrape.h
@@ -3,9 +3,18 @@
 #include <cstdint>
 
 // Surface-draping helpers shared by the in-world overlay modules (danger rings, loot beacons,
-// skill range rings). QueryAltitude swaps the global map context, so call these ONLY on the
-// render thread. GW's "no altitude data" sentinel is 0.f, and up is -z (highest surface = min z).
+// skill range rings). GW's "no altitude data" sentinel is 0.f, and up is -z (highest surface = min z).
+//
+// Plane 0 (the terrain heightfield) is read directly from the mapped terrain object -- no game call,
+// no map-context swap -- so it is safe from any thread and cheap enough to sample per vertex per frame.
+// Non-zero planes (bridges/prop surfaces) still route through GW::Map::QueryAltitude, which swaps the
+// global map context, so the DrapeZ/SurfaceZ helpers must run ONLY on the render thread. They prune the
+// old all-planes loop to just the planes whose pathing trapezoid actually contains (x,y).
 namespace TerrainDrape {
+    // Exact terrain surface z at (x,y) on plane 0, interpolated from the heightfield. Returns 0.f when
+    // (x,y) is outside the terrain or the map is not loaded (matching GW's OOB sentinel). Native read.
+    float NativeTerrainZ(float x, float y);
+
     float QueryAltAt(float x, float y, uint32_t zplane);
 
     // Surface altitude at (x,y), choosing the plane closest to `ref`.

--- a/GWToolboxdll/Utils/TerrainDrape.h
+++ b/GWToolboxdll/Utils/TerrainDrape.h
@@ -25,4 +25,12 @@ namespace TerrainDrape {
 
     // Plane count of the current pathing map; 0 while the map is still loading.
     uint32_t PathingPlaneCount();
+
+    // Verification helper (harness `drapeverify`). Fills three altitudes at (x,y):
+    //   old_all   -- the previous behavior: GW::Map::QueryAltitude on EVERY plane, highest surface (min z)
+    //   new_z     -- the current SurfaceZ (native plane-0 read + trapezoid-pruned non-zero planes)
+    //   prune_gp0 -- the pruned non-zero planes combined with the GAME's plane-0 value, so the trapezoid
+    //                pruning can be checked in isolation from the native-vs-game plane-0 sampling delta.
+    // Any nullptr out-pointer is skipped. Render thread only (uses QueryAltitude).
+    void DrapeCompare(float x, float y, uint32_t n_planes, float* old_all, float* new_z, float* prune_gp0);
 }

--- a/tasks/prop-height-oracle-plan.md
+++ b/tasks/prop-height-oracle-plan.md
@@ -1,0 +1,160 @@
+# Prop Height Oracle — draping overlays on non-walkable props at 360 fps
+
+## Problem
+
+In-world overlays (skill range rings, danger rings, loot beacons, quest path) currently drape only
+on the terrain heightfield and on *walkable* pathing planes (bridges/stairs reachable via
+`GW::Map::QueryAltitude`). They cannot get the height of **non-walkable props** — e.g. the railings
+between the three stacked stair planes in the Great Temple of Balthasar — so overlays draw *under*
+those structures instead of *on* them.
+
+Goal: a height oracle that returns the surface Z for **any** `(x,y)` in the map — terrain, walkable
+prop surfaces, and non-walkable props alike — cheaply enough to sample hundreds–thousands of points
+per frame while holding **360 fps** (2.78 ms/frame total budget).
+
+## Why the obvious approach is too slow
+
+`GW::Map::QueryAltitude` costs ~21 µs/call: it swaps the global map context, derefs handles, and
+raycasts a prop collision mesh every call. 1,000 of those is ~21 ms — alone that caps the game at
+~45 fps. It also only works for **pathing planes**, so it can't reach non-walkable props at all.
+
+The fix is to move all mesh/transform/handle work to a **one-time precompute at map load** (off the
+render thread) and leave the per-query path doing an O(1) lookup with no game calls and no
+allocation.
+
+## Architecture: a two-layer height oracle
+
+**Layer 1 — terrain (already implemented).** `TerrainDrape::NativeTerrainZ(x,y)` is a pure heightfield
+read (~50–100 ns). Base surface everywhere.
+
+**Layer 2 — precomputed prop-surface index (new).** Everything above terrain (stairs, platforms,
+railings) is props. Bake their surfaces into a spatial index once, then look them up in O(1).
+
+Per-query, combine the two:
+
+```cpp
+float HeightAt(float x, float y, float ref_z) {
+    float z = TerrainDrape::NativeTerrainZ(x, y);      // base layer, native
+    const PropIndex* idx = g_prop_index.load(acquire); // null until bake completes
+    if (idx) {
+        for (const Tri& t : idx->triangles_in_cell(x, y)) {   // typically 0–4 tris
+            if (point_in_tri_xy(x, y, t)) {
+                const float cz = plane_z(t, x, y);
+                z = pick(z, cz, ref_z);                        // policy: see below
+            }
+        }
+    }
+    return z;
+}
+```
+
+No game call, no context swap, no mesh walk, no allocation.
+
+## Phase A — precompute (worker thread, map load, never blocks main)
+
+Follows the resident-cache / `GetResidentMilepathOrPrewarm` pattern: build off-thread, publish by
+atomic pointer swap; degrade to terrain-only until ready.
+
+1. **Enumerate `GetMapContext()->props->propArray`** (~644 props in the DoA outpost; Temple is
+   similar). For each prop:
+   - Read its collision mesh via `MapProp+0x58` model handle → `ModelData+0x08` → submesh table
+     `+0xac`/`+0xb0` → `'mgrg'` mesh (verts `+0x1c`, stride `+0x54`, indices `+0x08`, index count
+     `+0x10`). Layout is already reverse-engineered (see
+     `reference-gw-terrain-altitude-internals` / the prop-planes RE report).
+   - Build the model→world transform from `MapProp.position` (`+0x20`) + rotation (`+0x38`
+     angle/cos/sin).
+   - Transform each triangle to **world space once**; store 3 world verts (or plane eq + XY-AABB).
+   - Optionally drop triangles that can never be a top surface (steep downward normals) to shrink the
+     set. Keep near-vertical rail faces — the *top* of the railing is what we drape onto.
+2. **Insert into a uniform XY grid** (cell ≈ 48–96 gwinches, same order as the terrain tile). Each
+   triangle registers in every cell its XY-AABB overlaps. Cells with no props stay empty → those
+   queries fall straight through to terrain.
+3. **Publish**: `g_prop_index.store(new, release)`. Rebuild per map load; free the old index after a
+   frame boundary.
+
+Cost is paid once, off the render thread — zero per-frame impact.
+
+## Phase B — query policy
+
+Two consumers, two rules, both served by how the query picks among candidate surfaces:
+
+- **"Draw on top" (rings, danger zones):** take the **highest** surface (min z, since up = −z) among
+  terrain + covering prop triangles. A ring crossing a railing footprint rides onto the rail top.
+- **"Follow the path up the stairs" (quest path):** take the surface **nearest the running reference
+  z** (`ref_z` = previous dense sample) — the existing `ClosestSurfaceZ` continuity idea, now fed by
+  *all* surfaces. A line climbing the three stacked planes tracks each stair ramp without jumping to
+  the plane above or sinking to the ground below.
+
+The stairs are likely walkable pathing planes already, but folding them into the same triangle oracle
+gives one uniform query for stairs + railings and removes the `QueryAltitude` dependency entirely.
+
+## Performance budget (360 fps = 2.78 ms/frame)
+
+Per query: 1 native terrain read + 1 grid lookup + ≤~4 point-in-triangle tests ≈ **150–300 ns**.
+
+| Workload                              | queries/frame | cost        |
+|---------------------------------------|--------------:|-------------|
+| Large skill ring (rebuilt each frame) |         ~1,000 | ~0.2 ms     |
+| Several overlays at once              |         ~3,000 | ~0.6–0.9 ms |
+| Stress                                |         ~5,000 | ~1.0–1.5 ms |
+
+All inside 2.78 ms with headroom for actual rendering. (Old `QueryAltitude` path: ~21 µs/query →
+1,000 = ~21 ms; ~100× worse and can't reach non-walkable props.)
+
+**Memory:** only prop triangles. ~10k–100k tris × ~40 bytes ≈ 0.5–4 MB plus the grid — negligible.
+
+## Mesh source — recommendation and fallback
+
+- **Collision mesh (`'mgrg'`) first.** Low-poly, already decoded, and is the surface the game itself
+  treats as "height." Down-raycast → first hit = top of the railing's blocker volume = "on the
+  railing, not under it."
+- **Fallbacks** if collision proves inadequate for a specific prop (e.g. a railing whose collision is
+  a thin vertical plane with no usable top): the render mesh (via FrCache, already touched by the
+  compositor) or the DAT model via `model_file_id` (toolbox already parses FFNA models). Only reach
+  for these if verification on the Temple railings shows gaps.
+
+## Verification plan
+
+1. **Reachability (P0, ~10 min):** guarded probe that walks one elevated non-walkable Temple prop's
+   `+0x58` → mesh and dumps world-space triangle count + z-range. This is the one hard technical
+   unknown; everything else is mechanical.
+2. **Correctness:** on walkable planes, compare `HeightAt` vs `QueryAltitude` over N random points
+   (reuse the `drapeverify` harness) — should match within interpolation noise. On railings, compare
+   against the prop's known top.
+3. **Visual:** stand on the Temple stairs, enable a draped overlay, confirm the line rides all three
+   planes and sits *on* the railings. (Needs GW focused for a real fps read.)
+4. **Perf:** `drapebench`-style A/B and a foreground fps read with a large ring.
+
+## Risks / edge cases
+
+- **Railing collision may be a vertical blocker without a clean top** → raycast-down still hits its
+  top edge, but verify; render/DAT mesh is the fallback.
+- **Moving props** (doors, lifts): mostly static; for movers, re-transform that prop's cached *local*
+  triangles per frame (cheap, one prop) or exclude them.
+- **Map teardown / reload:** oracle is per-map; atomic swap + deferred free avoids torn reads; null
+  index → terrain-only fallback, never a crash.
+- **Selection policy:** `propArray` is *all* geometry (walls, statues). "Highest surface" alone would
+  let a ring climb a wall. Mitigate via the continuity rule (rejects far-off surfaces) and/or tag only
+  near-horizontal top triangles as drape-eligible. Decide explicitly per overlay.
+
+## Phasing / milestones
+
+1. **P0** — prove collision-mesh reachability on a Temple railing prop (guarded probe).
+2. **P1** — worker-thread bake of the world-space triangle grid for the current map; harness dump of
+   its size/extent.
+3. **P2** — `HeightAt` query + wire it behind `SurfaceZ`/`DrapeZ` as the prop layer; validate with
+   `drapeverify` on walkable planes.
+4. **P3** — continuity policy for the 3-plane stairs; visual check on the Temple.
+5. **P4** — perf tune (cell size, triangle culling) + foreground fps confirmation.
+
+**Gating unknown:** P0 — whether a non-walkable prop's collision mesh is readable from live memory.
+The layout is decoded; validating it is the first concrete step.
+
+## Related
+
+- `reference-gw-terrain-altitude-internals` (memory) — decoded terrain heightfield + prop raycast +
+  point-location.
+- `project-native-terrain-altitude` (memory) — Layer 1 (native terrain) + trapezoid-pruned
+  `SurfaceZ`, PR #2414.
+- Harness verbs already built for this line of work: `nativez`, `drapebench`, `drapeverify`,
+  `fpsprobe`, `propprobe`.


### PR DESCRIPTION
Closes #2409. Also addresses the FPS collapse in #2408.

## Problem

Draped in-world overlays (skill range rings, loot beacons, danger rings, quest path, rivers, weather) sample the surface through `GW::Map::QueryAltitude` **once per plane per vertex, every frame**. That call swaps the global map context and walks the terrain heightfield, so a large ring (~1000 verts × N planes) collapses the frame rate.

## Change

**Read the terrain heightfield directly.** `TerrainDrape::NativeTerrainZ(x, y)` resolves the exact surface z at a point straight from the mapped terrain object (`MapContext+0x84`) — a 32×32-float-chunk grid, 96-gwinch tiles, Y-flipped, split on the B–C diagonal. It's a pure memory read: no game call, no context swap, thread-safe.

- `QueryAltAt` now routes **plane 0** (the common case) through `NativeTerrainZ`, so every draped consumer benefits with no change at the call sites. Non-zero planes still go through `QueryAltitude` for the prop-mesh raycast.
- `SurfaceZ` / `DrapeZ` no longer scan all planes. They take the native plane-0 surface as the baseline and query only the non-zero planes whose **pathing trapezoid actually contains (x, y)**, found via a point-location DAG walk — directly answering the issue's "query only the planes that exist" ask.

The terrain struct layout and query math were reverse-engineered from the client; `GwTerrain` is guarded by `offsetof` static_asserts.

## Verification (in-game, harness, map 474, 42 planes)

- **Correctness:** native z matches the client's own plane-0 value; the residual (avg ~2 gwinches) is one-signed and slope-correlated — the game's radius-5 disk-max versus point-exact interpolation, not a decode error.
- **Performance:** direct A/B on identical points, measured as an in-process CPU-timing loop (independent of window focus / frame pacing) → **~15× faster** per `SurfaceZ` call (21.5 → 1.46 µs).
- **Per-frame impact:** the skill-range rings rebuild every frame. A Sandstorm cast (312 + 1050-radius rings) is ~690 `SurfaceZ` calls/frame → **old ≈ 14.8 ms/frame** (a hard ~67 fps ceiling from ring sampling alone; the #2408 collapse) vs **new ≈ 1.0 ms/frame**. The largest allowed ring (512-segment cap, ~1024 samples) is old ≈ 22 ms vs new ≈ 1.5 ms.

Adds Debug-only harness verbs (`nativez`, `drapebench`, `fpsprobe`) used to produce the numbers above; these compile out of shipped builds.

## Behavior note

Plane-0 draping is now point-exact rather than radius-5-blurred like the client. This hugs the terrain more precisely — better for overlays — but is a deliberate behavior change worth flagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qkJXMrytQ75KYP4o2yZgX