### PR TITLE
site: redirect legacy prefix-less doc URLs to /docs/<slug>/

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -46,6 +46,10 @@ Links between docs use absolute paths (`[Settings](/docs/settings/)`). The
 legacy Jekyll-style relative links (`[Settings](settings)`) were rewritten
 during the port.
 
+Every doc slug also gets an automatic redirect from its legacy prefix-less URL
+(`/linux` → `/docs/linux/`), generated in `astro.config.mjs` by scanning
+`src/content/docs/` — no per-page bookkeeping needed.
+
 ## Where things live
 
 - `src/layouts/Base.astro` — site chrome (head, header, footer).

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,3 +1,5 @@
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 import mdx from '@astrojs/mdx';
@@ -5,6 +7,16 @@ import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 import { rehypeHeadingIds } from '@astrojs/markdown-remark';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
+
+// Legacy Jekyll URLs had no /docs prefix (gwtoolbox.com/linux), so redirect
+// every bare doc slug to its current /docs/<slug>/ location.
+const docsDir = fileURLToPath(new URL('./src/content/docs', import.meta.url));
+const legacyDocRedirects = Object.fromEntries(
+  readdirSync(docsDir)
+    .filter((file) => /\.mdx?$/.test(file))
+    .map((file) => file.replace(/\.mdx?$/, ''))
+    .map((slug) => [`/${slug}`, `/docs/${slug}/`]),
+);
 
 // Lucide "link" icon as a hast node, appended to each heading as a permalink.
 const linkIcon = {
@@ -40,6 +52,7 @@ const linkIcon = {
 
 export default defineConfig({
   site: 'https://www.gwtoolbox.com',
+  redirects: legacyDocRedirects,
   integrations: [react(), mdx(), sitemap()],
   vite: {
     plugins: [tailwindcss()],


### PR DESCRIPTION
`gwtoolbox.com/linux` is dead — it was a valid URL on the old Jekyll site, but the Astro port moved every doc under `/docs/`.

Rather than hardcoding one redirect, `astro.config.mjs` now scans `src/content/docs/` and emits a redirect for each slug, so `/<slug>` → `/docs/<slug>/` for all pre-port URLs. Astro's static build renders each as a meta-refresh stub with `noindex` + a canonical link to the real page; they're excluded from the sitemap.

Verified with `npm run build`: `dist/linux/index.html` redirects to `/docs/linux/`, and the sitemap still lists only the 56 real pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)