### PR TITLE
fix: guard ImGui::GetIO() on game-thread paths against a null context

### DIFF
--- a/GWToolboxdll/Modules/CameraUnlockModule.cpp
+++ b/GWToolboxdll/Modules/CameraUnlockModule.cpp
@@ -312,7 +312,8 @@ void CameraUnlockModule::Update(float delta) {
     if (delta == 0.f) {
         return;
     }
-    if (GW::CameraMgr::GetCameraUnlock() && !GW::Chat::GetIsTyping() && !ImGui::GetIO().WantTextInput) {
+    // Update runs on the game thread, which outlives the ImGui context; no context means no text input
+    if (GW::CameraMgr::GetCameraUnlock() && !GW::Chat::GetIsTyping() && !(ImGui::GetCurrentContext() && ImGui::GetIO().WantTextInput)) {
         static bool keep_forward;
 
         float forward = 0;

--- a/GWToolboxdll/Modules/ChatSettings.cpp
+++ b/GWToolboxdll/Modules/ChatSettings.cpp
@@ -305,7 +305,9 @@ namespace {
             status->blocked = true;
             return;
         }
-        if (!ImGui::GetIO().KeyCtrl) {
+        // UI messages dispatch on the game thread, which outlives the ImGui context (before the first
+        // Present, and after DetachImgui on shutdown); GetIO() would deref a null GImGui.
+        if (!ImGui::GetCurrentContext() || !ImGui::GetIO().KeyCtrl) {
             return; // - Next logic only applicable when Ctrl is held
         }
 

--- a/GWToolboxdll/Modules/GamepadModule.cpp
+++ b/GWToolboxdll/Modules/GamepadModule.cpp
@@ -88,6 +88,10 @@ void GamepadModule::Update(float delta)
 {
     UNREFERENCED_PARAMETER(delta);
     HookXInput();
+    // Update runs on the game thread, which outlives the ImGui context; everything below touches it
+    if (!ImGui::GetCurrentContext()) {
+        return;
+    }
     if (!GetGamepadCursorPos(&gamepad_cursor_pos_client)) {
         if (was_in_cursor_mode && ImGui::ShowingContextMenu()) {
             // Close current popup menu if we're in gamepad mode and didn't get cursor position


### PR DESCRIPTION
Crash dump 8.32-20260804-110940 is an access violation reading 0x00000104 in ChatSettings OnStartWhisper (ChatSettings.cpp:308), symbolised against the 8.32 release PDB:

    call  ImGui::GetIO()
    cmpb  $0x0, 0xd4(%eax)   ; .KeyCtrl  <-- faults, eax = 0x30

GetIO() returns &GImGui->IO (IO is at +0x30), so a null GImGui yields 0x30 and reading KeyCtrl at +0xd4 lands on 0x104, matching the address in Gw.exe's own crash record.

The ImGui context is created and destroyed on the render thread by AttachImgui/DetachImgui, but UI message callbacks and ToolboxModule::Update run on the game thread and are not tied to that lifecycle. Both before the first Present and after DetachImgui on shutdown, those paths can dereference a null context.

Guard the three call sites that are reachable off the render thread. Draw() paths are unaffected, and WndProc handlers are already gated by CanRenderToolbox() plus DetachWndProcHandler() running before DetachImgui().