### PR TITLE
fix(QuestModule): stop quest/marker path recalcs leading back to a passed waypoint

### DIFF
--- a/GWToolboxdll/Modules/QuestModule.cpp
+++ b/GWToolboxdll/Modules/QuestModule.cpp
@@ -246,27 +246,29 @@ namespace {
             const bool same_map = PathfindingWindow::IsWorldPosOnMap(goal_world) && !goal_cross_map;
             GW::GamePos target{};
             if (same_map) {
-                if (!WorldMapWidget::WorldMapToGamePos(goal_world, target)) return;
+                if (!WorldMapWidget::WorldMapToGamePos(goal_world, target)) {
+                    // Nothing enqueued, so clear the in-flight flag — leaving it set blocks every Update for 5s.
+                    calculating = 0;
+                    calculated_at = 0;
+                    return;
+                }
             }
             else {
-                if (route_world.empty() || route_map.empty()) return;
+                if (route_world.empty() || route_map.empty()) {
+                    // No cross-map route to walk toward: bailing left `calculating` set with no work queued, freezing the path.
+                    has_full_route = false;
+                    GW::Vec2f from_world{};
+                    WorldMapWidget::GamePosToWorldMap(from, from_world);
+                    RecalculateWorld(from_world);
+                    return;
+                }
                 target = route_map.back();
             }
-            // RecalculateSegment's game-coord leg keeps the A* per-waypoint zplane (a world-coord round-trip would zero it), so the line drapes on the real surface; only orient it (point nearest target last).
-            auto orient = [target](std::vector<GW::GamePos>& out) {
-                if (out.size() <= 1) return;
-                const auto sq = [](const GW::GamePos& a, const GW::GamePos& b) {
-                    const float dx = a.x - b.x, dy = a.y - b.y;
-                    return dx * dx + dy * dy;
-                };
-                if (sq(out.front(), target) < sq(out.back(), target)) std::ranges::reverse(out);
-            };
-
-            Resources::EnqueueWorkerTask([qid = quest_id, from, target, same_map, orient, gw = goal_world] {
+            // RecalculateSegment's game-coord leg keeps the A* per-waypoint zplane (a world-coord round-trip would zero it), so the line drapes on the real surface.
+            Resources::EnqueueWorkerTask([qid = quest_id, from, target, same_map, gw = goal_world] {
                 auto pts = new std::vector<GW::Vec2f>();         // required out-param; unused here
                 auto route_map = new std::vector<GW::GamePos>(); // current-map game coords with carried zplane
                 const bool ok = PathfindingWindow::RecalculateSegment(static_cast<GW::Constants::MapID>(0), from, target, pts, route_map);
-                if (ok) orient(*route_map);
                 Resources::EnqueueMainTask([qid, from, route_map, pts, ok, same_map, gw] {
                     const auto cqp = GetCalculatedQuestPath(qid, false);
                     if (cqp && cqp->goal_world != gw) {
@@ -327,11 +329,15 @@ namespace {
 
             calculating = TIMER_INIT();
             const bool goal_changed = calculated_to != goal_world;
-            if (goal_changed) goal_cross_map = false; // new goal — re-test whether it's reachable on the current map
+            if (goal_changed) {
+                goal_cross_map = false; // new goal — re-test whether it's reachable on the current map
+                has_full_route = false; // and plot it from scratch instead of re-walking the old route's leg
+            }
             calculated_from = from_game; // anchor for Update's move threshold
             calculated_to = goal_world;
             const bool same_map = PathfindingWindow::IsWorldPosOnMap(goal_world) && !goal_cross_map;
-            if (!same_map && goal_changed) {
+            // Gate on the route we hold, not on `goal_changed`: a failed plot otherwise left us re-walking a leg that no longer exists.
+            if (!same_map && !has_full_route) {
                 RecalculateWorld(from_world);
             }
             else {
@@ -339,7 +345,7 @@ namespace {
             }
         }
 
-        // Drop only points we've walked past
+        // Drop points we've walked past; the drawn head starts at the live player pos, so anything behind us draws backwards.
         bool TrimLeadingWaypoints(const GW::GamePos& from)
         {
             bool dropped = false;
@@ -348,7 +354,11 @@ namespace {
                 const float segx = b.x - a.x, segy = b.y - a.y;
                 const float len2 = segx * segx + segy * segy;
                 const float t = len2 > 0.f ? ((from.x - a.x) * segx + (from.y - a.y) * segy) / len2 : 1.f;
-                if (t < 1.f) break; // route_map[1] still ahead
+                // Also drop when standing on b: walking off the line keeps the projection short of 1 and pins the head to a reached waypoint.
+                constexpr float waypoint_reached_sqr = 166.f * 166.f; // adjacent range
+                const float bx = from.x - b.x, by = from.y - b.y;
+                const bool reached = bx * bx + by * by < waypoint_reached_sqr;
+                if (t < 1.f && !reached) break; // route_map[1] still ahead
                 route_map.erase(route_map.begin());
                 dropped = true;
             }

--- a/GWToolboxdll/Windows/Pathfinding/Pathing.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/Pathing.cpp
@@ -2292,8 +2292,8 @@ namespace Pathing {
             PATH_LOG_INFO("[AStar] insert: start=(%.0f,%.0f,z%d) trap=%d edges=%zu | goal=(%.0f,%.0f,z%d) trap=%d edges=%zu",
                 start_pos.x, start_pos.y, (int)start_pos.zplane, (int)spt->id, sb.start_edges.size(),
                 goal_pos.x, goal_pos.y, (int)goal_pos.zplane, (int)gpt->id, sb.goal_edges.size());
+            m_path.insertPoint(goal_pos); // goal-first: finalize() reverses to start..goal
             m_path.insertPoint(start_pos);
-            m_path.insertPoint(goal_pos);
             m_path.setCost(GW::GetDistance(start_pos, goal_pos));
             m_path.finalize();
             return Error::FailedToFinializePath;
@@ -2307,8 +2307,9 @@ namespace Pathing {
             const auto& vis = SE[i];
             if (vis.point_id != GOAL_ID) continue;
             if ((vis.blocked_planes & current_blocked_planes).none()) {
-                m_path.insertPoint(start_pos);
+                // Goal-first, like BuildPath: finalize() reverses, so points() comes back start..goal.
                 m_path.insertPoint(goal_pos);
+                m_path.insertPoint(start_pos);
                 m_path.setCost(vis.distance);
                 m_path.finalize();
                 return Error::OK;


### PR DESCRIPTION
Follow-up to French's report that custom-marker pathing "gets stuck constantly if you're off by a little", and Marc's read that recalculation picks an old pathing point instead of pathing to the target.

A recalc does already run A* from the current position, but three things left the drawn head pointing at a point behind the player:

**1. The full cross-map plot was gated on the wrong flag.** `Recalculate` used `goal_changed`, while `has_full_route` — the flag meant for exactly this — was written in five places and never read anywhere. So a failed or cleared cross-map plot never got re-plotted as long as the marker stayed put; we kept re-walking a leg from a route that no longer existed.

**2. The in-flight flag could wedge.** `Recalculate` sets `calculating = TIMER_INIT()` before calling `RecalculateMap`, which bailed early on an empty route without queueing any work. `IsCalculating()` then blocked every `Update` for 5s, it retried, no-op'd and re-wedged — the path frozen on its last route. Now the flag is cleared on that path, and an empty cross-map route re-plots the world route rather than bailing.

**3. Waypoint trimming needed the player dead on the line.** `TrimLeadingWaypoints` only dropped a leading point once the player's projection onto segment 0→1 reached `t >= 1`. Walking a little off the line (which is what "off by a little" means) keeps `t` short of 1 indefinitely, so the head stayed pinned to a waypoint already reached and the first line — which starts at the live player position — drew backwards. Now it also drops within adjacent range of the next point.

**Bonus, same family:** `AStar::Search`'s LOS fast path inserted start-then-goal before `finalize()` reverses, so a straight-line result came back as `[goal, start]` — the opposite of `BuildPath`'s goal-first convention. `QuestModule` compensated with an `orient` lambda (removed here); the multi-map stitcher in `PathfindingWindow` and `CalculatePath`'s waypoint callback did not, so LOS segments were appended endpoint-first. Fixed at the source.

Not compile-tested — no MSVC toolchain here — so please give it a build before merging.