### PR TITLE
fix: record the real exception code in GW-triggered crash dumps

### DIFF
--- a/GWToolboxdll/Modules/CrashHandler.cpp
+++ b/GWToolboxdll/Modules/CrashHandler.cpp
@@ -84,8 +84,19 @@ namespace {
         EXCEPTION_RECORD exceptionRecord = {0};
         EXCEPTION_POINTERS exceptionPointers = {nullptr};
 
+        // GW has already written "Exception: <code>" into its own crash text; recover the real code from
+        // there, otherwise every dump is stamped EXCEPTION_BREAKPOINT and debuggers chase a phantom int3.
+        DWORD exception_code = EXCEPTION_BREAKPOINT;
+        if (message_buffer && message_buffer->buffer) {
+            unsigned int parsed = 0;
+            if (const auto exception_line = strstr(message_buffer->buffer, "Exception: ");
+                exception_line && sscanf(&exception_line[11], "%8x", &parsed) == 1 && parsed) {
+                exception_code = parsed;
+            }
+        }
+
         // Fill in exception record with info from CONTEXT
-        exceptionRecord.ExceptionCode = EXCEPTION_BREAKPOINT; // Or appropriate code
+        exceptionRecord.ExceptionCode = exception_code;
         exceptionRecord.ExceptionFlags = EXCEPTION_NONCONTINUABLE;
         exceptionRecord.ExceptionAddress = reinterpret_cast<PVOID>(pContext->Eip);
         exceptionRecord.NumberParameters = 0;


### PR DESCRIPTION
OnAppendStackTraceToCrashMessage hardcoded EXCEPTION_BREAKPOINT in the synthesised EXCEPTION_RECORD, so every dump taken via GW's own crash path was stamped 0x80000003 regardless of the actual fault.

This is actively misleading: two user dumps analysed recently both reported EXCEPTION_BREAKPOINT while the real faults were access violations (0xc0000005 reading 0x00000104 and 0x00000014). Anything reading the exception stream - minidump-stackwalk, WinDbg's !analyze - chases a phantom int3 that never happened.

GW has already written "Exception: <code>" into the same buffer we're handed, so parse it from there and only fall back to EXCEPTION_BREAKPOINT when it can't be read.