### PR TITLE
fix(minimap): make Custom Agents size edits apply to other players

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.cpp
@@ -1249,6 +1249,20 @@ Color AgentRenderer::GetColor(const GW::Agent* agent, const CustomAgent* ca) con
     return IM_COL32(0, 0, 0, 0);
 }
 
+float AgentRenderer::GetSeededDefaultSize(const GW::Constants::Allegiance allegiance, const float fallback) const
+{
+    const auto it = custom_agents_by_allegiance.find(static_cast<int>(allegiance));
+    if (it == custom_agents_by_allegiance.end()) {
+        return fallback;
+    }
+    for (const CustomAgent* ca : it->second) {
+        if (ca->is_default && ca->active && ca->size_active && ca->size >= 0) {
+            return ca->size;
+        }
+    }
+    return fallback;
+}
+
 float AgentRenderer::GetSize(const GW::Agent* agent, const CustomAgent* ca) const
 {
     if (ca && ca->size_active && ca->size >= 0) {
@@ -1282,22 +1296,22 @@ float AgentRenderer::GetSize(const GW::Agent* agent, const CustomAgent* ca) cons
             if (!living->GetIsDead() && living->GetHasQuest()) {
                 return size_ally_npc_quest;
             }
-            return size_ally;
+            return GetSeededDefaultSize(GW::Constants::Allegiance::Ally_NonAttackable, size_ally);
 
         case GW::Constants::Allegiance::Neutral: // neutral
-            return size_neutral;
+            return GetSeededDefaultSize(GW::Constants::Allegiance::Neutral, size_neutral);
 
         case GW::Constants::Allegiance::Spirit_Pet: // spirit / pet
-            return size_ally_spirit;
+            return GetSeededDefaultSize(GW::Constants::Allegiance::Spirit_Pet, size_ally_spirit);
 
         case GW::Constants::Allegiance::Npc_Minipet: // npc / minipet
             if (!living->GetIsDead() && living->GetHasQuest()) {
                 return size_ally_npc_quest;
             }
-            return size_ally_npc;
+            return GetSeededDefaultSize(GW::Constants::Allegiance::Npc_Minipet, size_ally_npc);
 
         case GW::Constants::Allegiance::Minion: // minion
-            return size_minion;
+            return GetSeededDefaultSize(GW::Constants::Allegiance::Minion, size_minion);
 
         case GW::Constants::Allegiance::Enemy: // hostile
             switch (living->player_number) {

--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.h
@@ -15,6 +15,9 @@ namespace GW {
     namespace UI {
         enum class UIMessage : uint32_t;
     }
+    namespace Constants {
+        enum class Allegiance : uint8_t;
+    }
 }
 
 using Color = uint32_t;
@@ -165,6 +168,11 @@ private:
     Color GetColor(const GW::Agent* agent, const CustomAgent* ca = nullptr) const;
     float GetSize(const GW::Agent* agent, const CustomAgent* ca = nullptr) const;
     Shape_e GetShape(const GW::Agent* agent, const CustomAgent* ca = nullptr) const;
+    // Real players never go through GetCustomAgentsToDraw (see Render()), so the seeded
+    // Neutral/Ally/.../Minion default rows only reach them through this fallback; read the
+    // row's current size instead of the (now write-only) legacy size_* field so editing the
+    // row in the Custom Agents list actually takes effect for players too.
+    float GetSeededDefaultSize(GW::Constants::Allegiance allegiance, float fallback) const;
 
     struct RenderPosition {
         float rotation_cos;


### PR DESCRIPTION
## Summary
- Since #4dba954f unified agent colors/sizes into the Custom Agents list, real players (other party members) never reach `GetCustomAgentsToDraw` (there's an explicit "we don't support custom agents for players" note in `Render()`), so they always fell through to `GetSize()`'s allegiance switch.
- That switch read `size_ally`/`size_neutral`/`size_ally_spirit`/`size_ally_npc`/`size_minion` directly - fields that are now only ever written once, at migration/seed time. Editing the seeded "Neutral"/"Ally"/"Ally (NPC)"/"Ally (Spirit/Pet)"/"Ally (Minion)" rows in the Custom Agents list only updates the row's own copy, never that legacy field.
- Net effect: no UI control could change other players' (or dead/neutral NPC fallback) minimap size anymore - reported in Discord as "other players stuck at 100 no matter what I set".

## Fix
Added `GetSeededDefaultSize()`, which looks up the current size on the matching seeded default row (falling back to the legacy field only if that row is missing/inactive/disabled), and use it in `GetSize()`'s switch fallback for the 5 migrated allegiances. This only touches size resolution - color/shape for players are unchanged.

## Test plan
- [ ] In-game: set "Ally" size in Custom Agents settings to something other than 100, confirm other party members/players on the minimap resize accordingly.
- [ ] Confirm "Restore Defaults" still resets both the legacy field and the seeded row back to 100.
- [ ] Confirm NPC allies/neutrals/spirits/minions still size correctly (unchanged behavior, still matched via `GetCustomAgentsToDraw`).