### PR TITLE
ci: restrict Windows build triggers to dev/master pushes and dev PRs

### DIFF
--- a/.github/workflows/cmake-clang.yml
+++ b/.github/workflows/cmake-clang.yml
@@ -1,8 +1,14 @@
 name: CMake (clang-cl)
 
 on:
+  # push covers dev/master (post-merge validation); pull_request covers PRs
+  # against dev - including from forks - so feature branches only build once
+  # a PR is open instead of on every push. See cmake.yml for the same setup.
   push:
-    paths:
+    branches:
+      - dev
+      - master
+    paths: &cmake-clang-paths
       # C/C++ source and headers
       - '**/*.cpp'
       - '**/*.c'
@@ -21,6 +27,14 @@ on:
       - 'vcpkg-overlays/**'
       # The workflow itself
       - '.github/workflows/cmake-clang.yml'
+  pull_request:
+    branches:
+      - dev
+    paths: *cmake-clang-paths
+
+concurrency:
+  group: cmake-clang-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,8 +1,15 @@
 name: CMake
 
 on:
+  # push covers dev (post-merge validation) and master (release builds, gated
+  # below on should_release). pull_request covers PRs against dev - including
+  # from forks, where CERTUM_OTP_URI is unset and signing/release is skipped -
+  # so branches only build once a PR is open instead of on every push.
   push:
-    paths:
+    branches:
+      - dev
+      - master
+    paths: &cmake-paths
       # C/C++ source and headers
       - '**/*.cpp'
       - '**/*.c'
@@ -21,6 +28,16 @@ on:
       - 'vcpkg-overlays/**'
       # The workflow itself
       - '.github/workflows/cmake.yml'
+  pull_request:
+    branches:
+      - dev
+    paths: *cmake-paths
+
+# Cancel a still-running build for the same ref when a new commit supersedes
+# it, instead of letting both run to completion on the paid Windows runner.
+concurrency:
+  group: cmake-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- `cmake.yml` and `cmake-clang.yml` previously triggered on `push` with no branch filter, so every push to *any* branch (feature branches, in-review PR branches, etc.) fired a full build on the paid `windows-2025-vs2026` runner - not just merges.
- Restrict `push` to `dev`/`master` and add a `pull_request` trigger scoped to `dev`, so a branch only builds once a PR against `dev` is actually open (this also naturally covers fork-based PRs, where `CERTUM_OTP_URI` is unset and signing/release already no-ops).
- Add a `concurrency` group with `cancel-in-progress: true` per workflow+ref, so pushing several fixup commits to the same PR cancels the superseded in-flight build instead of letting both run to completion.

## Test plan
- [ ] Confirm both workflows still trigger on push to `dev` and `master` (existing release-on-master behavior unaffected - the `should_release` gate still checks `github.ref == 'refs/heads/master'`)
- [ ] Open a test PR against `dev` touching a `.cpp`/`.h` file and confirm both workflows run once
- [ ] Push a follow-up commit to that PR and confirm the prior run is cancelled rather than left running
- [ ] Confirm a push to a branch with no open PR does *not* trigger a build

🤖 Generated with [Claude Code](https://claude.com/claude-code)