### PR TITLE
fix: align search label for pet/hero auto-flag setting with its UI checkbox

### DIFF
--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -1468,6 +1468,7 @@ void GameSettings::Initialize()
 {
     ToolboxModule::Initialize();
     SettingsRegistry::Register(this, settings);
+    SettingsRegistry::Describe(this, "automatically_flag_pet_to_fight_called_target", "Automatically lock heroes and pets onto your called target");
     SettingsRegistry::Describe(this, "combine_overhead_numbers", "Combine floating numbers above character", combine_overhead_numbers_help);
 
     OnSkillTomeWindow_UIMessage_Func = (GW::UI::UIInteractionCallback)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("GmSkTome.cpp", "selection.skillId", 0, 0), 0xfff);


### PR DESCRIPTION
Fixes #2426

The settings search was auto-prettifying the variable name `automatically_flag_pet_to_fight_called_target` to "Automatically flag pet to fight called target", but the actual ImGui checkbox label is "Automatically lock heroes and pets onto your called target". This mismatch meant clicking the search result never scrolled to or highlighted the widget.

Adds a `SettingsRegistry::Describe()` call in `GameSettings::Initialize()` to override the search label so it matches the visible UI text.

Generated with [Claude Code](https://claude.ai/code)