### PR TITLE
launcher: make the Linux guide URL in the error dialog clickable

### DIFF
--- a/GWToolbox/main.cpp
+++ b/GWToolbox/main.cpp
@@ -37,7 +37,7 @@ static void OpenLogFile(const std::filesystem::path& exe_path)
 
 static void ShowError(const wchar_t* message)
 {
-    ShowMessageBoxW(nullptr, message, L"GWToolbox - Error", 0);
+    ShowMessageBoxWithLinksW(nullptr, message, L"GWToolbox - Error");
 }
 
 static void ShowError(const char* message)
@@ -318,7 +318,8 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int n
         if (GetWineDiagnostics(wine)) {
             error += std::format(
                 L"\n\nGWToolbox is running under Wine on a non-Windows host, which is not supported. The "
-                L"Linux guide at https://www.gwtoolbox.com/linux is provided as-is for convenience only.\n\nDetected: {}",
+                L"Linux guide at <a href=\"https://www.gwtoolbox.com/docs/linux/\">gwtoolbox.com/docs/linux</a> "
+                L"is provided as-is for convenience only.\n\nDetected: {}",
                 wine
             );
             fprintf(stderr, "Wine detected: %S\n", wine.c_str());

--- a/GWToolbox/stdafx.h
+++ b/GWToolbox/stdafx.h
@@ -88,3 +88,43 @@ inline int ShowMessageBoxA(HWND hwnd, const char* text, const char* title, UINT 
 {
     return MessageBoxA(hwnd, text, (std::string(title) + " (v" GWTOOLBOXEXE_VERSION ")").c_str(), type);
 }
+
+// MessageBoxW can't render links, so the fallback path turns `<a href="url">text</a>` back into `text`.
+inline std::wstring StripLinkMarkup(const std::wstring& text)
+{
+    static const std::wregex link(L"<a href=\"[^\"]*\">([^<]*)</a>");
+    return std::regex_replace(text, link, L"$1");
+}
+
+// TaskDialog passes the clicked link's href in lParam.
+inline HRESULT CALLBACK OpenClickedLinkCallback(HWND, const UINT msg, WPARAM, const LPARAM lParam, LONG_PTR)
+{
+    if (msg == TDN_HYPERLINK_CLICKED) {
+        const auto url = reinterpret_cast<const wchar_t*>(lParam);
+        if (url && (wcsncmp(url, L"https://", 8) == 0 || wcsncmp(url, L"http://", 7) == 0)) {
+            ShellExecuteW(nullptr, L"open", url, nullptr, nullptr, SW_SHOWNORMAL);
+        }
+    }
+    return S_OK;
+}
+
+// Like ShowMessageBoxW, but `<a href="url">text</a>` in `text` renders as a clickable link;
+// falls back to a plain message box (markup stripped) if TaskDialog is unavailable.
+inline void ShowMessageBoxWithLinksW(HWND hwnd, const wchar_t* text, const wchar_t* title, PCWSTR icon = TD_ERROR_ICON)
+{
+    const std::wstring window_title = GwtbDialogTitle(title);
+
+    TASKDIALOGCONFIG config = {sizeof(config)};
+    config.hwndParent = hwnd;
+    config.dwFlags = TDF_ALLOW_DIALOG_CANCELLATION | TDF_ENABLE_HYPERLINKS | TDF_SIZE_TO_CONTENT;
+    config.dwCommonButtons = TDCBF_OK_BUTTON;
+    config.pszWindowTitle = window_title.c_str();
+    config.pszMainIcon = icon;
+    config.pszContent = text;
+    config.pfCallback = OpenClickedLinkCallback;
+
+    if (SUCCEEDED(TaskDialogIndirect(&config, nullptr, nullptr, nullptr))) {
+        return;
+    }
+    ShowMessageBoxW(hwnd, StripLinkMarkup(text).c_str(), title, MB_OK | MB_ICONERROR);
+}


### PR DESCRIPTION
When injection fails under Wine, the launcher's error dialog mentions the Linux guide as a bare URL — plain `MessageBoxW` can't render links, so there's nothing to click.

- `ShowMessageBoxWithLinksW` (GWToolbox/stdafx.h) shows the message via `TaskDialogIndirect` with `TDF_ENABLE_HYPERLINKS`, so `<a href="...">text</a>` in the message body becomes a real link. Clicks are handled in the task-dialog callback with `ShellExecuteW`, restricted to `http`/`https` hrefs. If `TaskDialogIndirect` fails, it falls back to the old message box with the markup stripped back to plain text.
- `ShowError` in the launcher now routes through it, so any future error text can carry links.
- The Wine message links `https://www.gwtoolbox.com/docs/linux/` (the current location; #2447 additionally keeps the old `/linux` URL alive).

comctl32 v6 is already manifested (GWToolbox/Inject.cpp) and `TaskDialogIndirect` is already used for the Defender prompt, so no new dependency. Under Wine, `ShellExecuteW` on a URL hands off to `winebrowser` → the host's default browser, which is exactly the audience for this dialog.

Not built locally — no MSVC toolchain in this environment, so CI is the first compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)