### PR TITLE
chore: DEBUG_ASSERT scan results that were failing silently

### DIFF
--- a/GWToolboxdll/Logger.cpp
+++ b/GWToolboxdll/Logger.cpp
@@ -15,6 +15,8 @@
 #include <GWCA/Utilities/Hooker.h>
 #include <GWCA/Utilities/Scanner.h>
 
+#include <Defines.h>
+
 namespace {
     FILE* logfile = nullptr;
     FILE* logfile2 = nullptr; // Debug: a second sink (log.txt on disk) so the harness can read it while the console stays
@@ -108,6 +110,7 @@ namespace {
     void HookGWLogger() {
         if (LogWithArguments_Func) return;
         LogWithArguments_Func = (LogWithArguments_pt)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("Log.cpp", "argListPtr", 0, 0));
+        DEBUG_ASSERT(LogWithArguments_Func);
         if (!LogWithArguments_Func) return;
         GW::Hook::CreateHook((void**)&LogWithArguments_Func, OnLogWithArguments, (void**)&LogWithArguments_Ret);
         GW::Hook::EnableHooks(LogWithArguments_Func);

--- a/GWToolboxdll/Modules/AudioSettings.cpp
+++ b/GWToolboxdll/Modules/AudioSettings.cpp
@@ -10,6 +10,8 @@
 #include <ImGuiAddons.h>
 #include <GWCA/Managers/GameThreadMgr.h>
 #include <GWCA/Managers/UIMgr.h>
+
+#include <Defines.h>
 #include <Utils/GuiUtils.h>
 #include <Timer.h>
 
@@ -222,11 +224,13 @@ void AudioSettings::Initialize()
 {
     ToolboxModule::Initialize();
     PlaySound_Func = (PlaySound_pt)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("SndMain.cpp","filename",0,0));
+    DEBUG_ASSERT(PlaySound_Func);
     if (PlaySound_Func) {
         GW::Hook::CreateHook((void**)&PlaySound_Func, OnPlaySound, reinterpret_cast<void**>(&PlaySound_Ret));
         GW::Hook::EnableHooks(PlaySound_Func);
     }
     PlayMusicFromSoundScript_Func = (PlayMusicFromSoundScript_pt)GW::Scanner::ToFunctionStart(GW::Scanner::Find("\x8d\x77\x0c\x83\xe0\xf3", "xxxxxx", 0));
+    DEBUG_ASSERT(PlayMusicFromSoundScript_Func);
     if (PlayMusicFromSoundScript_Func) {
         GW::Hook::CreateHook((void**)&PlayMusicFromSoundScript_Func, OnPlayMusicFromSoundScript, reinterpret_cast<void**>(&PlayMusicFromSoundScript_Ret));
         GW::Hook::EnableHooks(PlayMusicFromSoundScript_Func);

--- a/GWToolboxdll/Modules/ChatSettings.cpp
+++ b/GWToolboxdll/Modules/ChatSettings.cpp
@@ -443,6 +443,7 @@ void ChatSettings::Initialize()
         RegisterUIMessageCallback(&OnUIMessage_Entry, message_id, OnUIMessage);
     }
     ColorHexOrLabelToColor_Func = (ColorHexOrLabelToColor_pt)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("CtlTextMl.cpp", "value", 0, 0));
+    DEBUG_ASSERT(ColorHexOrLabelToColor_Func);
     if (ColorHexOrLabelToColor_Func) {
         GW::Hook::CreateHook((void**)&ColorHexOrLabelToColor_Func, OnColorHexOrLabelToColor, (void**)&ColorHexOrLabelToColor_Ret);
         GW::Hook::EnableHooks(ColorHexOrLabelToColor_Func);
@@ -450,6 +451,7 @@ void ChatSettings::Initialize()
     // b'\x75\x16\x68\x88\xe1\x00\x00'
 
     ChatLogLine_UICallback_Func = (GW::UI::UIInteractionCallback)GW::Scanner::ToFunctionStart(GW::Scanner::Find("\x75\x16\x68\x88\xe1\x00\x00", "xxxxxxx"),0xfff);
+    DEBUG_ASSERT(ChatLogLine_UICallback_Func);
     if (ChatLogLine_UICallback_Func) {
         GW::Hook::CreateHook((void**)&ChatLogLine_UICallback_Func, OnChatLogLine_UICallback, (void**)&ChatLogLine_UICallback_Ret);
         GW::Hook::EnableHooks(ChatLogLine_UICallback_Func);

--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -1472,27 +1472,33 @@ void GameSettings::Initialize()
     SettingsRegistry::Describe(this, "combine_overhead_numbers", "Combine floating numbers above character", combine_overhead_numbers_help);
 
     OnSkillTomeWindow_UIMessage_Func = (GW::UI::UIInteractionCallback)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("GmSkTome.cpp", "selection.skillId", 0, 0), 0xfff);
+    DEBUG_ASSERT(OnSkillTomeWindow_UIMessage_Func);
     Log::Log("[GameSettings] OnSkillTomeWindow_UIMessage_Func = %p\n", OnSkillTomeWindow_UIMessage_Func);
 
     SkillList_UICallback_Func = (GW::UI::UIInteractionCallback)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("GmCtlSkList.cpp", "!obj", 0xc71, 0));
+    DEBUG_ASSERT(SkillList_UICallback_Func);
     Log::Log("[GameSettings] SkillList_UICallback_Func = %p\n", SkillList_UICallback_Func);
 
     auto address = GW::Scanner::Find("\xF7\x40\x0C\x10\x00\x02\x00\x75", "xxxxxx??", +7);
+    DEBUG_ASSERT(address);
     if (address) gold_confirm_patch.SetPatch(address, "\x90\x90", 2);
     Log::Log("[GameSettings] gold_confirm_patch = %p\n", gold_confirm_patch.GetAddress());
 
     address = GW::Scanner::Find("\xdf\xe0\xf6\xc4\x41\x7a\x79", "xxxxxxx", 0x5);
+    DEBUG_ASSERT(address);
     if (address) remove_skill_warmup_duration_patch.SetPatch(address, "\x90\x90", 2);
     Log::Log("[GameSettings] remove_skill_warmup_duration_patch = %p\n", remove_skill_warmup_duration_patch.GetAddress());
 
     // Call our CreateCodedTextLabel function instead of default CreateCodedTextLabel for patching skill descriptions
     SetFrameSkillDescription_Func = (SetFrameSkillDescription_pt)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("GmTipSkill.cpp", "No valid case for switch variable \'m_powerType\'", 0, 0));
+    DEBUG_ASSERT(SetFrameSkillDescription_Func);
 
     Log::Log("[GameSettings] SetFrameSkillDescription_Func = %p\n", SetFrameSkillDescription_Func);
 
     // See OnAgentAllegianceChanged
     address = GW::Scanner::Find("\x81\xce\xa0\x06\x00\x00", "xxxxxx");
     if (address) address = GW::Scanner::FunctionFromNearCall(GW::Scanner::FindInRange("\xe8", "x", 0, address, address + 0xff));
+    DEBUG_ASSERT(address);
     if (address) {
         SetGlobalNameTagVisibility_Func = (SetGlobalNameTagVisibility_pt)address;
         if (GW::Scanner::IsValidPtr(*(uintptr_t*)(address + 0xa)))

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -37,6 +37,8 @@
 #include <Windows/GWMarketWindow.h>
 
 #include <GWCA/GameEntities/Frame.h>
+
+#include <Defines.h>
 #include <Utils/ToolboxUtils.h>
 #include <Utils/TextUtils.h>
 
@@ -1617,6 +1619,7 @@ void InventoryManager::Initialize()
 
     AddItemRowToWindow_Func = reinterpret_cast<AddItemRowToWindow_pt>(GW::Scanner::Find(
         "\x83\xc4\x04\x80\x78\x04\x06\x0f\x84\xd3\x00\x00\x00\x6a\x02\xff\x37", nullptr, -0x10));
+    DEBUG_ASSERT(AddItemRowToWindow_Func);
     if (AddItemRowToWindow_Func) {
         GW::Hook::CreateHook((void**)&AddItemRowToWindow_Func, OnAddItemToWindow, reinterpret_cast<void**>(&RetAddItemRowToWindow));
         GW::Hook::EnableHooks(AddItemRowToWindow_Func);

--- a/GWToolboxdll/Modules/MouseFix.cpp
+++ b/GWToolboxdll/Modules/MouseFix.cpp
@@ -169,12 +169,15 @@ namespace {
             return false;
         }
         uintptr_t address = GW::Scanner::Find("\xc7\x45\xf0\x10\x00\x00\x00\xc7\x45\xf4\x02\x00\x00\x00", "xx?xxxxxx?xxxx", 0x15);
+        DEBUG_ASSERT(address);
         if(address && GW::Scanner::IsValidPtr(*(uintptr_t*)address)) {
             ProcessInput_Func = (OnProcessInput_pt)GW::Scanner::ToFunctionStart(address, 0xfff);
             HasRegisteredTrackMouseEvent = *(bool**)address;
             gw_mouse_move = (GwMouseMove*)(HasRegisteredTrackMouseEvent - 0x20);
             SetCursorPosCenter_Func = (SetCursorPosCenter_pt)GW::Scanner::FunctionFromNearCall(GW::Scanner::FindInRange("\x89\x46\x08\xe8????", "xxxx????", 3, address, address + 0xff));
         }
+        DEBUG_ASSERT(ProcessInput_Func);
+        DEBUG_ASSERT(SetCursorPosCenter_Func);
 
         GWCA_INFO("[SCAN] ProcessInput_Func = %p", ProcessInput_Func);
         GWCA_INFO("[SCAN] HasRegisteredTrackMouseEvent = %p", HasRegisteredTrackMouseEvent);

--- a/GWToolboxdll/Modules/Obfuscator.cpp
+++ b/GWToolboxdll/Modules/Obfuscator.cpp
@@ -848,9 +848,11 @@ void Obfuscator::Initialize()
     Reset();
 
     const auto GetCharacterSummary_Assertion = GW::Scanner::FindAssertion(R"(p:\code\gw\ui\char\uichinfo.cpp)", "!StrCmp(m_characterName, characterInfo.characterName)",0,0);
+    DEBUG_ASSERT(GetCharacterSummary_Assertion);
     if (GetCharacterSummary_Assertion) {
         // Hook to override character names on login screen
         GetCharacterSummary_Func = reinterpret_cast<GetCharacterSummary_pt>(GW::Scanner::ToFunctionStart(GetCharacterSummary_Assertion));
+        DEBUG_ASSERT(GetCharacterSummary_Func);
         GW::Hook::CreateHook((void**)&GetCharacterSummary_Func, OnGetCharacterSummary, reinterpret_cast<void**>(&RetGetCharacterSummary));
         GW::Hook::EnableHooks(GetCharacterSummary_Func);
         // Patch to allow missing character summary
@@ -859,6 +861,7 @@ void Obfuscator::Initialize()
     }
 
     GetAccountData_Func = (GetAccountData_pt)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion(R"(p:\code\gw\ui\game\vendor\vnacctnameset.cpp)", "charName", 0, 0));
+    DEBUG_ASSERT(GetAccountData_Func);
     if (GetAccountData_Func) {
         GW::Hook::CreateHook((void**)&GetAccountData_Func, OnGetAccountInfo, reinterpret_cast<void**>(&GetAccountData_Ret));
         GW::Hook::EnableHooks(GetAccountData_Func);

--- a/GWToolboxdll/Modules/QuestModule.cpp
+++ b/GWToolboxdll/Modules/QuestModule.cpp
@@ -24,6 +24,8 @@
 #include <GWCA/Context/WorldContext.h>
 #include <GWCA/Managers/MemoryMgr.h>
 #include <GWCA/Utilities/MemoryPatcher.h>
+
+#include <Defines.h>
 #include <Utils/GuiUtils.h>
 #include <Utils/ToolboxUtils.h>
 #include <Widgets/WorldMapWidget.h>
@@ -845,6 +847,7 @@ void QuestModule::Initialize()
 
     memset(&custom_quest_marker, 0, sizeof(custom_quest_marker));
     uintptr_t address = GW::Scanner::FindAssertion("UiCtlWebLink.cpp", "challengeId < CHALLENGES", 0, -0x7);
+    DEBUG_ASSERT(address);
     if (address) {
         bypass_custom_quest_assertion_patch.SetPatch(address, "\xeb", 1);
         bypass_custom_quest_assertion_patch.TogglePatch(true);

--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -34,6 +34,8 @@
 #include <GWCA/Managers/ItemMgr.h>
 #include <GWCA/Managers/UIMgr.h>
 #include <GWCA/Utilities/Scanner.h>
+
+#include <Defines.h>
 #include <Modules/Resources.h>
 #include <Timer.h>
 #include <Utils/GuiUtils.h>
@@ -428,6 +430,7 @@ namespace GW {
         {
             if (!account_uuid) {
                 auto address = GW::Scanner::Find("\x50\x6a\x18\x6a\x02\xff\x15", "xxxxxxx", 0x7);
+                DEBUG_ASSERT(address);
                 if (address && GW::Scanner::IsValidPtr(*(uintptr_t*)address, GW::ScannerSection::Section_DATA)) {
                     address = *(uintptr_t*)address;
                     account_uuid = (GUID*)(address + 0x90);

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -839,6 +839,7 @@ void Minimap::Initialize()
     }
 
     uintptr_t address = GW::Scanner::Find("\x8b\x46\x40\x85\xc0\x74\x0c", "xxxxx?x", 0x5);
+    DEBUG_ASSERT(address);
     if (address) {
         hide_flagging_controls_patch.SetPatch(address, "\xeb", 1);
     }

--- a/GWToolboxdll/Windows/HotkeysWindow.cpp
+++ b/GWToolboxdll/Windows/HotkeysWindow.cpp
@@ -120,6 +120,7 @@ namespace {
 
         using GetActionLabel_pt = wchar_t*(__cdecl*)(GW::UI::ControlAction action);
         const auto GetActionLabel_Func = reinterpret_cast<GetActionLabel_pt>(GW::Scanner::Find("\x83\xfe\x5b\x74\x27\x83\xfe\x5c\x74\x22\x83\xfe\x5d\x74\x1d", "xxxxxxxxxxxxxxx", -0x7));
+        DEBUG_ASSERT(GetActionLabel_Func);
         GWCA_INFO("[SCAN] GetActionLabel_Func = %p\n", reinterpret_cast<void*>(GetActionLabel_Func));
         if (!GetActionLabel_Func) {
             return;

--- a/GWToolboxdll/Windows/InfoWindow.cpp
+++ b/GWToolboxdll/Windows/InfoWindow.cpp
@@ -46,6 +46,8 @@
 #include <GWCA/Managers/SkillbarMgr.h>
 #include <GWCA/Managers/StoCMgr.h>
 
+#include <Defines.h>
+
 #include <Widgets/AlcoholWidget.h>
 #include <Widgets/Minimap/Minimap.h>
 #include <Widgets/PartyDamage.h>
@@ -632,6 +634,7 @@ namespace {
         if (hook && ValidateAsyncDecodeStr_Func) return;
         if (hook) {
             ValidateAsyncDecodeStr_Func = (DoAsyncDecodeStr_pt)GW::Scanner::ToFunctionStart(GW::Scanner::FindUseOfString("(codedString[0] & ~WORD_BIT_MORE) >= WORD_VALUE_BASE"));
+            DEBUG_ASSERT(ValidateAsyncDecodeStr_Func);
             if (ValidateAsyncDecodeStr_Func) {
                 GW::Hook::CreateHook((void**)&ValidateAsyncDecodeStr_Func, OnValidateAsyncDecodeStr, (void**)&ValidateAsyncDecodeStr_Ret);
                 GW::Hook::EnableHooks(ValidateAsyncDecodeStr_Func);
@@ -651,6 +654,7 @@ namespace {
         if (hook && CreateTexture_Func) return;
         if (hook) {
             CreateTexture_Func = (CreateTexture_pt)GW::Scanner::ToFunctionStart(GW::Scanner::FindAssertion("GrTex2d.cpp", "!(flags & GR_TEXTURE_TRANSFER_OWNERSHIP)", 0, 0));
+            DEBUG_ASSERT(CreateTexture_Func);
             if (CreateTexture_Func) {
                 GW::Hook::CreateHook((void**)&CreateTexture_Func, OnCreateTexture, (void**)&CreateTexture_Ret);
                 GW::Hook::EnableHooks(CreateTexture_Func);
@@ -727,6 +731,7 @@ namespace {
         wchar_t** file_ids = 0;
         ArenaNetFileParser::GameAssetFile asset;
         auto addr = GW::Scanner::FindUseOfString("index < arrsize(s_fileId)", 0x11);
+        DEBUG_ASSERT(addr);
         if (!(addr && GW::Scanner::IsValidPtr(*(uintptr_t*)addr, GW::ScannerSection::Section_DATA))) {
             return false;
         }
@@ -767,6 +772,7 @@ namespace {
     {
         if (!SetFpsLimits_Func) {
             SetFpsLimits_Func = (SetFpsLimits_pt)GW::Scanner::ToFunctionStart(GW::Scanner::Find("\x68\x40\x42\x0f\x00\xe8", "xxxxxx"));
+            DEBUG_ASSERT(SetFpsLimits_Func);
             if (SetFpsLimits_Func) {
                 GW::Hook::CreateHook((void**)&SetFpsLimits_Func, OnSetFpsLimits, (void**)&SetFpsLimits_Ret);
                 GW::Hook::EnableHooks(SetFpsLimits_Func);

--- a/GWToolboxdll/Windows/PacketLoggerWindow.cpp
+++ b/GWToolboxdll/Windows/PacketLoggerWindow.cpp
@@ -15,6 +15,8 @@
 #include <GWCA/Managers/MapMgr.h>
 #include <GWCA/Managers/GameThreadMgr.h>
 
+#include <Defines.h>
+
 #include <Logger.h>
 #include <Utils/GuiUtils.h>
 
@@ -184,6 +186,7 @@ namespace {
     StoCHandlerArray* GetStoCHandlerArray() {
 
         uintptr_t address = GW::Scanner::Find("\x75\x04\x33\xC0\x5D\xC3\x8B\x41\x08\xA8\x01\x75", "xxxxxxxxxxxx", -6);
+        DEBUG_ASSERT(address);
         const uintptr_t StoCHandler_Addr = *(uintptr_t*)address;
 
         struct GameServer {


### PR DESCRIPTION
Follow-up to #2459.

`GW::Scanner::*` returns 0 when an anchor stops matching after a client patch, and
essentially every call site is written as:

```cpp
Foo_Func = (Foo_pt)GW::Scanner::ToFunctionStart(...);
if (Foo_Func) {
    GW::Hook::CreateHook(...);
}
```

so the hook is silently skipped and the feature just stops working - with no log, no
assert, and no failure in a debug run either. That's exactly how the broken `GmNpc.cpp`
anchor in `DialogModule` went unnoticed.

**23 of 59** scan-result assignments in shipped toolbox code had no `ASSERT`/`DEBUG_ASSERT`
coverage. This adds one to each, following the convention already used in
`CameraUnlockModule`, `LoginModule` and `TextToSpeechModule`.

No logic changes: the runtime null checks are untouched, `DEBUG_ASSERT` compiles out in
release, so release behaviour is byte-for-byte the same.

### Deliberately not touched

| site | why |
|---|---|
| `ChatSettings.cpp:459`, `WorldMapWidget.cpp:966/970` | already `ASSERT(<patch>.IsValid())` a few lines down |
| `GuildWarsSettingsModule.cpp:659` | already `#ifdef _DEBUG ASSERT(key_mappings_array)` |
| `GameWorldCompositor.cpp:82/92` | already detects failure and sets `compositor_failed` |
| `CompletionWindow.cpp:1323/1332` | both scans are inside `/* */` |
| `DialogModule.cpp:244` | asserted in #2459, kept out of here to avoid a conflict |

Worth calling out: `PacketLoggerWindow.cpp:186` dereferences the scan result on the very
next line (`*(uintptr_t*)address`), so a dead anchor there is a null deref rather than a
silently missing feature.

All 23 anchors currently resolve against build **38797** (verified in Ghidra), so nothing
here should fire today - it's purely so the *next* one gets caught.