### PR TITLE
fix(market): unique ImGui IDs for order/whisper buttons

### DIFF
--- a/GWToolboxdll/Windows/GWMarketWindow.cpp
+++ b/GWToolboxdll/Windows/GWMarketWindow.cpp
@@ -1117,14 +1117,14 @@ namespace {
         }
 
         const auto font_size = ImGui::CalcTextSize(" ");
-        auto DrawOrder = [font_size](const MarketItem& order) {
+        auto DrawOrder = [font_size](const MarketItem& order, size_t index) {
             // NB: Seems to be an array of prices given by the API, but the website only shows the first one?
             const auto& price = order.prices[0];
             if (order_view_currency != Currency::All && order_view_currency != price.type) return;
 
-            // Use the order's address for a unique ID; descriptions are often empty and would collide,
+            // Use the row index for a unique ID; descriptions are often empty and would collide,
             // making the per-row "Whisper" buttons share an ImGui ID.
-            ImGui::PushID(&order);
+            ImGui::PushID(static_cast<int>(index));
             const auto top = ImGui::GetCursorPosY();
             ImGui::TextUnformatted(order.player.c_str());
             const auto timetext = TextUtils::RelativeTime(order.lastRefresh);
@@ -1199,15 +1199,17 @@ namespace {
         ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "SELL ORDERS:");
         ImGui::Separator();
 
-        for (const auto& order : current_item_orders) {
-            if (order.orderType == OrderType::Sell && order.valid()) DrawOrder(order);
+        for (size_t i = 0; i < current_item_orders.size(); i++) {
+            const auto& order = current_item_orders[i];
+            if (order.orderType == OrderType::Sell && order.valid()) DrawOrder(order, i);
         }
 
         ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.0f, 1.0f), "BUY ORDERS:");
         ImGui::Separator();
 
-        for (const auto& order : current_item_orders) {
-            if (order.orderType == OrderType::Buy && order.valid()) DrawOrder(order);
+        for (size_t i = 0; i < current_item_orders.size(); i++) {
+            const auto& order = current_item_orders[i];
+            if (order.orderType == OrderType::Buy && order.valid()) DrawOrder(order, i);
         }
     }
 
@@ -1239,13 +1241,13 @@ namespace {
         }
 
         const auto font_size = ImGui::CalcTextSize(" ");
-        auto DrawOrder = [font_size](const MarketItem& order) {
+        auto DrawOrder = [font_size](const MarketItem& order, size_t index) {
             if (order.prices.empty()) return;
 
             const auto& price = order.prices[0];
 
-            // Use the order's address for a unique ID; descriptions are often empty and would collide.
-            ImGui::PushID(&order);
+            // Use the row index for a unique ID; descriptions are often empty and would collide.
+            ImGui::PushID(static_cast<int>(index));
             // const auto top = ImGui::GetCursorPosY();
 
             // Player name and time
@@ -1291,27 +1293,29 @@ namespace {
 
         // Show sell orders first
         bool has_sell_orders = false;
-        for (const auto& order : edit_window_matching_orders) {
+        for (size_t i = 0; i < edit_window_matching_orders.size(); i++) {
+            const auto& order = edit_window_matching_orders[i];
             if (order.orderType == OrderType::Sell && order.valid()) {
                 if (!has_sell_orders) {
                     ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "SELL ORDERS:");
                     ImGui::Separator();
                     has_sell_orders = true;
                 }
-                DrawOrder(order);
+                DrawOrder(order, i);
             }
         }
 
         // Show buy orders
         bool has_buy_orders = false;
-        for (const auto& order : edit_window_matching_orders) {
+        for (size_t i = 0; i < edit_window_matching_orders.size(); i++) {
+            const auto& order = edit_window_matching_orders[i];
             if (order.orderType == OrderType::Buy && order.valid()) {
                 if (!has_buy_orders) {
                     ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.0f, 1.0f), "BUY ORDERS:");
                     ImGui::Separator();
                     has_buy_orders = true;
                 }
-                DrawOrder(order);
+                DrawOrder(order, i);
             }
         }
 

--- a/GWToolboxdll/Windows/GWMarketWindow.cpp
+++ b/GWToolboxdll/Windows/GWMarketWindow.cpp
@@ -1117,14 +1117,14 @@ namespace {
         }
 
         const auto font_size = ImGui::CalcTextSize(" ");
-        auto DrawOrder = [font_size](const MarketItem& order, size_t index) {
+        auto DrawOrder = [font_size](const MarketItem& order) {
             // NB: Seems to be an array of prices given by the API, but the website only shows the first one?
             const auto& price = order.prices[0];
             if (order_view_currency != Currency::All && order_view_currency != price.type) return;
 
-            // Use the row index for a unique ID; descriptions are often empty and would collide,
+            // Use the order's address for a unique ID; descriptions are often empty and would collide,
             // making the per-row "Whisper" buttons share an ImGui ID.
-            ImGui::PushID(static_cast<int>(index));
+            ImGui::PushID(&order);
             const auto top = ImGui::GetCursorPosY();
             ImGui::TextUnformatted(order.player.c_str());
             const auto timetext = TextUtils::RelativeTime(order.lastRefresh);
@@ -1199,17 +1199,15 @@ namespace {
         ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "SELL ORDERS:");
         ImGui::Separator();
 
-        for (size_t i = 0; i < current_item_orders.size(); i++) {
-            const auto& order = current_item_orders[i];
-            if (order.orderType == OrderType::Sell && order.valid()) DrawOrder(order, i);
+        for (const auto& order : current_item_orders) {
+            if (order.orderType == OrderType::Sell && order.valid()) DrawOrder(order);
         }
 
         ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.0f, 1.0f), "BUY ORDERS:");
         ImGui::Separator();
 
-        for (size_t i = 0; i < current_item_orders.size(); i++) {
-            const auto& order = current_item_orders[i];
-            if (order.orderType == OrderType::Buy && order.valid()) DrawOrder(order, i);
+        for (const auto& order : current_item_orders) {
+            if (order.orderType == OrderType::Buy && order.valid()) DrawOrder(order);
         }
     }
 
@@ -1241,13 +1239,13 @@ namespace {
         }
 
         const auto font_size = ImGui::CalcTextSize(" ");
-        auto DrawOrder = [font_size](const MarketItem& order, size_t index) {
+        auto DrawOrder = [font_size](const MarketItem& order) {
             if (order.prices.empty()) return;
 
             const auto& price = order.prices[0];
 
-            // Use the row index for a unique ID; descriptions are often empty and would collide.
-            ImGui::PushID(static_cast<int>(index));
+            // Use the order's address for a unique ID; descriptions are often empty and would collide.
+            ImGui::PushID(&order);
             // const auto top = ImGui::GetCursorPosY();
 
             // Player name and time
@@ -1293,29 +1291,27 @@ namespace {
 
         // Show sell orders first
         bool has_sell_orders = false;
-        for (size_t i = 0; i < edit_window_matching_orders.size(); i++) {
-            const auto& order = edit_window_matching_orders[i];
+        for (const auto& order : edit_window_matching_orders) {
             if (order.orderType == OrderType::Sell && order.valid()) {
                 if (!has_sell_orders) {
                     ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "SELL ORDERS:");
                     ImGui::Separator();
                     has_sell_orders = true;
                 }
-                DrawOrder(order, i);
+                DrawOrder(order);
             }
         }
 
         // Show buy orders
         bool has_buy_orders = false;
-        for (size_t i = 0; i < edit_window_matching_orders.size(); i++) {
-            const auto& order = edit_window_matching_orders[i];
+        for (const auto& order : edit_window_matching_orders) {
             if (order.orderType == OrderType::Buy && order.valid()) {
                 if (!has_buy_orders) {
                     ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.0f, 1.0f), "BUY ORDERS:");
                     ImGui::Separator();
                     has_buy_orders = true;
                 }
-                DrawOrder(order, i);
+                DrawOrder(order);
             }
         }
 

--- a/GWToolboxdll/Windows/GWMarketWindow.cpp
+++ b/GWToolboxdll/Windows/GWMarketWindow.cpp
@@ -1122,7 +1122,9 @@ namespace {
             const auto& price = order.prices[0];
             if (order_view_currency != Currency::All && order_view_currency != price.type) return;
 
-            ImGui::PushID(order.description.c_str());
+            // Use the order's address for a unique ID; descriptions are often empty and would collide,
+            // making the per-row "Whisper" buttons share an ImGui ID.
+            ImGui::PushID(&order);
             const auto top = ImGui::GetCursorPosY();
             ImGui::TextUnformatted(order.player.c_str());
             const auto timetext = TextUtils::RelativeTime(order.lastRefresh);
@@ -1242,7 +1244,8 @@ namespace {
 
             const auto& price = order.prices[0];
 
-            ImGui::PushID(order.description.c_str());
+            // Use the order's address for a unique ID; descriptions are often empty and would collide.
+            ImGui::PushID(&order);
             // const auto top = ImGui::GetCursorPosY();
 
             // Player name and time


### PR DESCRIPTION
## Problem

Jon flagged that the **Whisper** buttons in the GW Market window don't have unique ImGui IDs.

Both `DrawOrder` lambdas in `GWMarketWindow.cpp` pushed `order.description.c_str()` as the ImGui ID for each order row. But orders frequently have an **empty** description (the code even guards rendering with `if (!order.description.empty())`), so every such row pushed the same empty-string ID. ImGui then treats all those `Whisper##seller` buttons as the same widget — clicking one whispers the wrong seller, or only the first row's button responds.

## Fix

Push the order's stable address (`&order`) as the ID instead. Each `MarketItem` in the vector has a unique, frame-stable address, so every row (and its Whisper button) gets a distinct ImGui ID.

Applied to both `DrawOrder` lambdas (main item view and the edit-window matching-orders view) for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)