### PR TITLE
fix(DialogModule): restore the NPC dialog frame hook broken by a client update

### DIFF
--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -2387,7 +2387,7 @@ void CHAT_CMD_FUNC(ChatCommands::CmdDialog)
     if (!DialogModule::GetDialogAgent()) {
         const auto* target = GW::Agents::GetTargetAsAgentLiving();
         const auto* me = GW::Agents::GetControlledCharacter();
-        if (target && target->allegiance == GW::Constants::Allegiance::Npc_Minipet && GetDistance(me->pos, target->pos) < GW::Constants::Range::Area) {
+        if (target && me && target->allegiance == GW::Constants::Allegiance::Npc_Minipet && GetDistance(me->pos, target->pos) < GW::Constants::Range::Area) {
             GW::Agents::InteractAgent(target);
         }
     }

--- a/GWToolboxdll/Modules/DialogModule.cpp
+++ b/GWToolboxdll/Modules/DialogModule.cpp
@@ -11,6 +11,7 @@
 #include <GWCA/Utilities/Scanner.h>
 #include <GWCA/Utilities/Hooker.h>
 
+#include <Defines.h>
 #include <Utils/GuiUtils.h>
 #include <Modules/DialogModule.h>
 #include <Logger.h>
@@ -245,6 +246,7 @@ void DialogModule::Initialize()
 
     // NB: Don't pin the assertion line number; it shifts whenever ArenaNet edits GmNpc.cpp (0x3fe -> 0x40c)
     NPCDialogUICallback_Func = (GW::UI::UIInteractionCallback)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("GmNpc.cpp", "msg.createParam", 0, 0));
+    DEBUG_ASSERT(NPCDialogUICallback_Func);
     if (NPCDialogUICallback_Func) {
         GW::Hook::CreateHook((void**)&NPCDialogUICallback_Func, OnNPCDialogUICallback, reinterpret_cast<void**>(&NPCDialogUICallback_Ret));
         GW::Hook::EnableHooks(NPCDialogUICallback_Func);

--- a/GWToolboxdll/Modules/DialogModule.cpp
+++ b/GWToolboxdll/Modules/DialogModule.cpp
@@ -243,10 +243,14 @@ void DialogModule::Initialize()
         RegisterUIMessageCallback(&dialog_hook, message_id, OnPostUIMessage, 0x500);
     }
 
-    NPCDialogUICallback_Func = (GW::UI::UIInteractionCallback)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("GmNpc.cpp", "msg.createParam", 0x3fe, 0));
+    // NB: Don't pin the assertion line number; it shifts whenever ArenaNet edits GmNpc.cpp (0x3fe -> 0x40c)
+    NPCDialogUICallback_Func = (GW::UI::UIInteractionCallback)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("GmNpc.cpp", "msg.createParam", 0, 0));
     if (NPCDialogUICallback_Func) {
         GW::Hook::CreateHook((void**)&NPCDialogUICallback_Func, OnNPCDialogUICallback, reinterpret_cast<void**>(&NPCDialogUICallback_Ret));
         GW::Hook::EnableHooks(NPCDialogUICallback_Func);
+    }
+    else {
+        Log::Error("Failed to find NPC dialog UI callback; dialog state won't be reset when a conversation ends");
     }
 }
 

--- a/GWToolboxdll/Modules/DialogModule.cpp
+++ b/GWToolboxdll/Modules/DialogModule.cpp
@@ -80,6 +80,10 @@ namespace {
         dialog_button_messages.clear();
 
         dialog_body.reset(nullptr);
+        // Remember who we were talking to; needed to re-open the dialog if the server closes it mid-conversation
+        if (dialog_info.agent_id) {
+            last_agent_id = dialog_info.agent_id;
+        }
         dialog_info = {};
     }
 
@@ -88,10 +92,6 @@ namespace {
         GW::Hook::EnterHook();
         if (message->message_id == GW::UI::UIMessage::kDestroyFrame) {
             ResetDialog();
-            if (dialog_info.agent_id) {
-                last_agent_id = dialog_info.agent_id;
-            }
-            dialog_info.agent_id = 0;
         }
         NPCDialogUICallback_Ret(message, wparam, lparam);
         GW::Hook::LeaveHook();
@@ -102,7 +102,9 @@ namespace {
         if (queued_dialogs_to_send.empty()) {
             return;
         }
-        const auto npc = GW::Agents::GetAgentByID(last_agent_id);
+        // dialog_info may not have been reset yet, depending on which of the close messages arrived first
+        const auto agent_id = dialog_info.agent_id ? dialog_info.agent_id : last_agent_id;
+        const auto npc = GW::Agents::GetAgentByID(agent_id);
         const auto me =  npc ? GW::Agents::GetControlledCharacter() : nullptr;
         if (me && GetDistance(npc->pos, me->pos) < GW::Constants::Range::Area) {
             GW::Agents::InteractAgent(npc);


### PR DESCRIPTION
Reported on Discord: `/dialog 0` misbehaves - it no longer talks to the nearby NPC, and it's slow at taking quests.

### Root cause: the client changed, not toolbox

`DialogModule::Initialize` anchors its NPC dialog frame hook with an **exact assertion line number**:

```cpp
FindAssertion("GmNpc.cpp", "msg.createParam", 0x3fe, 0)
```

which compiles to a scan for `push 0x3fe; mov edx, <GmNpc.cpp>; mov ecx, <msg.createParam>`.

In the current client there are exactly three `GmNpc.cpp` + `msg.createParam` assertion sites,
and none of them is at 0x3fe:

| line | address | function |
|---|---|---|
| **0x40c** | `0x00509712` | `FUN_00509660` |
| 0x31b | `0x0050a261` | `FUN_0050a190` |
| 0x12b | `0x0050a762` | `FUN_0050a740` |

`FUN_00509660` is the intended target - it's a frame callback switching on `msg.message_id`,
and it handles `case 0xb` (`kDestroyFrame`), which is the only message `OnNPCDialogUICallback`
cares about. GmNpc.cpp simply grew by 14 lines, so `FindAssertion` now returns 0,
`NPCDialogUICallback_Func` is null and **the hook is never installed** - silently.

### Why that produces the reported symptoms

`ResetDialog()` never runs when the conversation window is destroyed, so state leaks from the
previous NPC:

* `dialog_info.agent_id` stays non-zero, so `CmdDialog`'s `if (!DialogModule::GetDialogAgent())`
  is false and it **skips `InteractAgent(target)`** - "it used to speak to the npc in nearby range".
* `dialog_buttons` / `dialog_body` stay populated, so `IsDialogButtonAvailable()` answers about the
  *previous* conversation: valid sends get blocked in `OnPreUIMessage`, queued dialogs sit until the
  3 second timeout in `Update()` drops them - "it's slow at taking quests".

### Changes

1. Pass `0` for the line number so the anchor matches on file + message alone, like almost every
   other `FindAssertion` call in GWCA. Survives the next time ArenaNet edits that file.
2. `Log::Error` if the anchor ever fails again instead of degrading silently.
3. Capture the agent id **inside** `ResetDialog()`. `ResetDialog()` has cleared `dialog_info` since
   fbab3775, so the `if (dialog_info.agent_id) last_agent_id = ...` that ran right after it always
   saw a zeroed struct - meaning `OnDialogClosedByServer()` (which re-opens the conversation when the
   server ends it mid-chain) could never find the NPC. Latent until the hook works again, but it
   needs fixing for that path to actually function.
4. Drive-by: null-check the controlled character in `CmdDialog` before dereferencing it.

Verified the addresses/line numbers above against the current `Gw.exe` in Ghidra.