### PR TITLE
fix(game settings): honour "Remember my online status" setting

### DIFF
--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -674,6 +674,7 @@ namespace {
     // Override the login status dropdown by sending ui message 0x51 if found
     void OverrideDefaultOnlineStatus()
     {
+        if (!settings.remember_online_status) return; // Opted out; leave GW's default status alone
         GW::GameThread::Enqueue([] {
             GW::UI::SelectDropdownOption(GW::UI::GetFrameByLabel(L"StatusOverride"), settings.last_online_status);
         });


### PR DESCRIPTION
## Problem

The "Remember my online status when returning to character select screen" checkbox has no effect — unticking it does not stop Toolbox from re-applying your stored friend list status.

`OverrideDefaultOnlineStatus()` in `GWToolboxdll/Modules/GameSettings.cpp` selects the stored `last_online_status` in the `StatusOverride` dropdown, but never reads `settings.remember_online_status`. Its only caller (the `kGetPreGameContext_Value0` handler) invokes it unconditionally, so the override runs on every visit to the character select screen regardless of the setting.

## Fix

Return early from `OverrideDefaultOnlineStatus()` when `remember_online_status` is unset, so opting out leaves Guild Wars' default status behaviour untouched. The guard sits in the function rather than at the call site so any future caller inherits it.

The check happens before the `GW::GameThread::Enqueue`, so the setting is read at the moment character select appears rather than whenever the queued task runs.

## Scope

One line, one file. Recording of `last_online_status` on map load and at init is unchanged, so toggling the setting back on still restores the correct status.

---
_Generated by [Claude Code](https://claude.ai/code/session_017EBrcRPHPWrybZNPQx1vry)_